### PR TITLE
Restructure `train!` callbacks

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -2,7 +2,7 @@ using Juno
 using Flux.Tracker: back!, value
 
 runall(f) = f
-runall(fs::AbstractVector) = () -> foreach(call, fs)
+runall(fs::AbstractVector) = (args...) -> map(f->f(args...), fs)
 
 """
     train!(loss, data, opt)
@@ -10,27 +10,39 @@ runall(fs::AbstractVector) = () -> foreach(call, fs)
 For each datapoint `d` in `data` computes the gradient of `loss(d...)` through
 backpropagation and calls the optimizer `opt`.
 
-Takes a callback as keyword argument `cb`. For example, this will print "training"
-every 10 seconds:
+Takes a callback as keyword argument `log_cb`: this is for use for logging, debugging etc.
+Also optionally another callback `stopping_criteria`,
+If `stopping_crieria` returns true, then the training is stopped early.
+Otherwise, training will run for every datapoint.
+
+Both callbacks takes as their arguments the step_number, and the current loss.
+They are both called _before_ the network parameters are updated.
+
+For example, the following will print the current loss every 10 steps
+and will at every step check to see if the loss is less than 0.1, and if so will stop early.
 
 ```julia
 Flux.train!(loss, data, opt,
-            cb = throttle(() -> println("training"), 10))
+            log_cb = throttle((i, l) -> println("At iter \$i, training loss=\$l"), 10),
+            stopping_criteria = (i, l) -> l < 0.1
+            )
 ```
 
-The callback can return `:stop` to interrupt the training loop.
-
-Multiple optimisers and callbacks can be passed to `opt` and `cb` as arrays.
+Multiple optimisers and callbacks can be passed to `opt`, `log_cb`, and `stopping_criteria` as vectors.
 """
-function train!(loss, data, opt; cb = () -> ())
-  cb = runall(cb)
+function train!(loss, data, opt; log_cb=(i,l) -> (), stopping_criteria=(i,l) -> false)
+  log_cb = runall(log_cb)
+  stopping_criteria = runall(stopping_criteria)
   opt = runall(opt)
-  @progress for d in data
+  @progress for (step, d) in enumerate(data)
     l = loss(d...)
     isinf(value(l)) && error("Loss is Inf")
     isnan(value(l)) && error("Loss is NaN")
+
+    log_cb(step, value(l))
+    any(stopping_criteria(step, value(l))) && break
+
     back!(l)
     opt()
-    cb() == :stop && break
   end
 end

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -24,11 +24,11 @@ end
   Flux.train!(() -> (sleep(0.1); loss_calls+=1; l),
               Iterators.repeated((), 100),
               ()->(opt_calls+=1; nothing),
-              log_cb = Flux.throttle((j,v) -> log_calls+=1, 1),
-              stopping_criteria = Flux.throttle((j,v) -> (j > 3), 1))
+              log_cb = (j,v) -> log_calls+=1,
+              stopping_criteria = (j,v) -> (j > 3))
 
-  @test 3 < loss_calls < 50
-  @test log_calls == 2
+  @test loss_calls == 4
+  @test log_calls == 4
   @test opt_calls == loss_calls - 1
 end
 


### PR DESCRIPTION
Rather than #131 
this is a more complete reworking of the callbacks.

I like the idea of #127,
but I think that it deserves its own callback, currently called `stopping_citeria`, returning `true` when it is time to stop.
Rather than having `cb` return a magic symbol.

I renamed `cb` to `log_cb`.

Also I made both callbacks take the iteration number, and the current loss as parameters.
Because they are very often wanted in these things.
This is breaking.

A deprecation could be added by doing something like:

```
if cb!=nothing
    warn("cb deprecated...")
    push!(log_cb, (i,l)->cb())
    push!(stopping_criteria, (i,l)->cb()==:stop)
end
```

if that is desired.

