### PR TITLE
Optimizers

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -41,6 +41,7 @@ include("layers/shims.jl")
 include("backend/backend.jl")
 
 include("data.jl")
+include("optimizers.jl")
 include("training.jl")
 
 end # module

--- a/src/backend/tensorflow/model.jl
+++ b/src/backend/tensorflow/model.jl
@@ -4,18 +4,18 @@ struct Exec
   session ::Session
   input   ::Any
   output  ::Any
-  grads   ::Any
-  params  ::Dict{Flux.Param,Tensor}
+  params  ::Dict{Param,Param{Tensor}}
   stacks  ::Dict{Any,Any}
 end
 
 function makesession(model, inputs; session = Session(Graph()))
   inputs = mapt(_ -> placeholder(Float32), inputs)
   params, stacks, output = tograph(model, inputs...)
-  # grads = gradients(output, [collectt(inputs)..., values(params)...])
-  grads = placeholder(Float32)
+  params = Dict(x=>Param{Tensor}(y, gradients(output, y)) for (x, y) in params)
+  inputs = mapt(x->Param{Tensor}(x, gradients(output, x)), inputs)
+  output = mapt(x->Param{Tensor}(x, placeholder(Float32)), output)
   run(session, global_variables_initializer())
-  Exec(session, inputs, output, grads, params, stacks)
+  Exec(session, inputs, output, params, stacks)
 end
 
 retuple(xs) = xs
@@ -23,29 +23,31 @@ retuple(xs::AbstractArray{<:AbstractArray}) = (retuple.(xs)...,)
 
 dictt(xs, ys) = Dict(zip(collectt(xs), collectt(ys)))
 
-function params(m::Exec, args...)
-  shapecheckt(m.input, args)
-  idict = dictt(m.input, args)
-  pdict = Dict(t => p.x for (p, t) in m.params)
-  merge(idict, pdict)
+function Flux.params(m::Exec)
+  collect(keys(m.params))
 end
 
 function (m::Exec)(args...)
-  retuple(run(m.session, m.output, params(m, args...)))
+  dict = merge(
+    Dict(y.x=>x.x for (x, y) in m.params),
+    Dict(x.x=>y for (x, y) in zip(m.input, args))
+  )
+  retuple(run(m.session, mapt(x->x.x, m.output), dict))
 end
 
-pullt!(_, xs) = shift!(xs)
-pullt!(x::Tuple, xs) = map(x -> pullt!(x, xs), x)
-
-# TODO: gradients don't work yet
-# `gradients` lacks support for `grad_y`s and multiple `y`s
-
 function Flux.back!(m::Exec, Δ, args...)
-  Δps = run(m.session, m.grads, params(m, args...))
-  Δin = pullt!(m.input, Δps)
+  dict = merge(
+    Dict(y.x=>x.x for (x, y) in m.params),
+    Dict(x.x=>y for (x, y) in zip(m.input, args)),
+    Dict(x.Δx=>y for (x, y) in zip(collectt(m.output), collectt(Δ)))
+  )    
+
+  Δin, Δps = run(m.session, (mapt(x->x.Δx, m.input), map(x->x.Δx, values(m.params))), dict)
+
   for (p, Δ) in zip(keys(m.params), Δps)
     p.Δx .+= Δ
   end
+
   Δin
 end
 
@@ -70,8 +72,9 @@ function (m::Model)(args...)
   @tferr m.exec.stacks m.exec(args...)
 end
 
-Flux.back!(m::Model, Δ, args...) = back!(m.exec, Δ, args...)
-Flux.update!(m::Model, η) = (update!(m.exec, η); m)
+Flux.back!(m::Model, Δ, args...) = Flux.back!(m.exec, Δ, args...)
+Flux.update!(m::Model, η) = (Flux.update!(m.exec, η); m)
+Flux.params(m::Model) = Flux.params(m.exec)
 
 # Recurrent Models
 

--- a/src/backend/tensorflow/tensorflow.jl
+++ b/src/backend/tensorflow/tensorflow.jl
@@ -1,7 +1,7 @@
 module TF
 
 using ..Flux, DataFlow, TensorFlow, Juno
-import Flux: accuracy, convertel
+import Flux: accuracy, convertel, Param
 
 export tf
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -13,12 +13,12 @@ may be arrays or tuples of arrays (for multiple inputs/outputs).
 back!(model, Δ, xs...) = error("Backprop not implemented for $(typeof(model))")
 
 """
-    update!(model, η) => m
+    update!(model, o) => model
 
-Update the parameters of the model `m` using the accumulated gradients from
-`back!`, using the learning rate `η`.
+Update the parameters of the model `model` using the accumulated gradients from
+`back!`, using the optimizer `o`.
 """
-update!(m, η) = m
+update!(m, o) = m
 
 """
     graph(model) => ::IVertex{Any} | nothing

--- a/src/layers/affine.jl
+++ b/src/layers/affine.jl
@@ -22,3 +22,7 @@ function update!(m::Affine, η)
   update!(m.b, η)
   m
 end
+
+function params(m::Affine)
+  Param[m.W, m.b]
+end

--- a/src/layers/control.jl
+++ b/src/layers/control.jl
@@ -9,6 +9,8 @@ end
 (s::Chain)(x) = foldl((x, m) -> m(x), x, s.layers)
 update!(s::Chain, η) = foreach(l -> update!(l, η), s.layers)
 
+params(s::Chain) = mapreduce(params, append!, s.layers)
+
 function back!(s::Chain, Δ, x)
   crumbs = foldl([x], s.layers[1:end-1]) do crumbs, layer
     push!(crumbs, layer(crumbs[end]))

--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -1,118 +1,292 @@
-export SGD
+export SGD, AdaGrad, RMSProp, AdaDelta, Adam
 
 struct Optimizer
-    cache::Dict{Param, Vector{Function}}
-    steps
-    Optimizer(steps) = new(Dict{Param, Function}(), steps)
+  cache::Dict{Param, Vector{Function}}
+  steps
+  Optimizer(steps) = new(Dict{Param, Function}(), steps)
 end
 
 function update!(p::Param, o::Optimizer)
-    steps = Base.@get!(o.cache, p, map(x->x(p), o.steps))
-    foreach(f->f(p), steps)
-    p.x .-= p.Δx
+  steps = Base.@get!(o.cache, p, map(x->x(p), o.steps))
+  foreach(f->f(p), steps)
+  @. p.x -= p.Δx
 end
 
 function Momentum(η)
+  function (p)
+    momentum = zeros(p.x)
+
     function (p)
-        momentum = zeros(p.x)
-        
-        function (p)
-            momentum .= η .* momentum .+ p.Δx
-            p.Δx .= momentum
-        end
+      @. momentum = η * momentum + p.Δx
+      @. p.Δx = momentum
     end
+  end
 end
 
-function NesterovMomentum()
-    error("TODO")
+function NesterovMomentum(η)
+  function (p)
+    momentum = zeros(p.x)
+
+    function (p)
+      @. momentum = η * momentum + p.Δx
+      @. p.Δx = η * momentum + p.Δx
+    end
+  end
 end
 
-function WeightDecayConst()
-    error("TODO")
+function WeightDecayConst(γ)
+  function (p)
+    function (p)
+      # avoid bouncing around 0
+      x = p.x - p.Δx
+      @. p.Δx += (abs(x) <= γ) * x + (abs(x) > γ) * γ * sign(x)
+    end
+  end
 end
 
-function WeightDecayRatio()
-    error("TODO")
+function WeightDecayRatio(γ)
+  function (p)
+    function (p)
+      @. p.Δx += γ * p.x
+    end
+  end
 end
 
 function GradDecayFix(lr)
-    function (p::Param)
-        function (p::Param)
-            p.Δx .= lr .* p.Δx
-        end
+  function (p)
+    function (p)
+      @. p.Δx *= lr
     end
+  end
 end
 
-function GradDecayExp()
-    error("TODO")
+function GradDecayExp(γ)
+  function (p)
+    n_iter = 0
+
+    function (p)
+      p.Δx .*= γ ^ n_iter
+      n_iter += 1
+    end
+  end
 end
 
-function GradDecayInv()
-    error("TODO")
+function GradDecayInv(γ)
+  function (p)
+    n_iter = 0
+
+    function (p)
+      p.Δx .*= 1 / (1 + γ * n_iter)
+      n_iter += 1
+    end
+  end
 end
 
 function WeightClipConst()
-    error("TODO")
+  error("TODO")
 end
 
 function WeightClipNorm()
-    error("TODO")
+  error("TODO")
 end
 
-function GradClipConst()
-    error("TODO")
+function GradClipConst(threshold)
+  function (p)
+    function (p)
+      p.Δx .= max.(min.(p.Δx, threshold), -threshold)
+    end
+  end
 end
 
 function GradClipNorm()
-    error("TODO")
+  error("TODO")
+end
+
+function Accumulate(window)
+  function (p)
+    index = 0
+    acc = zeros(p.x)
+
+    function (p)
+      acc .+= p.Δx
+
+      if index >= window
+        p.Δx .= acc
+        acc .= 0
+        index = 0
+      else
+        p.Δx .= 0
+        index += 1
+      end
+    end
+  end
+end
+
+function _AdaGrad(ϵ)
+  function (p)
+    acc = zeros(p.x) .+ ϵ
+
+    function (p)
+      @. acc += p.Δx ^ 2
+      @. p.Δx /= √acc
+    end
+  end
+end
+
+function _RMSProp(ρ, ϵ)
+  function (p)
+    acc  = zeros(p.x) .+ ϵ
+
+    function (p)
+      @. acc = ρ * acc + (1 - ρ) * p.Δx ^ 2
+      @. p.Δx /= √acc
+    end
+  end
+end
+
+function _AdaDelta(ρ, ϵ)
+  function (p)
+    acc = zeros(p.x) .+ ϵ
+    Δacc = zeros(p.x) .+ ϵ
+
+    function (p)
+      @. acc = ρ * acc + (1 - ρ) * p.Δx ^ 2
+      @. p.Δx *= √Δacc / √acc
+      @. Δacc = ρ * Δacc + (1 - ρ) * p.Δx ^ 2
+    end
+  end
+end
+
+function _Adam(β1, β2, ϵ)
+  function (p)
+    mt = zeros(p.x)
+    vt = zeros(p.x) .+ ϵ
+    β1p = β1
+    β2p = β2
+
+    function (p)
+      @. mt = β1 * mt + (1 - β1) * p.Δx
+      @. vt = β2 * vt + (1 - β2) * p.Δx ^ 2
+
+      @. p.Δx = √(1 - β2p) / √(1 - β1p) * mt / √vt
+
+      β1p *= β1
+      β2p *= β2
+    end
+  end
 end
 
 macro restrict_range(var::Symbol, range::String)
-    left, right = split(range, ", ")
-    lo = left[1] == '[' ? :>= : :>
-    lt = left[2:end]
-    ro = right[end] == ']' ? :<= : :<
-    rt = right[1:end-1]
+  left, right = split(range, ", ")
+  lo = left[1] == '[' ? :>= : :>
+  lt = left[2:end]
+  ro = right[end] == ']' ? :<= : :<
+  rt = right[1:end-1]
 
-    error_msg = "$var ∈ $range must be hold"
-    var = esc(var)
+  error_msg = "$var ∈ $range must be hold"
+  var = esc(var)
 
-    quote
-        $( lt != "-∞" && :( $lo($var, $(parse(Float64, lt))) || throw(ArgumentError($error_msg)) ) )
-        $( rt != "∞"  && :( $ro($var, $(parse(Float64, rt))) || throw(ArgumentError($error_msg)) ) )
-    end
+  quote
+    $( lt != "-∞" && :( $lo($var, $(parse(Float64, lt))) || throw(ArgumentError($error_msg)) ) )
+    $( rt != "∞"  && :( $ro($var, $(parse(Float64, rt))) || throw(ArgumentError($error_msg)) ) )
+  end
 end
 
-"""
-Stochastic gradient descent optimizer.
-Includes support for momentum,
-learning rate decay, and Nesterov momentum.
-
-# Arguments
-    lr: float >= 0. Learning rate.
-    momentum: float >= 0. Parameter updates momentum.
-    decay: float >= 0. Learning rate decay over each update.
-    nesterov: boolean. Whether to apply Nesterov momentum.
-"""
 function SGD(; lr::Real=.1,
                momentum::Real=0,
                decay::Real=0,
                nesterov::Bool=false)
 
-    @restrict_range lr       "[0, ∞)"
-    @restrict_range momentum "[0, 1]"
-    @restrict_range decay    "[0, ∞)"
+  @restrict_range lr       "[0, ∞)"
+  @restrict_range momentum "[0, 1]"
+  @restrict_range decay    "[0, ∞)"
 
-    steps = []
+  steps = []
 
-    if momentum != 0
-        nesterov ? push!(steps, NesterovMomentum(momentum)) :
-                   push!(steps, Momentum(momentum))
-    end
+  if momentum != 0
+    nesterov ? push!(steps, NesterovMomentum(momentum)) :
+               push!(steps, Momentum(momentum))
+  end
 
-    decay != 0 && push!(steps, GradDecayInv(decay))
+  decay != 0 && push!(steps, GradDecayInv(decay))
 
-    lr != 1 && push!(steps, GradDecayFix(lr))
+  lr != 1 && push!(steps, GradDecayFix(lr))
 
-    Optimizer(steps)
+  Optimizer(steps)
+end
+
+function AdaGrad(; lr::Real=.001,
+                   epsilon::Real=1e-6,
+                   decay::Real=0.)
+
+  @restrict_range lr      "[0, ∞)"
+  @restrict_range epsilon "(0, ∞)"
+  @restrict_range decay   "[0, ∞)"
+
+  steps = Any[_AdaGrad(epsilon)]
+
+  decay != 0 && push!(steps, GradDecayInv(decay))
+
+  lr != 1 && push!(steps, GradDecayFix(lr))
+
+  Optimizer(steps)
+end
+
+function RMSProp(; lr::Real=.001,
+                   rho::Real=.9,
+                   epsilon::Real=1e-6,
+                   decay::Real=0.)
+
+  @restrict_range lr      "[0, ∞)"
+  @restrict_range rho     "[0, 1]"
+  @restrict_range epsilon "(0, ∞)"
+  @restrict_range decay   "[0, ∞)"
+
+  steps = Any[_RMSProp(rho, epsilon)]
+
+  decay != 0 && push!(steps, GradDecayInv(decay))
+
+  lr != 1 && push!(steps, GradDecayFix(lr))
+
+  Optimizer(steps)
+end
+
+function AdaDelta(; lr::Real=1.,
+                    rho::Real=.9,
+                    epsilon::Real=1e-6,
+                    decay::Real=0.)
+
+  @restrict_range lr      "[0, ∞)"
+  @restrict_range rho     "[0, 1]"
+  @restrict_range epsilon "(0, ∞)"
+  @restrict_range decay   "[0, ∞)"
+
+  steps = Any[_AdaDelta(rho, epsilon)]
+
+  decay != 0 && push!(steps, GradDecayInv(decay))
+
+  lr != 1 && push!(steps, GradDecayFix(lr))
+
+  Optimizer(steps)
+end
+
+function Adam(; lr::Real=.1,
+                beta1::Real=.9,
+                beta2::Real=.999,
+                epsilon::Real=1e-6,
+                decay::Real=0.)
+
+  @restrict_range lr      "[0, ∞)"
+  @restrict_range beta1   "[0, 1]"
+  @restrict_range beta2   "[0, 1]"
+  @restrict_range epsilon "(0, ∞)"
+  @restrict_range decay   "[0, ∞)"
+
+  steps = Any[_Adam(beta1, beta2, epsilon)]
+
+  decay != 0 && push!(steps, GradDecayInv(decay))
+
+  lr != 1 && push!(steps, GradDecayFix(lr))
+
+  Optimizer(steps)
 end

--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -1,15 +1,18 @@
 export SGD, AdaGrad, RMSProp, AdaDelta, Adam
 
 struct Optimizer
-  cache::Dict{Param, Vector{Function}}
   steps
-  Optimizer(steps) = new(Dict{Param, Function}(), steps)
 end
 
-function update!(p::Param, o::Optimizer)
-  steps = Base.@get!(o.cache, p, map(x->x(p), o.steps))
-  foreach(f->f(p), steps)
-  @. p.x -= p.Δx
+function (o::Optimizer)(ps::Vector{Param})
+  states = map(ps) do p
+    p, map(x->x(p), o.steps)
+  end
+
+  () -> for (p, steps) in states
+    foreach(f->f(p), steps)
+    @. p.x -= p.Δx
+  end
 end
 
 function Momentum(η)

--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -1,0 +1,118 @@
+export SGD
+
+struct Optimizer
+    cache::Dict{Param, Vector{Function}}
+    steps
+    Optimizer(steps) = new(Dict{Param, Function}(), steps)
+end
+
+function update!(p::Param, o::Optimizer)
+    steps = Base.@get!(o.cache, p, map(x->x(p), o.steps))
+    foreach(f->f(p), steps)
+    p.x .-= p.Δx
+end
+
+function Momentum(η)
+    function (p)
+        momentum = zeros(p.x)
+        
+        function (p)
+            momentum .= η .* momentum .+ p.Δx
+            p.Δx .= momentum
+        end
+    end
+end
+
+function NesterovMomentum()
+    error("TODO")
+end
+
+function WeightDecayConst()
+    error("TODO")
+end
+
+function WeightDecayRatio()
+    error("TODO")
+end
+
+function GradDecayFix(lr)
+    function (p::Param)
+        function (p::Param)
+            p.Δx .= lr .* p.Δx
+        end
+    end
+end
+
+function GradDecayExp()
+    error("TODO")
+end
+
+function GradDecayInv()
+    error("TODO")
+end
+
+function WeightClipConst()
+    error("TODO")
+end
+
+function WeightClipNorm()
+    error("TODO")
+end
+
+function GradClipConst()
+    error("TODO")
+end
+
+function GradClipNorm()
+    error("TODO")
+end
+
+macro restrict_range(var::Symbol, range::String)
+    left, right = split(range, ", ")
+    lo = left[1] == '[' ? :>= : :>
+    lt = left[2:end]
+    ro = right[end] == ']' ? :<= : :<
+    rt = right[1:end-1]
+
+    error_msg = "$var ∈ $range must be hold"
+    var = esc(var)
+
+    quote
+        $( lt != "-∞" && :( $lo($var, $(parse(Float64, lt))) || throw(ArgumentError($error_msg)) ) )
+        $( rt != "∞"  && :( $ro($var, $(parse(Float64, rt))) || throw(ArgumentError($error_msg)) ) )
+    end
+end
+
+"""
+Stochastic gradient descent optimizer.
+Includes support for momentum,
+learning rate decay, and Nesterov momentum.
+
+# Arguments
+    lr: float >= 0. Learning rate.
+    momentum: float >= 0. Parameter updates momentum.
+    decay: float >= 0. Learning rate decay over each update.
+    nesterov: boolean. Whether to apply Nesterov momentum.
+"""
+function SGD(; lr::Real=.1,
+               momentum::Real=0,
+               decay::Real=0,
+               nesterov::Bool=false)
+
+    @restrict_range lr       "[0, ∞)"
+    @restrict_range momentum "[0, 1]"
+    @restrict_range decay    "[0, ∞)"
+
+    steps = []
+
+    if momentum != 0
+        nesterov ? push!(steps, NesterovMomentum(momentum)) :
+                   push!(steps, Momentum(momentum))
+    end
+
+    decay != 0 && push!(steps, GradDecayInv(decay))
+
+    lr != 1 && push!(steps, GradDecayFix(lr))
+
+    Optimizer(steps)
+end

--- a/src/params.jl
+++ b/src/params.jl
@@ -39,3 +39,5 @@ end
 
 Base.copy!(xs, p::Param) = copy!(xs, p.x)
 Base.copy!(p::Param, xs) = copy!(p.x, xs)
+
+params(m) = Param[]

--- a/src/training.jl
+++ b/src/training.jl
@@ -29,10 +29,11 @@ function train!(m, train; cb = [], opt = SGD(),
                 epoch = 1, loss = mse)
     @progress for e in 1:epoch
       info("Epoch $e")
-      opt! = opt(params(m))
+      opt! = nothing # `params(m)` is not valid before calling m(x) in mxnet backend
       @cb for (x, y) in train
         x, y = mapt(tobatch, (x, y))
         ŷ = m(x)
+        opt! = opt! == nothing ? opt(params(m)) : opt!
         any(isnan, ŷ) && error("NaN")
         Δ = back!(loss, 1, ŷ, y)
         back!(m, Δ, x)

--- a/src/training.jl
+++ b/src/training.jl
@@ -25,8 +25,8 @@ macro cb(ex, t, f)
   end)
 end
 
-function train!(m, train; cb = [],
-                epoch = 1, η = 0.1, loss = mse)
+function train!(m, train; cb = [], opt = SGD(),
+                epoch = 1, loss = mse)
     @progress for e in 1:epoch
       info("Epoch $e")
       @cb for (x, y) in train
@@ -35,7 +35,7 @@ function train!(m, train; cb = [],
         any(isnan, ŷ) && error("NaN")
         Δ = back!(loss, 1, ŷ, y)
         back!(m, Δ, x)
-        update!(m, η)
+        update!(m, opt)
       end 5 foreach(f -> f(), cb)
     end
     return m

--- a/src/training.jl
+++ b/src/training.jl
@@ -27,9 +27,9 @@ end
 
 function train!(m, train; cb = [], opt = SGD(),
                 epoch = 1, loss = mse)
+    opt! = nothing # `params(m)` is not valid before calling m(x) in both backends
     @progress for e in 1:epoch
       info("Epoch $e")
-      opt! = nothing # `params(m)` is not valid before calling m(x) in mxnet backend
       @cb for (x, y) in train
         x, y = mapt(tobatch, (x, y))
         ŷ = m(x)

--- a/src/training.jl
+++ b/src/training.jl
@@ -29,13 +29,14 @@ function train!(m, train; cb = [], opt = SGD(),
                 epoch = 1, loss = mse)
     @progress for e in 1:epoch
       info("Epoch $e")
+      opt! = opt(params(m))
       @cb for (x, y) in train
         x, y = mapt(tobatch, (x, y))
         ŷ = m(x)
         any(isnan, ŷ) && error("NaN")
         Δ = back!(loss, 1, ŷ, y)
         back!(m, Δ, x)
-        update!(m, opt)
+        opt!()
       end 5 foreach(f -> f(), cb)
     end
     return m

--- a/test/optimizer.jl
+++ b/test/optimizer.jl
@@ -1,38 +1,44 @@
 @testset "training julia models" begin
 
-    @testset "linear regression" begin
-        srand(0)
+  @testset "linear regression" begin
+    srand(0)
 
-        model = Affine(10, 1)
+    truth = Float32[0, 4, 2, 2, -3, 6, -1, 3, 2, -5]'
 
-        truth = Float32[0, 4, 2, 2, -3, 6, -1, 3, 2, -5]'
-
-        data = map(1:256) do i
-            x = rand(Float32, 10)
-            x, truth * x + 3rand(Float32)
-        end
-
-        Flux.train!(model, data, epoch=5)
-
-        @test cor(reshape.((model.W.x, truth), 10)...) > .99
+    data = map(1:256) do i
+      x = rand(Float32, 10)
+      x, truth * x + 3rand(Float32)
     end
 
-    @testset "logistic regression" begin
-        srand(0)
+    # It's hard to tell if an optimizer works exactly right, but we
+    # can at least ensure that they all converge at the right point
+    for opt in (SGD(), SGD(momentum=.9, decay=.01), AdaGrad(lr=1.), RMSProp(lr=.1), AdaDelta(lr=1e3), Adam())
+      model = Affine(10, 1)
 
-        model = Chain(Affine(10, 1), σ)
+      Flux.train!(model, data, epoch=10, opt=opt)
 
-        truth = Float32[0, 4, 2, 2, -3, 6, -1, 3, 2, -5]'
-
-        data = map(1:256) do i
-            x = rand(Float32, 10)
-            x, truth * x + 2rand(Float32) > 5f0
-        end
-
-        Flux.train!(model, data, epoch=10)
-
-        @test cor(reshape.((model.layers[1].W.x, truth), 10)...) > .99
+      @test cor(reshape.((model.W.x, truth), 10)...) > .99
     end
+  end
+
+  @testset "logistic regression" begin
+    srand(0)
+
+    truth = Float32[0, 4, 2, 2, -3, 6, -1, 3, 2, -5]'
+
+    data = map(1:256) do i
+      x = rand(Float32, 10)
+      x, truth * x + 2rand(Float32) > 5f0
+    end
+
+    for opt in (SGD(), SGD(momentum=.9, decay=.01), AdaGrad(lr=1.), RMSProp(lr=.1), AdaDelta(lr=1e3), Adam())
+      model = Chain(Affine(10, 1), σ)
+
+      Flux.train!(model, data, epoch=10)
+
+      @test cor(reshape.((model.layers[1].W.x, truth), 10)...) > .99
+    end
+  end
 
 end
 


### PR DESCRIPTION
I tried to add some optimizers. As for the definition of model in src/model.jl line 8:

> A "model" is a function with state. 

Optimizers are essentially models, which have the signature of `(param, grad) -> delta` with their internal states. So we can implement them just as models, using `@net`. This PR did exactly this. The only problem is that we cannot use the same `back!` and `update!` to update optimizers. Currently I introduced two APIs called `axpy!` and `zero!` and found them enough to update almost all common optimizers. Maybe there is better way to design this.

a definition of optimizer looks like this:

```
@net type _NesterovMomentum # <: Optimizer
  μ
  α
  momentum
  (param, grad) -> begin
    v = grad .+ μ * momentum
    μ * v .+ α * grad
  end
end

NesterovMomentum(μ=.9, α=1) = param -> _NesterovMomentum(μ, zero!(similar(param)))

update!(o::_NesterovMomentum, param, grad) = begin
  axpy!(o.μ, o.momentum, o.momentum)
  axpy!(1, grad, o.momentum)
  o
end
```

and to train a model using optimizers (SGD with momentum and decay) looks like this:

```
train!(model, data, η = .01, optimizers=[SGD(), Momentum(.9), Decay(1e-4)])
```

Currently them works on MXNet backend. What's your opinions of this approch?