### PR TITLE
Fix link to basics in docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,4 +11,4 @@ Pkg.add("Flux")
 Pkg.test("Flux") # Check things installed correctly
 ```
 
-Start with the [basics](basics.html). The [model zoo](https://github.com/FluxML/model-zoo/) is also a good starting point for many common kinds of models.
+Start with the [basics](models/basics.html). The [model zoo](https://github.com/FluxML/model-zoo/) is also a good starting point for many common kinds of models.


### PR DESCRIPTION
It's nice if the link on the front page of the docs works when you announce the new release on discourse :-)
Looking forward to digging into the new version!