### PR TITLE
WIP - Maxout for dense layer.

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -1,4 +1,3 @@
-using Flux:vcat, maximum
 """
     Chain(layers...)
 
@@ -44,11 +43,11 @@ end
 
 Creates a traditional `Dense` layer with parameters `W` and `b`.
 
-
     y = σ.(W * x .+ b)
 
 The input `x` must be a vector of length `in`, or a batch of vectors represented
 as an `in × N` matrix. The out `y` will be a vector or batch of length `out`.
+Optional parameter `maxout` denotes number of maxout units to pass through.
 
 ```julia
 julia> d = Dense(5, 2)
@@ -91,6 +90,7 @@ end
 function Base.show(io::IO, l::Dense)
   print(io, "Dense(", size(l.W, 2), ", ", size(l.W, 1))
   l.σ == identity || print(io, ", ", l.σ)
+  l.m == 1 || print(", maxout = ",l.m)
   print(io, ")")
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,6 +4,7 @@ initn(dims...) = randn(dims...)/100
 glorot_uniform(dims...) = (rand(dims...) - 0.5)*sqrt(24.0/(sum(dims)))
 glorot_normal(dims...) = (randn(dims...)*sqrt(2.0/sum(dims)))
 
+
 unsqueeze(xs, dim) = reshape(xs, (size(xs)[1:dim-1]..., 1, size(xs)[dim:end]...))
 
 stack(xs, dim) = cat(dim, unsqueeze.(xs, dim)...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,7 +4,6 @@ initn(dims...) = randn(dims...)/100
 glorot_uniform(dims...) = (rand(dims...) - 0.5)*sqrt(24.0/(sum(dims)))
 glorot_normal(dims...) = (randn(dims...)*sqrt(2.0/sum(dims)))
 
-
 unsqueeze(xs, dim) = reshape(xs, (size(xs)[1:dim-1]..., 1, size(xs)[dim:end]...))
 
 stack(xs, dim) = cat(dim, unsqueeze.(xs, dim)...)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -82,7 +82,7 @@ end
 
 @testset "Params" begin
   m = Dense(10, 5)
-  @test size.(params(m)) == [(5, 10), (5,)]
+  @test size.(params(m)) == [(5, 10, 1), (5, 1)]
   m = RNN(10, 5)
   @test size.(params(m)) == [(5, 10), (5, 5), (5,), (5,)]
 end


### PR DESCRIPTION
Implementation of `maxout` for `Dense` layer. ([Link to paper](https://arxiv.org/pdf/1302.4389.pdf)).

This implementation of maxout is specific to a particular layer. I've worked with `Dense` here. The architecture involves keeping `n` sets of weights and biases and obtaining `n` variants of the output. The maximum across the second axis is taken forward. For instance, a `Dense(5, 4, maxout = 3)` looks like:
![Maxout](https://i.imgur.com/AdpuYuU.png)
(biases have been ignored in the image for simplicity).

If this looks good, I can proceed to add support for batching and integrate `maxout` with other types of layers as well. This implementation might look slow. I guess it could be improved by adding support for `back!` for the `maximum` function.

An alternate implementation of `maxout` may be found at https://github.com/FluxML/NNlib.jl/pull/33.

