### PR TITLE
Define dot operator for TrackedArray

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -13,7 +13,7 @@ export Chain, Dense, RNN, LSTM,
   param, params, mapleaves
 
 using NNlib
-export σ, sigmoid, relu, leakyrelu, elu, swish, softmax
+export σ, sigmoid, relu, leakyrelu, elu, swish, softmax, ⋅
 
 include("tracker/Tracker.jl")
 using .Tracker

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -120,3 +120,19 @@ function throttle(f, timeout; leading=true, trailing=false)
     nothing
   end
 end
+
+"""
+Extends dot operator of Base.
+Returns a zero dimensional TrackedArray by computing dot product of two
+TrackedArrays.
+
+```julia
+julia> param([1,2]) ⋅ param([2,2]) 
+Tracked 0-dimensional Array{Float64,0}:
+6.0
+```
+"""
+
+function Base.:⋅(a::TrackedArray, b::TrackedArray)
+  return param(a.data ⋅ b.data)
+end


### PR DESCRIPTION
Extends `Base` to add support for the `⋅` operator for `TrackedArray`s.
Fixes #114.