### PR TITLE
rewrite logitcrossentropy using logsoftmax

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -34,4 +34,6 @@ include("layers/normalisation.jl")
 
 include("data/Data.jl")
 
+@require CuArrays include("cuda/cuda.jl")
+
 end # module

--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -1,0 +1,7 @@
+module CUDA
+
+using CuArrays
+
+CuArrays.cudnn_available() && include("cudnn.jl")
+
+end

--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -69,6 +69,13 @@ function rnnWorkspaceSize(r::RNNDesc)
   return Int(size[])
 end
 
+function rnnTrainingReserveSize(r::RNNDesc)
+  size = Csize_t[0]
+  @check ccall((:cudnnGetRNNTrainingReserveSize,libcudnn), cudnnStatus_t, (Ptr{Void}, Ptr{Void}, Cint, Ptr{Ptr{Void}}, Ptr{Csize_t}),
+    libcudnn_handle[], r, 1, [TensorDesc(r.T, (1,r.input,1))], size)
+  return Int(size[])
+end
+
 function rnnParamSize(r::RNNDesc)
   size = Csize_t[0]
   @check ccall((:cudnnGetRNNParamsSize, libcudnn), cudnnStatus_t, (Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Csize_t},Cint),

--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -1,0 +1,59 @@
+using CuArrays.CUDNN: @check, libcudnn, cudnnStatus_t, libcudnn_handle, cudnnDataType
+
+mutable struct DropoutDesc
+  ptr::Ptr{Void}
+  states::CuVector{UInt8}
+end
+
+Base.unsafe_convert(::Type{Ptr{Void}}, dd::DropoutDesc) = dd.ptr
+
+function DropoutDesc(ρ::Real; seed::Integer=0)
+  d = [C_NULL]
+  s = Csize_t[0]
+  @check ccall((:cudnnCreateDropoutDescriptor,libcudnn), cudnnStatus_t, (Ptr{Ptr{Void}},), d)
+  @check ccall((:cudnnDropoutGetStatesSize,libcudnn),cudnnStatus_t,(Ptr{Void},Ptr{Csize_t}),libcudnn_handle[],s)
+  states = CuArray{UInt8}(s[]) # TODO: can we drop this when ρ=0?
+  desc = DropoutDesc(d[], states)
+  @check ccall((:cudnnSetDropoutDescriptor,libcudnn),cudnnStatus_t,(Ptr{Void},Ptr{Void},Cfloat,Ptr{Void},Csize_t,Culonglong),
+    desc,libcudnn_handle[],ρ,states,length(states),seed)
+  finalizer(desc, x ->
+    @check ccall((:cudnnDestroyDropoutDescriptor,libcudnn),cudnnStatus_t,(Ptr{Void},),x))
+  return desc
+end
+
+const RNN_RELU = 0 # Stock RNN with ReLu activation
+const RNN_TANH = 1 # Stock RNN with tanh activation
+const LSTM = 2     # LSTM with no peephole connections
+const GRU = 3      # Using h' = tanh(r * Uh(t-1) + Wx) and h = (1 - z) * h' + z * h(t-1)
+
+const LINEAR_INPUT = 0
+const SKIP_INPUT = 1
+
+const UNIDIRECTIONAL = 0
+const BIDIRECTIONAL = 1
+
+const RNN_ALGO_STANDARD = 0
+const RNN_ALGO_PERSIST_STATIC = 1
+const RNN_ALGO_PERSIST_DYNAMIC = 2
+
+mutable struct RNNDesc
+  ptr::Ptr{Void}
+end
+
+Base.unsafe_convert(::Type{Ptr{Void}}, d::RNNDesc) = d.ptr
+
+function RNNDesc(T, mode, input, hidden; layers = 1)
+  d = [C_NULL]
+  @check ccall((:cudnnCreateRNNDescriptor,libcudnn),cudnnStatus_t,(Ptr{Ptr{Void}},),d)
+  rd = RNNDesc(d[])
+  finalizer(rd, x ->
+    @check ccall((:cudnnDestroyRNNDescriptor,libcudnn),cudnnStatus_t,(Ptr{Void},),x))
+
+  dropoutDesc = DropoutDesc()
+  inputMode = LINEAR_INPUT
+  direction = UNIDIRECTIONAL
+  algo = RNN_ALGO_STANDARD
+  @check ccall((:cudnnSetRNNDescriptor_v6,libcudnn), cudnnStatus_t, (Ptr{Void},Ptr{Void},Cint,Cint,Ptr{Void},Cint,Cint,Cint,Cint,Cint),
+    libcudnn_handle[],rd,hidden,layers,dropoutDesc,inputMode,direction,mode,algo,cudnnDataType(T))
+  return rd
+end

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -4,28 +4,6 @@ using NNlib: log_fast, logsoftmax
 
 mse(ŷ, y) = sum((ŷ .- y).^2)/length(y)
 
-"""
-`crossentropy` takes the output probability distribution `ŷ` and the target probability
-distribution `y` as the inputs to compute the cross entropy loss. It is numerically unstable
-due to the independent treatment of the log-softmax operation, and it is recommended
-to use `logitcrossentropy`.
-
-    julia> srand(123);
-
-    julia> x = randn(5, 4);
-
-    julia> y = rand(10, 4);
-
-    julia> y = y ./ sum(y, 1);
-
-    julia> m = Dense(5, 10);
-
-    julia> ŷ = softmax(m(x));
-
-    julia> Flux.crossentropy(ŷ, y)
-    Tracked 0-dimensional Array{Float64,0}:
-    2.44887
-"""
 function crossentropy(ŷ::AbstractVecOrMat, y::AbstractVecOrMat; weight = 1)
   return -sum(y .* log_fast.(ŷ) .* weight) / size(y, 2)
 end
@@ -33,23 +11,19 @@ end
 @deprecate logloss(x, y) crossentropy(x, y)
 
 """
+    logitcrossentropy(logŷ::AbstractVecOrMat, y::AbstractVecOrMat; weight = 1)
+
 `logitcrossentropy` takes the logits of the output probability distribution `logŷ` and
 the target probability distribution `y` as the inputs to compute the cross entropy loss.
 It is mathematically equivalent to the combination of `softmax(logŷ)` and `crossentropy`,
 i.e., `crossentropy(softmax(logŷ), y)`, but it is more numerically stable than the former.
 
     julia> srand(123);
-
     julia> x = randn(5, 4);
-
     julia> y = rand(10, 4);
-
     julia> y = y ./ sum(y, 1);
-
     julia> m = Dense(5, 10);
-
     julia> logŷ = m(x);
-
     julia> Flux.logitcrossentropy(logŷ, y)
     Tracked 0-dimensional Array{Float64,0}:
     2.44887

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -1,19 +1,61 @@
-using NNlib: log_fast
+using NNlib: log_fast, logsoftmax
 
 # Cost functions
 
 mse(ŷ, y) = sum((ŷ .- y).^2)/length(y)
 
+"""
+`crossentropy` takes the output probability distribution `ŷ` and the target probability
+distribution `y` as the inputs to compute the cross entropy loss. It is numerically unstable
+due to the independent treatment of the log-softmax operation, and it is recommended
+to use `logitcrossentropy`.
+
+    julia> srand(123);
+
+    julia> x = randn(5, 4);
+
+    julia> y = rand(10, 4);
+
+    julia> y = y ./ sum(y, 1);
+
+    julia> m = Dense(5, 10);
+
+    julia> ŷ = softmax(m(x));
+
+    julia> Flux.crossentropy(ŷ, y)
+    Tracked 0-dimensional Array{Float64,0}:
+    2.44887
+"""
 function crossentropy(ŷ::AbstractVecOrMat, y::AbstractVecOrMat; weight = 1)
   return -sum(y .* log_fast.(ŷ) .* weight) / size(y, 2)
 end
 
 @deprecate logloss(x, y) crossentropy(x, y)
 
-function logitcrossentropy(logŷ::AbstractVecOrMat, y::AbstractVecOrMat)
-  logŷ = logŷ .- maximum(logŷ, 1)
-  ypred = logŷ .- log_fast.(sum(exp.(logŷ), 1))
-  -sum(y .* ypred) / size(y, 2)
+"""
+`logitcrossentropy` takes the logits of the output probability distribution `logŷ` and
+the target probability distribution `y` as the inputs to compute the cross entropy loss.
+It is mathematically equivalent to the combination of `softmax(logŷ)` and `crossentropy`,
+i.e., `crossentropy(softmax(logŷ), y)`, but it is more numerically stable than the former.
+
+    julia> srand(123);
+
+    julia> x = randn(5, 4);
+
+    julia> y = rand(10, 4);
+
+    julia> y = y ./ sum(y, 1);
+
+    julia> m = Dense(5, 10);
+
+    julia> logŷ = m(x);
+
+    julia> Flux.logitcrossentropy(logŷ, y)
+    Tracked 0-dimensional Array{Float64,0}:
+    2.44887
+"""
+function logitcrossentropy(logŷ::AbstractVecOrMat, y::AbstractVecOrMat; weight = 1)
+  return -sum(y .* logsoftmax(logŷ) .* weight) / size(y, 2)
 end
 
 """

--- a/test/layers/stateless.jl
+++ b/test/layers/stateless.jl
@@ -1,26 +1,38 @@
-using Flux: onehotbatch, mse, crossentropy
+using Flux: onehotbatch, mse, crossentropy, logitcrossentropy
 
 @testset "losses" begin
   # First, regression-style y's
   y = [1, 1, 0, 0]
-  y_hat = [.9, .1, .1, .9]
+  ŷ = [.9, .1, .1, .9]
 
   @testset "mse" begin
-    @test mse(y_hat, y) ≈ (.1^2 + .9^2)/2
+    @test mse(ŷ, y) ≈ (.1^2 + .9^2)/2
   end
 
   # Now onehot y's
   y = onehotbatch([1, 1, 0, 0], 0:1)
-  y_hat = [.1 .9; .9 .1; .9 .1; .1 .9]'
-  y_logloss = 1.203972804325936
+  ŷ = [.1 .9; .9 .1; .9 .1; .1 .9]'
+  v = log(.1 / .9)
+  logŷ = [v 0.0; 0.0 v; 0.0 v; v 0.0]'
+  lossvalue = 1.203972804325936
 
   @testset "crossentropy" begin
-    @test crossentropy(y_hat, y) ≈ y_logloss
+    @test crossentropy(ŷ, y) ≈ lossvalue
+  end
+
+  @testset "logitcrossentropy" begin
+    @test logitcrossentropy(logŷ, y) ≈ lossvalue
   end
 
   @testset "weighted_crossentropy" begin
-    @test crossentropy(y_hat, y, weight = ones(2)) ≈ y_logloss
-    @test crossentropy(y_hat, y, weight = [.5, .5]) ≈ y_logloss/2
-    @test crossentropy(y_hat, y, weight = [2, .5]) ≈ 1.5049660054074199
+    @test crossentropy(ŷ, y, weight = ones(2)) ≈ lossvalue
+    @test crossentropy(ŷ, y, weight = [.5, .5]) ≈ lossvalue/2
+    @test crossentropy(ŷ, y, weight = [2, .5]) ≈ 1.5049660054074199
+  end
+
+  @testset "weighted_logitcrossentropy" begin
+    @test logitcrossentropy(logŷ, y, weight = ones(2)) ≈ lossvalue
+    @test logitcrossentropy(logŷ, y, weight = [.5, .5]) ≈ lossvalue/2
+    @test logitcrossentropy(logŷ, y, weight = [2, .5]) ≈ 1.5049660054074199
   end
 end


### PR DESCRIPTION
Rewriting the `logitcrossentropy` function using the `logsoftmax` function in order to take advantage of the CUDA acceleration for GPU computation.