### PR TITLE
add batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 docs/build/
 docs/site/
 docs/flux.css
+.vscode/
 deps

--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -29,31 +29,27 @@ loss(x, y) = Flux.mse(m(x), y)
 Flux.train!(loss, data, opt)
 ```
 
-The objective will almost always be defined in terms of some *cost function* that measures the distance of the prediction `m(x)` from the target `y`. Flux has several of these built in, like `mse` for mean squared error or `crossentropy` for cross entropy loss, but you can calculate it however you want.
+In supervised tasks, the objective is tipically defined in terms of some *cost function* that measures the distance of the prediction `m(x)` from the target `y`. Flux has several of these built in, like `mse` for mean squared error or `crossentropy` for cross entropy loss, but you can calculate it however you want. In general scenarios, the loss function can take any number of inputs.
 
-## Datasets
+## Data
 
-The `data` argument provides a collection of data to train with (usually a set of inputs `x` and target outputs `y`). For example, here's a dummy data set with only one data point:
-
-```julia
-x = rand(784)
-y = rand(10)
-data = [(x, y)]
-```
-
-`Flux.train!` will call `loss(x, y)`, calculate gradients, update the weights and then move on to the next data point if there is one. We can train the model on the same data three times:
+The data argument `train!` provides a collection of data to train with (usually a set of inputs `x` and target outputs `y`). 
+For large datasets it is often convenient to arrange the data in small `batches`.
+For example, here's a synthetic data set with 10 data points partitioned in minibatches of size 1:
 
 ```julia
-data = [(x, y), (x, y), (x, y)]
-# Or equivalently
-data = Iterators.repeated((x, y), 3)
+X = rand(784, 10)
+Y = rand(10)
+data = batches(X, Y, batchsize=1)
 ```
+
+For each `(x, y)` in `data`, `Flux.train!` will call `loss(x, y)`, calculate gradients, update the weights and then move on to the next data point if there is one.
 
 It's common to load the `x`s and `y`s separately. In this case you can use `zip`:
 
 ```julia
 xs = [rand(784), rand(784), rand(784)]
-ys = [rand( 10), rand( 10), rand( 10)]
+ys = [2, 3, 1]
 data = zip(xs, ys)
 ```
 

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -25,6 +25,8 @@ using .Optimise
 using .Optimise: @epochs
 
 include("utils.jl")
+export batches, mat
+
 include("onehot.jl")
 include("treelike.jl")
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,6 +94,48 @@ function batchseq(xs, pad = nothing, n = maximum(length(x) for x in xs))
   [batch([xs_[j][i] for j = 1:length(xs_)]) for i = 1:n]
 end
 
+
+"""
+  batches(X, Y...; batchsize=1, shuffle=false)
+
+Returns an iterators partitioning the inputs
+along the last dimension in subsets of size `batchsize`.
+
+***Example Usage***
+```julia
+for (x, y) in batches(X, Y, batchsize=100, shuffle=true)
+  ...
+end
+"""
+function batches(x::AbstractArray, y::AbstractArray...; batchsize=1, shuffle=false)
+  m = size(x, ndims(x))
+  @assert all(y-> size(y, ndims(y)) == m , y)
+  all_indx = shuffle ? randperm(m) : [1:m;]  
+  part = [all_indx[i:min(end,i+batchsize-1)] for i=1:batchsize:m]
+
+  if length(y) > 0 
+    ((getbatch(x,is), [getbatch(y,is) for y in y]...) for is in part)
+  else
+    (getbatch(x,is) for is in part)
+  end
+end
+
+"""
+  mat(x::AbstractArray)
+
+Reshapes `x` into a matrix (i.e. a bi-dimensional array)
+preserving the size of the last dimension.
+"""
+mat(x::AbstractArray) = reshape(x, :, size(x, ndims(x)))
+
+function getbatch(x::AbstractArray, is)
+  sz = size(x)
+  x = mat(x)
+  b = x[:,is]
+  reshape(b, sz[1:end-1]..., :)
+end
+
+
 # Other
 
 """

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -86,3 +86,39 @@ end
   m = RNN(10, 5)
   @test size.(params(m)) == [(5, 10), (5, 5), (5,), (5,)]
 end
+
+@testset "batches" begin
+  x = rand(10)
+  b = batches(x) |> collect
+  @test length(b) == 10
+  @test all(i -> b[i] == x[i:i],1:10)
+
+  b = batches(x, batchsize=3) |> collect
+  @test length(b) == 4
+  @test b[1] == x[1:3]
+  @test b[2] == x[4:6]
+  @test b[3] == x[7:9]
+  @test b[4] == x[10:10]
+
+  y = rand(8)
+  @test_throws AssertionError batches(x, y)
+
+  x = reshape(x, 2, 5)
+  y = rand(5)
+  b = batches(x,y, batchsize=2) |> collect
+  @test length(b) == 3
+  @test b[1] == (x[:,1:2], y[1:2])
+  @test b[2] == (x[:,3:4], y[3:4])
+  @test b[3] == (x[:,5:5], y[5:5])
+end
+
+@testset "mat" begin
+  x = rand(2)
+  @test mat(x) == reshape(x, 1, 2)
+  x = rand(2,2)
+  @test mat(x) == x
+  x = rand(2,2,2)
+  @test mat(x) == reshape(x,4,2)
+  x = rand(2,2,2,2)
+  @test mat(x) == reshape(x,8,2)
+end


### PR DESCRIPTION
I think a basic data partitioning tool should be part of Flux, being batch partitioning such a common task.

Also here I add the `mat(x)` method, reshaping an array into a matrix, which is something you typically want to do before feeding the output of tensor input (e.g. the output of a convolutional layer) to a fully connected layer