### PR TITLE
Reshape with Tuple Dimensions and Kronecker Product 

### DIFF
--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -106,8 +106,22 @@ end
 Base.reshape(xs::TrackedArray, dims::Union{Colon,Int64}...) =
   track(reshape, xs, dims...)
 
+Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Int64,N}} where N) =
+  track(reshape, xs, dims)
+
 back(::typeof(reshape), Δ, xs::TrackedArray, _...) =
   back(xs, reshape(Δ, size(xs)))
+
+
+function Base.kron(mat1::AbstractMatrix,mat2::AbstractMatrix)
+    m1, n1 = size(mat1)
+    mat1_rsh = reshape(mat1,(1,m1,1,n1))
+
+    m2, n2 = size(mat2)
+    mat2_rsh = reshape(mat2,(m2,1,n2,1))
+
+    return reshape(mat1_rsh.*mat2_rsh, (m1*m2,n1*n2))
+end
 
 # Reductions
 

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -113,7 +113,7 @@ back(::typeof(reshape), Δ, xs::TrackedArray, _...) =
   back(xs, reshape(Δ, size(xs)))
 
 
-function Base.kron(mat1::AbstractMatrix,mat2::AbstractMatrix)
+function _kron(mat1::AbstractMatrix,mat2::AbstractMatrix)
     m1, n1 = size(mat1)
     mat1_rsh = reshape(mat1,(1,m1,1,n1))
 
@@ -122,6 +122,10 @@ function Base.kron(mat1::AbstractMatrix,mat2::AbstractMatrix)
 
     return reshape(mat1_rsh.*mat2_rsh, (m1*m2,n1*n2))
 end
+
+Base.kron(a::TrackedMatrix, b::TrackedMatrix)  = _kron(a, b)
+Base.kron(a::TrackedMatrix, b::AbstractMatrix) = _kron(a, b)
+Base.kron(a::AbstractMatrix, b::TrackedMatrix) = _kron(a, b)
 
 # Reductions
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -29,6 +29,10 @@ gradtest(f, dims...) = gradtest(f, rand.(dims)...)
 @test gradtest(vcat, rand(5), rand(3), rand(8))
 @test gradtest(vcat, rand(5,2), rand(3,2), rand(8,2))
 
+@test gradtest(kron,rand(5,1), rand(3,1))
+@test gradtest(kron, rand(5,1), rand(3,1), rand(8,1))
+@test gradtest(kron, rand(5,2), rand(3,2), rand(8,2))
+
 @test gradtest(diagm, rand(3))
 
 @testset "mean" begin

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -29,6 +29,8 @@ gradtest(f, dims...) = gradtest(f, rand.(dims)...)
 @test gradtest(vcat, rand(5), rand(3), rand(8))
 @test gradtest(vcat, rand(5,2), rand(3,2), rand(8,2))
 
+@test gradtest(kron,rand(5), rand(3))
+@test gradtest(kron, rand(5), rand(3), rand(8))
 @test gradtest(kron,rand(5,1), rand(3,1))
 @test gradtest(kron, rand(5,1), rand(3,1), rand(8,1))
 @test gradtest(kron, rand(5,2), rand(3,2), rand(8,2))


### PR DESCRIPTION
Fixes #149 
(though not in the more clever `∂(X⊗Y) = (∂X)⊗Y + X⊗(∂Y)` we also discussed.