### PR TITLE
Fixed optimisers not applying gradient to parameters

### DIFF
--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -1,4 +1,4 @@
-function updateParam(p::Param)
+function applyGradient(p::Param)
     p.x .-= p.Δ
     p.Δ .= 0
 end
@@ -6,7 +6,7 @@ end
 function descent(p::Param, η::Real)
   function ()
 	p.Δ .= p.Δ .* η
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
@@ -14,7 +14,7 @@ function momentum(p::Param, ρ::Real)
   mo = zeros(p.x)
   function ()
 	p.Δ .= mo .= ρ .* mo .+ p.Δ
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
@@ -23,21 +23,21 @@ function nesterov(p::Param, ρ::Real)
   function ()
     mo  .= ρ .* mo .+ p.Δ
     p.Δ .= ρ .* mo .+ p.Δ
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
 function clip(p::Param, thresh::Real)
   function ()
 	clamp!(p.Δ, -thresh, thresh)
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
 function weightdecay(p::Param, γ::Real)
   function ()
 	p.Δ .+= γ .* p.x
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
@@ -46,7 +46,7 @@ function invdecay(p::Param, γ::Real)
   function ()
     p.Δ .*= 1 / (1 + γ * n)
     n += 1
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
@@ -55,7 +55,7 @@ function rmsprop(p::Param; η::Real = 0.001, ρ::Real = 0.9, ϵ::Real = 1e-8)
   function ()
     @. acc = ρ * acc + (1 - ρ) * p.Δ ^ 2
     @. p.Δ /= √acc * η
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
@@ -64,7 +64,7 @@ function adagrad(p::Param; η::Real = 0.01, ϵ::Real = 1e-8)
   function ()
     @. acc += p.Δ ^ 2
     @. p.Δ /= √acc * η
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
@@ -75,7 +75,7 @@ function adadelta(p::Param; ρ::Real = 0.95, ϵ::Real = 1e-8)
     @. acc = ρ * acc + (1 - ρ) * p.Δ ^ 2
     @. p.Δ *= √Δacc / √acc
     @. Δacc = ρ * Δacc + (1 - ρ) * p.Δ ^ 2
-	updateParam(p)
+	applyGradient(p)
   end
 end
 
@@ -89,6 +89,6 @@ function adam(p::Param; η::Real = 0.001, β1::Real = 0.9, β2::Real = 0.999, ϵ
     @. p.Δ = √(1 - β2p) / √(1 - β1p) * mt / √vt * η
     β1p *= β1
     β2p *= β2
-	updateParam(p)
+	applyGradient(p)
   end
 end

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -1,13 +1,21 @@
+function updateParam(p::Param)
+    p.x .-= p.Δ
+    p.Δ .= 0
+end
+
 function descent(p::Param, η::Real)
   function ()
-    p.x .-= p.Δ .* η
-    p.Δ .= 0
+	p.Δ .= p.Δ .* η
+	updateParam(p)
   end
 end
 
 function momentum(p::Param, ρ::Real)
   mo = zeros(p.x)
-  () -> p.Δ .= mo .= ρ .* mo .+ p.Δ
+  function ()
+	p.Δ .= mo .= ρ .* mo .+ p.Δ
+	updateParam(p)
+  end
 end
 
 function nesterov(p::Param, ρ::Real)
@@ -15,15 +23,22 @@ function nesterov(p::Param, ρ::Real)
   function ()
     mo  .= ρ .* mo .+ p.Δ
     p.Δ .= ρ .* mo .+ p.Δ
+	updateParam(p)
   end
 end
 
 function clip(p::Param, thresh::Real)
-  () -> clamp!(p.Δ, -thresh, thresh)
+  function ()
+	clamp!(p.Δ, -thresh, thresh)
+	updateParam(p)
+  end
 end
 
 function weightdecay(p::Param, γ::Real)
-  () -> p.Δ .+= γ .* p.x
+  function ()
+	p.Δ .+= γ .* p.x
+	updateParam(p)
+  end
 end
 
 function invdecay(p::Param, γ::Real)
@@ -31,6 +46,7 @@ function invdecay(p::Param, γ::Real)
   function ()
     p.Δ .*= 1 / (1 + γ * n)
     n += 1
+	updateParam(p)
   end
 end
 
@@ -39,6 +55,7 @@ function rmsprop(p::Param; η::Real = 0.001, ρ::Real = 0.9, ϵ::Real = 1e-8)
   function ()
     @. acc = ρ * acc + (1 - ρ) * p.Δ ^ 2
     @. p.Δ /= √acc * η
+	updateParam(p)
   end
 end
 
@@ -47,6 +64,7 @@ function adagrad(p::Param; η::Real = 0.01, ϵ::Real = 1e-8)
   function ()
     @. acc += p.Δ ^ 2
     @. p.Δ /= √acc * η
+	updateParam(p)
   end
 end
 
@@ -57,6 +75,7 @@ function adadelta(p::Param; ρ::Real = 0.95, ϵ::Real = 1e-8)
     @. acc = ρ * acc + (1 - ρ) * p.Δ ^ 2
     @. p.Δ *= √Δacc / √acc
     @. Δacc = ρ * Δacc + (1 - ρ) * p.Δ ^ 2
+	updateParam(p)
   end
 end
 
@@ -70,5 +89,6 @@ function adam(p::Param; η::Real = 0.001, β1::Real = 0.9, β2::Real = 0.999, ϵ
     @. p.Δ = √(1 - β2p) / √(1 - β1p) * mt / √vt * η
     β1p *= β1
     β2p *= β2
+	updateParam(p)
   end
 end


### PR DESCRIPTION
Hi,
the more advanced optimisers (all except SGD) weren't applying the computed gradient to the parameters. Such behaviour seems rather confusing to me, so I changed it so that all optimisers behave in the same way.

Thank you,
GenaBitu