### PR TITLE
Lazy Softmax

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -23,6 +23,7 @@ include("utils.jl")
 include("onehot.jl")
 include("tree.jl")
 
+include("layers/softmax.jl")
 include("layers/stateless.jl")
 include("layers/basic.jl")
 include("layers/recurrent.jl")

--- a/src/layers/softmax.jl
+++ b/src/layers/softmax.jl
@@ -1,19 +1,19 @@
-mutable struct Softmax{T,N,A,B} <: AbstractArray{T,N}
+mutable struct Softmax{T,N,A} <: AbstractArray{T,N}
   logits::A
-  probs::B
-  Softmax{T,N,A,B}(logits::A) where {T,N,A,B} = new(logits)
+  probs::A
+  Softmax{T,N,A}(logits::A) where {T,N,A} = new(logits)
 end
 
 Softmax(logits::AbstractVecOrMat{<:AbstractFloat}) =
-  Softmax{eltype(logits),ndims(logits),typeof(logits),typeof(Tracker.data(logits))}(logits)
+  Softmax{eltype(logits),ndims(logits),typeof(logits)}(logits)
 
 @forward Softmax.logits Base.size
 
 Base.IndexStyle(::Type{Softmax{T,N,A}}) where {T,N,A} = IndexStyle(A)
 
 function Base.getindex(s::Softmax, i)
-  isdefined(s, :probs) || (s.probs = NNlib.softmax(Tracker.data(s.logits)))
-  s.probs[i]
+  isdefined(s, :probs) || (s.probs = NNlib.softmax(s.logits))
+  Tracker.data(s.probs)[i]
 end
 
 softmax(xs::AbstractVecOrMat{<:AbstractFloat}) = Softmax(xs)

--- a/src/layers/softmax.jl
+++ b/src/layers/softmax.jl
@@ -1,0 +1,23 @@
+mutable struct Softmax{T,N,A,B} <: AbstractArray{T,N}
+  logits::A
+  probs::B
+  Softmax{T,N,A,B}(logits::A) where {T,N,A,B} = new(logits)
+end
+
+Softmax(logits::AbstractVecOrMat{<:AbstractFloat}) =
+  Softmax{eltype(logits),ndims(logits),typeof(logits),typeof(Tracker.data(logits))}(logits)
+
+@forward Softmax.logits Base.size
+
+Base.IndexStyle(::Type{Softmax{T,N,A}}) where {T,N,A} = IndexStyle(A)
+
+function Base.getindex(s::Softmax, i)
+  isdefined(s, :probs) || (s.probs = NNlib.softmax(Tracker.data(s.logits)))
+  s.probs[i]
+end
+
+softmax(xs::AbstractVecOrMat{<:AbstractFloat}) = Softmax(xs)
+
+softmax(xs::AbstractVecOrMat{<:Real}) = softmax(convert.(AbstractFloat, xs))
+
+softmax(xs::TrackedArray) = TrackedArray(Tracker.Call(NNlib.softmax, xs), Softmax(xs))

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -12,3 +12,6 @@ function logitcrossentropy(logŷ::AbstractVecOrMat, y::AbstractVecOrMat)
   ypred = logŷ .- log.(sum(exp.(logŷ), 1))
   -sum(y .* ypred) / size(y, 2)
 end
+
+crossentropy(ŷ::Union{Softmax,TrackedArray{<:Softmax}}, y::AbstractVecOrMat) =
+  logitcrossentropy(Tracker.data(ŷ).logits, y)

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -11,8 +11,8 @@ gradtest(f, dims...) = gradtest(f, rand.(dims)...)
 
 @test gradtest(x -> sin.(sum(x, (2, 3))), (3,4,5))
 
-@test gradtest(x -> softmax(x).*(1:3), 3)
-@test gradtest(x -> softmax(x).*(1:3), (3,5))
+@test gradtest(x -> NNlib.softmax(x).*(1:3), 3)
+@test gradtest(x -> NNlib.softmax(x).*(1:3), (3,5))
 
 @test gradtest(Flux.mse, rand(5,5), rand(5, 5))
 @test gradtest(Flux.crossentropy, rand(5,5), rand(5, 5))


### PR DESCRIPTION
`softmax` looks just like it did before:

```julia
julia> ps = softmax([1,2,3])
3-element Flux.Softmax{Float64,1,Array{Float64,1}}:
 0.0900306
 0.244728
 0.665241
```

But under the hood it's now lazy, and actually stores the original logits:

```julia
julia> ps.logits
3-element Array{Float64,1}:
 1.0
 2.0
 3.0
```

What this means is that functions like `crossentropy` can avoid computing the `softmax` entirely and be much faster; but this is completely transparent and models benefit from it for free. With our sparse matrix types this gets us fast code without memorising a bunch of horrific functions like `tf.nn.sparse_softmax_cross_entropy_with_logits`. `crossentropy(softmax(ŷ), y)` is identical.

Needs tests, gradient checks and some GPU support hacks.