### PR TITLE
Make crossentropy symmetric

### DIFF
--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -3,7 +3,7 @@
 mse(ŷ, y) = sum((ŷ .- y).^2)/length(y)
 
 crossentropy(ŷ::AbstractVecOrMat, y::AbstractVecOrMat) =
-  -sum(y .* log.(ŷ)) / size(y, 2)
+  -sum(y .* log.(ŷ) + (1-y).*log.(1-̂y)) / size(y, 2)
 
 @deprecate logloss(x, y) crossentropy(x, y)
 


### PR DESCRIPTION
The current loss function always goes to zero if yhat -> constant 1. It needs the extra term so it's penalized when not getting yhat correct, instead of only being penalized not getting yhat correct when y is 1.

@oxinabox had this idea.