### PR TITLE
Convert OneHot CuArrays to dense CuArrays before passing to CUDNN methods

### DIFF
--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -325,6 +325,10 @@ function (m::CuLSTM{T})(h::NTuple{2,CuParam{T}}, x::CuParam{T}) where T <: Union
   return (result[2], result[3]), result[1]
 end
 
+(m::CuRNN{T})(h::CuParam{T}, x) where T <: Union{Float32,Float64} = m(h, CuArray{T}(x))
+(m::CuGRU{T})(h::CuParam{T}, x) where T <: Union{Float32,Float64} = m(h, CuArray{T}(x))
+(m::CuLSTM{T})(h::NTuple{2,CuParam{T}}, x) where T <: Union{Float32,Float64} = m(h, CuArray{T}(x))
+
 function accum_transpose!(dst::CuArray, src::CuArray)
   function kernel(dst, src)
     I = @cuindex dst

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -36,7 +36,6 @@ adapt(T, xs::OneHotMatrix) = OneHotMatrix(xs.height, adapt(T, xs.data))
   import CuArrays: CuArray, cudaconvert
   Base.Broadcast._containertype(::Type{<:OneHotMatrix{<:CuArray}}) = CuArray
   cudaconvert(x::OneHotMatrix{<:CuArray}) = OneHotMatrix(x.height, cudaconvert(x.data))
-  (::Type{<:CuArray{T}})(x::OneHotMatrix{<:CuArray}) where {T} = broadcast(y -> T(y), x)
 end
 
 function onehot(l, labels)

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -36,6 +36,7 @@ adapt(T, xs::OneHotMatrix) = OneHotMatrix(xs.height, adapt(T, xs.data))
   import CuArrays: CuArray, cudaconvert
   Base.Broadcast._containertype(::Type{<:OneHotMatrix{<:CuArray}}) = CuArray
   cudaconvert(x::OneHotMatrix{<:CuArray}) = OneHotMatrix(x.height, cudaconvert(x.data))
+  (::Type{<:CuArray{T}})(x::OneHotMatrix{<:CuArray}) where {T} = broadcast(y -> T(y), x)
 end
 
 function onehot(l, labels)

--- a/test/cuda/cudnn.jl
+++ b/test/cuda/cudnn.jl
@@ -4,28 +4,45 @@ info("Testing Flux/CUDNN")
 
 @testset "RNN" begin
   @testset for R in [RNN, GRU, LSTM]
-    x = param(rand(10,5))
-    cux = cu(x)
     rnn = R(10, 5)
     curnn = mapleaves(cu, rnn)
-    y = (rnn(x); rnn(x))
-    cuy = (curnn(cux); curnn(cux))
+    @testset for batch_size in (1, 5)
+      Flux.reset!(rnn)
+      Flux.reset!(curnn)
+      x = batch_size == 1 ?
+        param(rand(10)) :
+        param(rand(10,batch_size))
+      cux = cu(x)
+      y = (rnn(x); rnn(x))
+      cuy = (curnn(cux); curnn(cux))
 
-    @test y.data ≈ collect(cuy.data)
-    @test haskey(Flux.CUDA.descs, curnn.cell)
+      @test y.data ≈ collect(cuy.data)
+      @test haskey(Flux.CUDA.descs, curnn.cell)
 
-    Δ = randn(size(y))
+      Δ = randn(size(y))
 
-    Flux.back!(y, Δ)
-    Flux.back!(cuy, cu(Δ))
+      Flux.back!(y, Δ)
+      Flux.back!(cuy, cu(Δ))
 
-    @test x.grad ≈ collect(cux.grad)
-    @test rnn.cell.Wi.grad ≈ collect(curnn.cell.Wi.grad)
-    @test rnn.cell.Wh.grad ≈ collect(curnn.cell.Wh.grad)
-    @test rnn.cell.b.grad ≈ collect(curnn.cell.b.grad)
-    @test rnn.cell.h.grad ≈ collect(curnn.cell.h.grad)
-    if isdefined(rnn.cell, :c)
-      @test rnn.cell.c.grad ≈ collect(curnn.cell.c.grad)
+      @test x.grad ≈ collect(cux.grad)
+      @test rnn.cell.Wi.grad ≈ collect(curnn.cell.Wi.grad)
+      @test rnn.cell.Wh.grad ≈ collect(curnn.cell.Wh.grad)
+      @test rnn.cell.b.grad ≈ collect(curnn.cell.b.grad)
+      @test rnn.cell.h.grad ≈ collect(curnn.cell.h.grad)
+      if isdefined(rnn.cell, :c)
+        @test rnn.cell.c.grad ≈ collect(curnn.cell.c.grad)
+      end
+
+      Flux.reset!(rnn)
+      Flux.reset!(curnn)
+      ohx = batch_size == 1 ?
+        Flux.onehot(rand(1:10), 1:10) :
+        Flux.onehotbatch(rand(1:10, batch_size), 1:10)
+      cuohx = cu(ohx)
+      y = (rnn(ohx); rnn(ohx))
+      cuy = (curnn(cuohx); curnn(cuohx))
+
+      @test y.data ≈ collect(cuy.data)
     end
   end
 end


### PR DESCRIPTION
Two notes:
- I'm surprised that `(::Type{<:CuArray{T}})(x::OneHotMatrix{<:CuArray}) where {T} = T.(x)` doesn't work. I would have thought that `T.(x)` and `broadcast(y -> T(y), x)` were equivalent, but in the first version broadcasting gets confused that `T` is a `DataType` and not obviously a function.
```
  Got an exception of type ErrorException outside of a @test
  don't know how to handle argument of type DataType
  Stacktrace:
   [1] cudaconvert(::DataType) at /home/schmrlng/.julia/v0.6/CUDAnative/src/execution.jl:20
   [2] map at ./tuple.jl:161 [inlined] (repeats 2 times)
   [3] broadcast at ./broadcast.jl:17 [inlined]
   [4] _broadcast! at /home/schmrlng/.julia/v0.6/CuArrays/src/broadcast.jl:22 [inlined]
   [5] broadcast_t at /home/schmrlng/.julia/v0.6/CuArrays/src/broadcast.jl:37 [inlined]
   [6] broadcast_c at /home/schmrlng/.julia/v0.6/CuArrays/src/broadcast.jl:58 [inlined]
   [7] broadcast at ./broadcast.jl:455 [inlined]
   [8] CuArrays.CuArray{Float32,N} where N(::Flux.OneHotMatrix{CuArray{Flux.OneHotVector,1}}) at /home/schmrlng/.julia/v0.6/Flux/src/onehot.jl:39
```
- `Pkg.test("Flux")` fails nondeterministically (about half the time) on my machine with this setup:
```
julia> CuArrays.CUDNN.CUDNN_VERSION
7005

julia> versioninfo()
Julia Version 0.6.2
Commit d386e40c17* (2017-12-13 18:08 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: AMD Ryzen 7 1800X Eight-Core Processor
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Barcelona)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, generic)
```
Here's an example backtrace:
```
julia> Pkg.test("Flux")
INFO: Testing Flux
INFO: Testing Flux/GPU
INFO: Testing Flux/CUDNN
batch_size = 1: Error During Test
  Got an exception of type CuArrays.CUDNN.CUDNNError outside of a @test
  CUDNNError(code 3, CUDNN_STATUS_BAD_PARAM)
  Stacktrace:
   [1] macro expansion at /home/schmrlng/.julia/v0.6/CuArrays/src/dnn/error.jl:19 [inlined]
   [2] cudnnRNNBackwardData(::Flux.CUDA.RNNDesc{Float32}, ::Int64, ::Array{CuArrays.CUDNN.TensorDesc,1}, ::CuArray{Float32,1}, ::Array{CuArrays.CUDNN.TensorDesc,1}, ::CuArray{Float32,1}, ::Ptr{Void}, ::Ptr{Void}, ::Ptr{Void}, ::Ptr{Void}, ::CuArrays.CUDNN.FilterDesc, ::CuArray{Float32,1}, ::CuArrays.CUDNN.TensorDesc, ::CuArray{Float32,1}, ::Ptr{Void}, ::Ptr{Void}, ::Array{CuArrays.CUDNN.TensorDesc,1}, ::CuArray{Float32,1}, ::CuArrays.CUDNN.TensorDesc, ::CuArray{Float32,1}, ::Ptr{Void}, ::Ptr{Void}, ::CuArray{UInt8,1}, ::CuArray{UInt8,1}) at /home/schmrlng/.julia/v0.6/Flux/src/cuda/cudnn.jl:189
   [3] backwardData(::Flux.CUDA.RNNDesc{Float32}, ::CuArray{Float32,1}, ::CuArray{Float32,1}, ::Int64, ::Void, ::CuArray{Float32,1}, ::Void, ::CuArray{UInt8,1}) at /home/schmrlng/.julia/v0.6/Flux/src/cuda/cudnn.jl:206
   [4] back_(::Flux.CUDA.RNNCall{Flux.RNNCell{Base.#tanh,TrackedArray{…,CuArray{Float32,2}},TrackedArray{…,CuArray{Float32,1}}}}, ::Tuple{CuArray{Float32,1},CuArray{Float32,1}}, ::Tuple{CuArray{Float32,1},Int64}, ::TrackedArray{…,CuArray{Float32,1}}, ::TrackedArray{…,CuArray{Float32,1}}) at /home/schmrlng/.julia/v0.6/Flux/src/cuda/cudnn.jl:347
   [5] back_(::Flux.Tracker.Call{Flux.CUDA.RNNCall{Flux.RNNCell{Base.#tanh,TrackedArray{…,CuArray{Float32,2}},TrackedArray{…,CuArray{Float32,1}}}},Tuple{TrackedArray{…,CuArray{Float32,1}},TrackedArray{…,CuArray{Float32,1}}}}, ::Tuple{CuArray{Float32,1},CuArray{Float32,1}}, ::Tuple{CuArray{Float32,1},Int64}) at /home/schmrlng/.julia/v0.6/Flux/src/tracker/back.jl:25
   [6] back(::Flux.Tracker.Tracked{Tuple{CuArray{Float32,1},CuArray{Float32,1}}}, ::Tuple{CuArray{Float32,1},Int64}) at /home/schmrlng/.julia/v0.6/Flux/src/tracker/back.jl:38
   [7] back_(::Flux.Tracker.Call{Base.#getindex,Tuple{Flux.Tracker.TrackedTuple{Tuple{CuArray{Float32,1},CuArray{Float32,1}}},Int64}}, ::CuArray{Float32,1}, ::CuArray{Float32,1}) at /home/schmrlng/.julia/v0.6/Flux/src/tracker/back.jl:25
   [8] back(::Flux.Tracker.Tracked{CuArray{Float32,1}}, ::CuArray{Float32,1}) at /home/schmrlng/.julia/v0.6/Flux/src/tracker/back.jl:38
   [9] back!(::TrackedArray{…,CuArray{Float32,1}}, ::CuArray{Float32,1}) at /home/schmrlng/.julia/v0.6/Flux/src/tracker/back.jl:63
   [10] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:25 [inlined]
   [11] macro expansion at ./test.jl:921 [inlined]
   [12] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:9 [inlined]
   [13] macro expansion at ./test.jl:921 [inlined]
   [14] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:6 [inlined]
   [15] macro expansion at ./test.jl:860 [inlined]
   [16] anonymous at ./<missing>:?
   [17] include_from_node1(::String) at ./loading.jl:576
   [18] include(::String) at ./sysimg.jl:14
   [19] include_from_node1(::String) at ./loading.jl:576
   [20] include(::String) at ./sysimg.jl:14
   [21] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/runtests.jl:15 [inlined]
   [22] macro expansion at ./test.jl:860 [inlined]
   [23] anonymous at ./<missing>:?
   [24] include_from_node1(::String) at ./loading.jl:576
   [25] include(::String) at ./sysimg.jl:14
   [26] process_options(::Base.JLOptions) at ./client.jl:305
   [27] _start() at ./client.jl:371
batch_size = 5: Test Failed
  Expression: rnn.cell.Wi.grad ≈ collect(curnn.cell.Wi.grad)
   Evaluated: [1.11268 0.908805 0.839832 1.02063 0.646228 1.21794 0.806236 0.861856 1.5464 1.13748; 0.938296 0.583229 0.55745 0.744329 0.463448 0.539153 0.376028 0.432123 0.909413 0.63029; 0.410614 0.601706 0.768691 0.605851 0.846949 -0.408809 0.172359 -0.276189 0.222307 -0.0706195; -0.377316 0.763428 0.942598 0.523233 1.0924 -0.27467 0.626277 -0.0776822 0.0116693 -0.107297; -0.00497259 0.0381735 -0.0218943 -0.00451346 -0.0457009 0.148085 -0.0905509 -0.0782189 0.0640281 -0.110064] ≈ Float32[0.513224 0.289267 0.197459 0.35043 0.0266432 0.959027 0.456809 0.672467 0.92216 0.80736; 0.203464 -0.176218 -0.229989 -0.0772243 -0.296056 0.221772 -0.0523083 0.199965 0.144199 0.225613; -0.37728 -0.212581 -0.0756086 -0.275027 0.0326007 -0.749108 -0.286908 -0.525111 -0.598164 -0.504518; -0.118878 1.03052 1.21954 0.81217 1.35952 -0.163048 0.776921 0.00396681 0.280793 0.0350262; -0.148828 -0.110501 -0.176049 -0.165346 -0.194387 0.0859528 -0.174405 -0.123668 -0.0857756 -0.189286]
Stacktrace:
 [1] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:28 [inlined]
 [2] macro expansion at ./test.jl:921 [inlined]
 [3] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:9 [inlined]
 [4] macro expansion at ./test.jl:921 [inlined]
 [5] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:6 [inlined]
 [6] macro expansion at ./test.jl:860 [inlined]
 [7] anonymous at ./<missing>:?
batch_size = 5: Test Failed
  Expression: rnn.cell.Wh.grad ≈ collect(curnn.cell.Wh.grad)
   Evaluated: [1.87783 -1.04984 1.02614 2.37401 1.1168; 0.0610257 -0.0770081 0.0758498 0.262042 0.106696; 0.820723 0.522702 -0.302216 0.604485 1.02928; 0.651526 0.628314 -0.466589 -0.0398684 0.674971; -0.763558 0.277113 -0.244825 -0.700887 -0.522323] ≈ Float32[1.23553 -1.3184 1.15435 1.82693 0.479566; -0.284539 -0.218738 0.144954 -0.0339744 -0.241954; -0.127288 0.12567 -0.113016 -0.20258 0.0901095; 0.685266 0.640903 -0.473394 -0.010203 0.711644; -0.83418 0.248105 -0.230704 -0.761357 -0.593487]
Stacktrace:
 [1] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:29 [inlined]
 [2] macro expansion at ./test.jl:921 [inlined]
 [3] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:9 [inlined]
 [4] macro expansion at ./test.jl:921 [inlined]
 [5] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:6 [inlined]
 [6] macro expansion at ./test.jl:860 [inlined]
 [7] anonymous at ./<missing>:?
batch_size = 5: Test Failed
  Expression: rnn.cell.b.grad ≈ collect(curnn.cell.b.grad)
   Evaluated: [1.85425, 0.901202, 0.161501, 0.762212, -0.0856587] ≈ Float32[1.15583, 0.0450521, -0.756472, 1.06332, -0.253264]
Stacktrace:
 [1] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:30 [inlined]
 [2] macro expansion at ./test.jl:921 [inlined]
 [3] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:9 [inlined]
 [4] macro expansion at ./test.jl:921 [inlined]
 [5] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:6 [inlined]
 [6] macro expansion at ./test.jl:860 [inlined]
 [7] anonymous at ./<missing>:?
batch_size = 5: Test Failed
  Expression: rnn.cell.h.grad ≈ collect(curnn.cell.h.grad)
   Evaluated: [-0.14314, -0.0374097, 0.429735, -0.748191, 0.537475] ≈ Float32[0.225151, -0.0593131, 0.490344, -0.492261, 0.471671]
Stacktrace:
 [1] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:31 [inlined]
 [2] macro expansion at ./test.jl:921 [inlined]
 [3] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:9 [inlined]
 [4] macro expansion at ./test.jl:921 [inlined]
 [5] macro expansion at /home/schmrlng/.julia/v0.6/Flux/test/cuda/cudnn.jl:6 [inlined]
 [6] macro expansion at ./test.jl:860 [inlined]
 [7] anonymous at ./<missing>:?
Test Summary:        | Pass  Fail  Error  Total
Flux                 |  155     4      1    160
  Throttle           |   11                  11
  Jacobian           |    1                   1
  Initialization     |   14                  14
  Params             |    2                   2
  Tracker            |   42                  42
  Dropout            |    8                   8
  BatchNorm          |   10                  10
  losses             |   11                  11
  Optimise           |    8                   8
  Training Loop      |    1                   1
  CuArrays           |    4                   4
  RNN                |   40     4      1     45
    R = Flux.RNN     |    6     4      1     11
      batch_size = 1 |    2            1      3
      batch_size = 5 |    4     4             8
    R = Flux.GRU     |   16                  16
    R = Flux.LSTM    |   18                  18
ERROR: LoadError: Some tests did not pass: 155 passed, 4 failed, 1 errored, 0 broken.
while loading /home/schmrlng/.julia/v0.6/Flux/test/runtests.jl, in expression starting on line 5
=======================================================[ ERROR: Flux ]========================================================

failed process: Process(`/home/schmrlng/code/oss/julia-0.6/usr/bin/julia -Cnative -J/home/schmrlng/code/oss/julia-0.6/usr/lib/julia/sys.so --compile=yes --depwarn=yes --check-bounds=yes --code-coverage=none --color=yes --compilecache=yes /home/schmrlng/.julia/v0.6/Flux/test/runtests.jl`, ProcessExited(1)) [1]

==============================================================================================================================
ERROR: Flux had test errors
```