### PR TITLE
Use `cache.julialang.org` to store CMU phones

### DIFF
--- a/src/data/cmudict.jl
+++ b/src/data/cmudict.jl
@@ -10,7 +10,7 @@ function load()
   isdir(deps("cmudict")) && return
   mkpath(deps("cmudict"))
   for x in ["", ".phones", ".symbols"]
-    download("http://svn.code.sf.net/p/cmusphinx/code/trunk/cmudict/cmudict-$version$x",
+    download("https://cache.julialang.org/http://svn.code.sf.net/p/cmusphinx/code/trunk/cmudict/cmudict-$version$x",
              deps("cmudict", "cmudict$x"))
   end
 end

--- a/src/data/cmudict.jl
+++ b/src/data/cmudict.jl
@@ -5,13 +5,18 @@ export cmudict
 using ..Data: deps
 
 const version = "0.7b"
+const cache_prefix = "https://cache.julialang.org"
 
 function load()
-  isdir(deps("cmudict")) && return
+  suffixes = ["", ".phones", ".symbols"]
+  if isdir(deps("cmudict"))
+    if all(isfile.(["cmudict$x" for x in suffixes]))
+      return
+    end
+  end
   mkpath(deps("cmudict"))
-  for x in ["", ".phones", ".symbols"]
-    download("https://cache.julialang.org/http://svn.code.sf.net/p/cmusphinx/code/trunk/cmudict/cmudict-$version$x",
-             deps("cmudict", "cmudict$x"))
+  for x in suffixes
+    download("$cache_prefix/http://svn.code.sf.net/p/cmusphinx/code/trunk/cmudict/cmudict-$version$x", deps("cmudict", "cmudict$x"))
   end
 end
 

--- a/src/data/mnist.jl
+++ b/src/data/mnist.jl
@@ -14,7 +14,7 @@ function load()
                  "t10k-images-idx3-ubyte",
                  "t10k-labels-idx1-ubyte"]
       isfile(file) && continue
-      download("http://yann.lecun.com/exdb/mnist/$file.gz", "$file.gz")
+      download("https://cache.julialang.org/http://yann.lecun.com/exdb/mnist/$file.gz", "$file.gz")
       open(file, "w") do io
         write(io, GZip.open(read, "$file.gz"))
       end

--- a/src/data/sentiment.jl
+++ b/src/data/sentiment.jl
@@ -5,7 +5,7 @@ using ..Data: deps
 
 function load()
   isfile(deps("sentiment.zip")) ||
-    download("https://nlp.stanford.edu/sentiment/trainDevTestTrees_PTB.zip",
+    download("https://cache.julialang.org/https://nlp.stanford.edu/sentiment/trainDevTestTrees_PTB.zip",
              deps("sentiment.zip"))
   return
 end


### PR DESCRIPTION
It's annoying that when third party servers go down our tests break. Let's at least make sure that if our tests break due to server outages it's our fault.