### PR TITLE
Add stopping conditions

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -11,6 +11,7 @@ export Chain, Dense, RNN, LSTM, GRU, Conv, Conv2D,
   Dropout, LayerNorm, BatchNorm,
   SGD, ADAM, Momentum, Nesterov, AMSGrad,
   param, params, mapleaves, cpu, gpu
+  
 
 @reexport using NNlib
 using NNlib: @fix

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -45,6 +45,84 @@ function train!(loss, data, opt; cb = () -> ())
   end
 end
 
+
+############
+# Stopping criteria
+
+"""
+    stopif(cbs...)
+
+Given one callback, returns a callback that
+returns`:stop` if that callback returns `true` or `:stop`.
+i.e. converts a boolean callback, into a stopping condition.
+If multiple callbacks are passed, this does the logical union of them
+"""
+stopif(cbs...) = () -> any(cb() ∈ (true,:stop) for cb in cbs) && :stop
+
+"""
+    atol(f, minval=0.0)
+
+For `f` a function (e.g. a loss function, an accurasy function) taking zero arguments.
+`atol` returns a callback, that returns `:stop` if `f` returns `minval` or less.
+"""
+atol(f, minval=0.0) = () -> f()<=minval && :stop
+
+"""
+    rtol(f, mindecrease=0.0)
+
+For `f` a function (e.g. a loss function, an accurasy function etc) taking zero arguments.
+`atol` returns a callback, that returns `:stop`
+if between successive calls to the callback `f()` has not decreased by at least `mindecrease`
+"""
+function rtol(f, mindecrease=0.0)
+    prev_score = f() # Initial score at declaration time
+    function ()
+        score = f()
+        should_stop = prev_score - score < mindecrease
+        prev_score = score
+        should_stop && :stop
+    end
+end
+
+"""
+    max_calls(ncalls)
+Returns a callback that returns :stop after it has been called `ncalls` times.
+"""
+function max_calls(ncalls)
+    calls_so_far = 0
+    function()
+        calls_so_far += 1
+        calls_so_far >= ncalls && :stop
+    end
+end
+
+
+"""
+    timeout(duration)
+Returns a callback that returns :stop after the given duration after it was first called.
+"""
+function timeout(duration::Dates.TimePeriod)
+    timer_started = false
+    local start_time
+    function()
+        if !timer_started
+            timer_started = true
+            start_time = now()
+            return false
+        else
+            start_time - now() > duration && :stop
+        end
+    end
+end
+
+timeout(seconds) = timeout(Dates.Second(seconds))
+
+
+#
+#########################
+
+
+
 """
     @epochs N body
 

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -1,5 +1,5 @@
 using Juno
-using Flux.Tracker: back!
+using Flux.Tracker: back!, data
 
 runall(f) = f
 runall(fs::AbstractVector) = () -> foreach(call, fs)
@@ -65,7 +65,7 @@ stopif(cbs...) = () -> any(cb() ∈ (true,:stop) for cb in cbs) && :stop
 For `f` a function (e.g. a loss function, an accurasy function) taking zero arguments.
 `atol` returns a callback, that returns `:stop` if `f` returns `minval` or less.
 """
-atol(f, minval=0.0) = () -> f()<=minval && :stop
+atol(f, minval=0.0) = () -> data(f())<=minval && :stop
 
 """
     rtol(f, mindecrease=0.0)
@@ -77,7 +77,7 @@ if between successive calls to the callback `f()` has not decreased by at least 
 function rtol(f, mindecrease=0.0)
     prev_score = f() # Initial score at declaration time
     function ()
-        score = f()
+        score = data(f())
         should_stop = prev_score - score < mindecrease
         prev_score = score
         should_stop && :stop

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -97,6 +97,25 @@ end
 # Other
 
 """
+    iter_throttle(f, period; default_return=false)
+Returns a function wraps `f` such that it will
+only run `f` every `period` times that it is called.
+In rounds which it does not run, returns `default_return`
+"""
+function iter_throttle(f, period; default_return=false)
+    round = 0
+    function(args...)
+        if round==period
+            round=0
+            f(args...)
+        else
+            round+=1
+            default_return
+        end
+    end
+end
+
+"""
 Returns a function that when invoked, will only be triggered at most once
 during `timeout` seconds. Normally, the throttled function will run
 as much as it can, without ever going more than once per `wait` duration;


### PR DESCRIPTION
Fix #227 

these are all type unstable, because they either return `false` or `:stop`
I guess I could make them all return `:donotstop` or `:stop`.

