### PR TITLE
layer: implement BatchNorm layer

### DIFF
--- a/docs/src/models/layers.md
+++ b/docs/src/models/layers.md
@@ -36,5 +36,6 @@ swish
 These layers don't affect the structure of the network but may improve training times or reduce overfitting.
 
 ```@docs
+BatchNorm
 Dropout
 ```

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -7,7 +7,7 @@ module Flux
 using Juno, Requires
 using Lazy: @forward
 
-export Chain, Dense, RNN, LSTM, Dropout,
+export BatchNorm, Chain, Dense, RNN, LSTM, Dropout,
   SGD, ADAM, Momentum, Nesterov,
   param, params, mapleaves
 

--- a/src/layers/normalisation.jl
+++ b/src/layers/normalisation.jl
@@ -109,7 +109,7 @@ children(BN::BatchNorm) =
   (BN.λ, BN.β, BN.γ, BN.μ, BN.σ, BN.momentum, BN.ϵ, BN.active)
 
 mapchildren(f, BN::BatchNorm) =  # e.g. mapchildren(cu, BN)
-  BatchNorm(λ, f(BN.β), f(BN.γ), BN.μ, BN.σ, BN.momentum, BN.ϵ, BN.active)
+  BatchNorm(BN.λ, f(BN.β), f(BN.γ), BN.μ, BN.σ, BN.momentum, BN.ϵ, BN.active)
 
 _testmode!(BN::BatchNorm, test) = (BN.active = !test)
 

--- a/src/layers/normalisation.jl
+++ b/src/layers/normalisation.jl
@@ -95,7 +95,7 @@ function (BN::BatchNorm)(x)
 
     ϵ = T(BN.ϵ)
     m = size(x, 2)  # batch size
-    μ = sum(x, 2) ./ m
+    μ = mean(x, 2)
     σ = sqrt.(sum((x .- μ).^2, 2) ./ m .+ ϵ)
 
     # update moving mean/std

--- a/src/layers/normalisation.jl
+++ b/src/layers/normalisation.jl
@@ -66,7 +66,7 @@ julia> m = Chain(
   softmax)
 Chain(Dense(784, 64), BatchNorm(64, λ = NNlib.relu), Dense(64, 10), BatchNorm(10), NNlib.softmax)
 
-julia> opt = SGD(params(m), 10)  # a crazy learning rate
+julia> opt = SGD(params(m), 10, decay = .1)  # a crazy learning rate
 ```
 """
 mutable struct BatchNorm{F,V,N}
@@ -85,6 +85,8 @@ BatchNorm(dims::Integer...; λ = identity,
   BatchNorm(λ, param(initβ(dims)), param(initγ(dims)), 0., 1., ϵ, momentum, true)
 
 function (BN::BatchNorm)(x)
+  λ, γ, β = BN.λ, BN.γ, BN.β
+
   if !BN.active
     μ = BN.μ
     σ = BN.σ
@@ -102,7 +104,7 @@ function (BN::BatchNorm)(x)
     BN.σ = (1 - mtm) .* BN.σ .+ mtm .* σ.data .* m ./ (m - 1)
   end
 
-  BN.λ.(BN.γ .* ((x .- μ) ./ σ) .+ BN.β)
+  λ.(γ .* ((x .- μ) ./ σ) .+ β)
 end
 
 children(BN::BatchNorm) =

--- a/src/layers/normalisation.jl
+++ b/src/layers/normalisation.jl
@@ -92,12 +92,12 @@ function (BN::BatchNorm)(x)
     ϵ = T(BN.ϵ)
     m = size(x, 2)  # batch size
     μ = sum(x, 2) ./ m
-    σ = sqrt.(sum((x .- μ).^2, 2) ./ (m - 1) .+ ϵ)
+    σ = sqrt.(sum((x .- μ).^2, 2) ./ m .+ ϵ)
 
     # update moving mean/std
     mtm = T(BN.momentum)
-    BN.μ = mtm .* μ.data .+ (1 - mtm) .* BN.μ
-    BN.σ = mtm .* σ.data .+ (1 - mtm) .* BN.σ
+    BN.μ = (1 - mtm) .* BN.μ .+ mtm .* μ.data
+    BN.σ = (1 - mtm) .* BN.σ .+ mtm .* σ.data .* m ./ (m - 1)
   end
 
   BN.λ.(BN.γ .* ((x .- μ) ./ σ) .+ BN.β)

--- a/src/layers/normalisation.jl
+++ b/src/layers/normalisation.jl
@@ -2,8 +2,8 @@
     testmode!(m)
     testmode!(m, false)
 
-Put layers like [`Dropout`](@ref) and `BatchNorm` into testing mode (or back to
-training mode with `false`).
+Put layers like [`Dropout`](@ref) and [`BatchNorm`](@ref) into testing mode
+(or back to training mode with `false`).
 """
 function testmode!(m, val::Bool=true)
   prefor(x -> _testmode!(x, val), m)
@@ -48,7 +48,7 @@ _testmode!(a::Dropout, test) = (a.active = !test)
     BatchNorm(dims...; λ = identity,
               initβ = zeros, initγ = ones, ϵ = 1e-8, momentum = .1)
 
-Batch Normalization Layer
+Batch Normalization Layer for [`Dense`](@ref) layer.
 
 See [Batch Normalization: Accelerating Deep Network Training by Reducing
      Internal Covariate Shift](https://arxiv.org/pdf/1502.03167.pdf)
@@ -65,6 +65,8 @@ julia> m = Chain(
   BatchNorm(10),
   softmax)
 Chain(Dense(784, 64), BatchNorm(64, λ = NNlib.relu), Dense(64, 10), BatchNorm(10), NNlib.softmax)
+
+julia> opt = SGD(params(m), 10)  # a crazy learning rate
 ```
 """
 mutable struct BatchNorm{F,V,N}

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -26,3 +26,43 @@ using Flux: testmode!
   y = m(x)
   @test count(a->a == 0, y) == 0
 end
+
+@testset "BatchNorm" begin
+  let m = BatchNorm(2), x = param([1 2; 3 4; 5 6]')
+
+    @test m.β.data == [0, 0]  # initβ(2)
+    @test m.γ.data == [1, 1]  # initγ(2)
+    # initial m.σ is 1
+    # initial m.μ is 0
+    @test m.active
+
+    # @test m(x).data ≈ [-1 -1; 0 0; 1 1]'
+    m(x)
+
+    # julia> x
+    #  2×3 Array{Float64,2}:
+    #  1.0  3.0  5.0
+    #  2.0  4.0  6.0
+    #
+    # μ of batch will be
+    #  (1. + 3. + 5.) / 3 = 3
+    #  (2. + 4. + 6.) / 3 = 4
+    #
+    # ∴ update rule with momentum:
+    #  .1 * 3 + 0 = .3
+    #  .1 * 4 + 0 = .4
+    @test m.μ ≈ reshape([0.3, 0.4], 2, 1)
+
+    # julia> .1 .* std(x, 2, corrected=false) .* (3 / 2).+ .9 .* [1., 1.]
+    # 2×1 Array{Float64,2}:
+    #  1.14495
+    #  1.14495
+    @test m.σ ≈ .1 .* std(x.data, 2, corrected=false) .* (3 / 2).+ .9 .* [1., 1.]
+
+    testmode!(m)
+    @test !m.active
+
+    x′ = m(x).data
+    @test x′[1] ≈ (1 - 0.3) / 1.1449489742783179
+  end
+end

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -65,4 +65,16 @@ end
     x′ = m(x).data
     @test x′[1] ≈ (1 - 0.3) / 1.1449489742783179
   end
+
+  # with activation function
+  let m = BatchNorm(2, λ = σ), x = param([1 2; 3 4; 5 6]')
+    @test m.active
+    m(x)
+
+    testmode!(m)
+    @test !m.active
+
+    x′ = m(x).data
+    @test x′[1] ≈ σ((1 - 0.3) / 1.1449489742783179)
+  end
 end


### PR DESCRIPTION
Please review it carefully, no test cases :p 

I just plug this layer to the MNIST example, and set the learning rate of SGD to a crazy number: `10`.
It performs quite fine and better than the original model.

---
Ref: [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/pdf/1502.03167.pdf)

