### PR TITLE
Add a graphviz backend

### DIFF
--- a/src/backend/backend.jl
+++ b/src/backend/backend.jl
@@ -20,8 +20,6 @@ function mxnet(m)
   eval(:(MX.mxnet($m)))
 end
 
-include(joinpath(dirname(@__FILE__), "graphviz/graphviz.jl"))
+include("graphviz/graphviz.jl")
 
-function graphviz(m)
-  GV.graphviz(m)
-end
+const graphviz = GV.graphviz

--- a/src/backend/backend.jl
+++ b/src/backend/backend.jl
@@ -1,4 +1,4 @@
-export tf, mxnet
+export tf, mxnet, graphviz
 
 function loadtf()
   isdefined(Flux, :TF) && return
@@ -18,4 +18,10 @@ end
 function mxnet(m)
   loadmx()
   eval(:(MX.mxnet($m)))
+end
+
+include(joinpath(dirname(@__FILE__), "graphviz/graphviz.jl"))
+
+function graphviz(m)
+  GV.graphviz(m)
 end

--- a/src/backend/graphviz/graph.jl
+++ b/src/backend/graphviz/graph.jl
@@ -1,0 +1,156 @@
+import Base: size, <<
+
+struct Tensor
+  name
+  size
+end
+
+size(t::Tensor) = t.size
+
+uid = ((id)->()->id+=1)(0)
+
+function <<(ctx::Context, str)
+  println(ctx[:buffer], "  " ^ ctx[:depth], str...)
+  ctx
+end
+
+function <<(ctx::Context, t::Tensor)
+  ctx[:memory] += isempty(t.size) ? 0 : *(t.size...)
+  ctx
+end
+
+function scope(f, ctx, name)
+  ctx << "subgraph cluster_$(uid()) {" << "  label = \"$name\""
+  ctx[:depth] += 1
+  result = f()
+  ctx[:depth] -= 1
+  ctx << "}"
+  result
+end
+
+function interp(ctx, c::DataFlow.Constant)
+  interp(ctx, c.value)
+end
+
+function interp(ctx, c::Flux.Param)
+  t = Tensor(uid(), size(c.x)) # TODO: is it possible to get variable name?
+  ctx << t
+  ctx << """$(t.name) [shape=box, label="param::$(t.size)"]"""
+  t
+end
+
+function interp(ctx, a::AArray)
+  t = Tensor(uid(), size(a))
+  ctx << t
+  ctx << """$(t.name) [shape=hexagon, label="input::$(t.size)"]"""
+  t
+end
+
+interp(ctx, t::Tensor) = t
+
+function interp(ctx, m::Flux.Model, xs...)
+  scope(ctx, typeof(m)) do
+    g = Flux.graph(m)
+    g == nothing && error("graphviz backend doesn't support $m")
+    DataFlow.iscyclic(g) && error("This model has a cycle; try unrolling it first.")
+    interpret(ctx, g, xs...)
+  end
+end
+
+interp(ctx, i::Input, t) = t
+
+function interp(ctx, c::Conv2D, x)
+  size_intered = Flux.infer(c, x.size)
+  node = replace("""
+    Conv2D(
+      kernel: $(size(c.filter.x, 4))
+      filter: $(join(size(c.filter.x)[1:2], 'x'))
+      stride: $(join(c.stride, 'x'))
+      border: valid
+    )""", '\n', "\\n")
+  t = Tensor(uid(), size_intered == nothing ? () : size_intered)
+  ctx << t
+  ctx << """$(t.name) [shape=oval, label="$node::$(t.size)"]"""
+  ctx << "$(x.name) -> $(t.name)"
+  t
+end
+
+function interp(ctx, p::MaxPool, x)
+  size = Flux.infer(p, x.size)
+  node = replace("""
+    Pool(
+      filter: $(join(p.size, 'x'))
+      stride: $(join(p.stride, 'x'))
+      function: max
+    )""", '\n', "\\n")
+  t = Tensor(uid(), size == nothing ? () : size)
+  ctx << t
+  ctx << """$(t.name) [shape=oval, label="$node::$(t.size)"]"""
+  ctx << "$(x.name) -> $(t.name)"
+  t
+end
+
+function interp(ctx, r::Reshape, x)
+  t = Tensor(uid(), *(x.size[2:end]...) == *(r.dims...) ? (x.size[1], r.dims...) : ())
+  ctx << """$(t.name) [shape=oval, label="Reshape::$(t.size)"]"""
+  ctx << "$(x.name) -> $(t.name)"
+  t
+end
+
+function interp(ctx, m::Flux.Stateful)
+  error("graphviz backend doesn't support recurrent model yet")
+end
+
+interp(ctx, m::Flux.SeqModel) = interp(ctx, m.model)
+
+for op in (:.+, :.-, :.*, :./)
+  op_str = string(op)
+  @eval function interp(ctx, ::typeof($op), xs...)
+    t = Tensor(uid(), try
+      any(isempty, map(size, xs)) ? () :
+      Base.Broadcast.broadcast_shape(map(size, xs)...)
+    catch e
+      e isa DimensionMismatch ? () : rethrow()
+    end)
+    ctx << t
+    ctx << """$(t.name) [shape=oval, label="$($op_str)::$(t.size)"]"""
+    for x in xs
+      ctx << "$(x.name) -> $(t.name)"
+    end
+    t
+  end
+end
+
+for op in (:tanh, :σ, :relu, :softmax)
+  op_str = string(op)
+  @eval function interp(ctx, ::typeof($op), x)
+    t = Tensor(uid(), x.size) # we don't count memory here as it will almost certanly be optimized out
+    ctx << """$(t.name) [shape=oval, label="$($op_str)::$(t.size)"]"""
+    ctx << "$(x.name) -> $(t.name)"
+    t
+  end
+end
+
+for op in (:tuple, )
+  @eval interp(ctx, ::typeof($op), xs...) = $op(xs...)
+end
+
+function interp(ctx, ::typeof(*), A::Tensor, B::Tensor)
+  t = Tensor(uid(), length(A.size) == length(B.size) == 2 &&
+                    A.size[2] == B.size[1] ?
+                    (A.size[1], B.size[2]) : ())
+  ctx << t
+  ctx << """$(t.name) [shape=oval, label="*::$(t.size)"]"""
+  ctx << "$(A.name) -> $(t.name)"
+  ctx << "$(B.name) -> $(t.name)"
+  t
+end
+
+function interp(ctx, ::typeof(*), A::Tensor, x::Number)
+  t = Tensor(uid(), A.size)
+  ctx << """$(t.name) [shape=oval, label="(* $x)::$(t.size)"]"""
+  ctx << "$(A.name) -> $(t.name)"
+  t
+end
+
+interp(ctx, ::typeof(*), x::Number, A::Tensor) = interp(ctx, *, A, x)

--- a/src/backend/graphviz/graph.jl
+++ b/src/backend/graphviz/graph.jl
@@ -1,4 +1,4 @@
-import Base: size, <<
+import Base: size
 
 struct Tensor
   name

--- a/src/backend/graphviz/graphviz.jl
+++ b/src/backend/graphviz/graphviz.jl
@@ -1,0 +1,10 @@
+module GV
+
+using DataFlow, DataFlow.Interpreter, ..Flux
+
+export graphviz
+
+include("graph.jl")
+include("model.jl")
+
+end

--- a/src/backend/graphviz/model.jl
+++ b/src/backend/graphviz/model.jl
@@ -3,6 +3,7 @@ mutable struct Model <: Flux.Model
 end
 
 graphviz(m::Flux.Model) = Model(Flux.graph(m))
+graphviz(m::Flux.Model, xs...) = graphviz(m)(xs...)
 
 function (m::Model)(xs...)
   xs = map(rawbatch, xs)

--- a/src/backend/graphviz/model.jl
+++ b/src/backend/graphviz/model.jl
@@ -3,12 +3,12 @@ mutable struct Model <: Flux.Model
 end
 
 graphviz(m::Flux.Model) = Model(Flux.graph(m))
-graphviz(m::Flux.Model, xs...) = graphviz(m)(xs...)
+graphviz(m::Flux.Model, xs...; depth = 2) = graphviz(m)(xs...; depth=depth)
 
-function (m::Model)(xs...)
+function (m::Model)(xs...; depth = 2)
   xs = map(rawbatch, xs)
   ctx = Context(mux(iline, ilambda, Flux.imap, iargs, ituple, interp),
-                memory = 0, depth = 0, buffer = IOBuffer())
+                max_depth = depth, memory = 0, depth = 0, buffer = IOBuffer())
   interpret(ctx, m.graph, xs...)
   buffer = take!(ctx[:buffer]) |> String
   "digraph model {\n\n$buffer\n}", ctx[:memory]

--- a/src/backend/graphviz/model.jl
+++ b/src/backend/graphviz/model.jl
@@ -1,0 +1,14 @@
+mutable struct Model <: Flux.Model
+  graph
+end
+
+graphviz(m::Flux.Model) = Model(Flux.graph(m))
+
+function (m::Model)(xs...)
+  xs = map(rawbatch, xs)
+  ctx = Context(mux(iline, ilambda, Flux.imap, iargs, ituple, interp),
+                memory = 0, depth = 0, buffer = IOBuffer())
+  interpret(ctx, m.graph, xs...)
+  buffer = take!(ctx[:buffer]) |> String
+  "digraph model {\n\n$buffer\n}", ctx[:memory]
+end

--- a/src/layers/shims.jl
+++ b/src/layers/shims.jl
@@ -20,7 +20,7 @@ for Pool in :[MaxPool, AvgPool].args
       stride::Dims{2}
     end
 
-    $Pool(size; stride = (1,1)) =
+    $Pool(size; stride = size) =
       $Pool(size, stride)
 
     infer(c::$Pool, in::Dims{4}) =


### PR DESCRIPTION
This adds a "fake" backend that doesn't perform actual training/prediction. Instead, it output a DOT string witch can be rendered as an image. For example:

```
using Flux

m = Chain(
         Input(784),
         Affine(784, 128), relu,
         Affine(128, 64), relu,
         Affine(64, 10), softmax)

dot, n_params = graphviz(m)(Array{Float32}(4, 784))

open("some.dot", "w") do f write(f, dot) end
```

then `dot -Tjpeg some.dot > some.jpeg`, or use `Graphviz.jl`(which unfortunatly broken on 0.6) to get this:

![image](https://cloud.githubusercontent.com/assets/7145046/25001905/2e23303c-207a-11e7-825f-6610ea8b60c4.png)

It also counts the elements of all tensors, which can be used to estimate the memory cost and can help users to select a batch size.