### PR TITLE
slight generalization of cat

### DIFF
--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -105,6 +105,21 @@ function back(::typeof(vcat), Δ, xs...)
   end
 end
 
+Base.cat(catdim::Int,a::T, b::T)  where {T<: TrackedArray} = track(cat,catdim, a, b)
+Base.cat(catdim::Int,a::T, b::T...)  where {T<: TrackedArray} = track(cat,catdim, a, b...)
+Base.cat(catdim::Int,a::T, b::S) where {T<: TrackedArray,S<:AbstractArray} = track(cat,catdim, a, b)
+Base.cat(catdim::Int,a::S, b::T) where {T<: TrackedArray,S<:AbstractArray} = track(cat,catdim, a, b)
+
+function back(::typeof(cat), Δ, catdim, xs...)
+  i = Array{Any}(fill(:,ndims(Δ)))
+  start = 0
+  for xsi in xs
+    i[catdim] = start+1:start+size(xsi,catdim)
+    @back(xsi, Δ[i...])
+    start += size(xsi, catdim)
+  end
+end
+
 Base.reshape(xs::TrackedArray, dims::Union{Colon,Int64}...) =
   track(reshape, xs, dims...)
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -31,6 +31,13 @@ gradtest(f, dims...) = gradtest(f, rand.(dims)...)
 @test gradtest(vcat, rand(5), rand(3), rand(8))
 @test gradtest(vcat, rand(5,2), rand(3,2), rand(8,2))
 
+@test gradtest((i...) -> cat(1,i...), rand(5), rand(3))
+@test gradtest((i...) -> cat(1,i...), rand(5), rand(8))
+@test gradtest((i...) -> cat(1,i...), rand(5,2),rand(3,2), rand(8,2))
+@test gradtest((i...) -> cat(2,i...), rand(5,1), rand(5,1))
+@test gradtest((i...) -> cat(2,i...), rand(5,1), rand(5,4))
+@test gradtest((i...) -> cat(2,i...), rand(5,2),rand(5,4), rand(5,8))
+
 @test gradtest(kron,rand(5), rand(3))
 @test gradtest(kron, rand(5), rand(3), rand(8))
 @test gradtest(kron,rand(5,1), rand(3,1))


### PR DESCRIPTION
I have generalized cat to allow multiple dimensions, since at the moment it cannot handle 4-dim arrays in convolutional functions. 

At the moment, the backward path breaks with
`cat(2,rand(4),rand(4))`

Appropriate tests are added.
