### PR TITLE
Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ os:
   - linux
   # - osx
 julia:
-  - 0.6
+  - 0.7
 # uncomment the following lines to override the default test script
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("Flux"); Pkg.test("Flux"; coverage=true)'
+# script:
+#   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#   - julia -e 'Pkg.clone(pwd()); Pkg.build("Flux"); Pkg.test("Flux"; coverage=true)'
 after_success:
   - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("Flux")); include(joinpath("docs", "make.jl"))'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6.0
+julia 0.7-
 Juno
 MacroTools 0.3.3
 NNlib

--- a/docs/src/internals/tracker.md
+++ b/docs/src/internals/tracker.md
@@ -134,7 +134,7 @@ All `Tracked*` objects (`TrackedArray`, `TrackedReal`) are light wrappers around
 
 ```julia
 julia> x.tracker
-Flux.Tracker.Tracked{Array{Float64,1}}(0x00000000, Flux.Tracker.Call{Void,Tuple{}}(nothing, ()), true, [5.0, 6.0], [-2.0, -2.0])
+Flux.Tracker.Tracked{Array{Float64,1}}(0x00000000, Flux.Tracker.Call{Nothing,Tuple{}}(nothing, ()), true, [5.0, 6.0], [-2.0, -2.0])
 ```
 
 The `Tracker` stores the gradient of a given object, which we've seen before.

--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -211,7 +211,7 @@ m(5) # => 26
 Flux provides a set of helpers for custom layers, which you can enable by calling
 
 ```julia
-Flux.treelike(Affine)
+Flux.@treelike Affine
 ```
 
 This enables a useful extra set of functionality for our `Affine` layer, such as [collecting its parameters](../training/optimisers.md) or [moving it to the GPU](../gpu.md).

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -4,7 +4,7 @@ module Flux
 
 # Zero Flux Given
 
-using Juno, Requires, Reexport, StatsBase
+using MacroTools, Juno, Requires, Reexport, StatsBase
 using MacroTools: @forward
 
 export Chain, Dense, RNN, LSTM, GRU, Conv,

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -4,7 +4,7 @@ module Flux
 
 # Zero Flux Given
 
-using Juno, Requires, Reexport
+using Juno, Requires, Reexport, StatsBase
 using MacroTools: @forward
 
 export Chain, Dense, RNN, LSTM, GRU, Conv,

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -4,7 +4,7 @@ module Flux
 
 # Zero Flux Given
 
-using MacroTools, Juno, Requires, Reexport, StatsBase
+using MacroTools, Juno, Requires, Reexport, Statistics, Random
 using MacroTools: @forward
 
 export Chain, Dense, RNN, LSTM, GRU, Conv,

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -37,6 +37,6 @@ include("layers/normalise.jl")
 
 include("data/Data.jl")
 
-@require CuArrays include("cuda/cuda.jl")
+@init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" include("cuda/cuda.jl")
 
 end # module

--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -2,23 +2,23 @@ using CuArrays.CUDNN: @check, libcudnn, cudnnStatus_t, libcudnn_handle,
   cudnnDataType, TensorDesc, FilterDesc
 
 mutable struct DropoutDesc
-  ptr::Ptr{Void}
+  ptr::Ptr{Nothing}
   states::CuVector{UInt8}
 end
 
-Base.unsafe_convert(::Type{Ptr{Void}}, dd::DropoutDesc) = dd.ptr
+Base.unsafe_convert(::Type{Ptr{Nothing}}, dd::DropoutDesc) = dd.ptr
 
 function DropoutDesc(ρ::Real; seed::Integer=0)
   d = [C_NULL]
   s = Csize_t[0]
-  @check ccall((:cudnnCreateDropoutDescriptor,libcudnn), cudnnStatus_t, (Ptr{Ptr{Void}},), d)
-  @check ccall((:cudnnDropoutGetStatesSize,libcudnn),cudnnStatus_t,(Ptr{Void},Ptr{Csize_t}),libcudnn_handle[],s)
+  @check ccall((:cudnnCreateDropoutDescriptor,libcudnn), cudnnStatus_t, (Ptr{Ptr{Nothing}},), d)
+  @check ccall((:cudnnDropoutGetStatesSize,libcudnn),cudnnStatus_t,(Ptr{Nothing},Ptr{Csize_t}),libcudnn_handle[],s)
   states = CuArray{UInt8}(s[]) # TODO: can we drop this when ρ=0?
   desc = DropoutDesc(d[], states)
-  @check ccall((:cudnnSetDropoutDescriptor,libcudnn),cudnnStatus_t,(Ptr{Void},Ptr{Void},Cfloat,Ptr{Void},Csize_t,Culonglong),
+  @check ccall((:cudnnSetDropoutDescriptor,libcudnn),cudnnStatus_t,(Ptr{Nothing},Ptr{Nothing},Cfloat,Ptr{Nothing},Csize_t,Culonglong),
     desc,libcudnn_handle[],ρ,states,length(states),seed)
   finalizer(desc, x ->
-    @check ccall((:cudnnDestroyDropoutDescriptor,libcudnn),cudnnStatus_t,(Ptr{Void},),x))
+    @check ccall((:cudnnDestroyDropoutDescriptor,libcudnn),cudnnStatus_t,(Ptr{Nothing},),x))
   return desc
 end
 
@@ -57,14 +57,14 @@ mutable struct RNNDesc{T}
   params::CuVector{T}
   weights::NTuple{2,CuMatrix{T}}
   bias::CuVector{T}
-  ptr::Ptr{Void}
+  ptr::Ptr{Nothing}
 end
 
-Base.unsafe_convert(::Type{Ptr{Void}}, d::RNNDesc) = d.ptr
+Base.unsafe_convert(::Type{Ptr{Nothing}}, d::RNNDesc) = d.ptr
 
 function rnnParamSize(T, r, input)
   size = Csize_t[0]
-  @check ccall((:cudnnGetRNNParamsSize, libcudnn), cudnnStatus_t, (Ptr{Void},Ptr{Void},Ptr{Void},Ptr{Csize_t},Cint),
+  @check ccall((:cudnnGetRNNParamsSize, libcudnn), cudnnStatus_t, (Ptr{Nothing},Ptr{Nothing},Ptr{Nothing},Ptr{Csize_t},Cint),
     libcudnn_handle[], r, TensorDesc(T, (1,input,1)), size, cudnnDataType(T))
   return Int(size[])÷sizeof(T)
 end
@@ -74,26 +74,26 @@ ngates(r::RNNDesc) = ngates(r.mode)
 
 function RNNDesc{T}(mode::Int, input::Int, hidden::Int; layers = 1) where T
   d = [C_NULL]
-  @check ccall((:cudnnCreateRNNDescriptor,libcudnn),cudnnStatus_t,(Ptr{Ptr{Void}},),d)
+  @check ccall((:cudnnCreateRNNDescriptor,libcudnn),cudnnStatus_t,(Ptr{Ptr{Nothing}},),d)
 
   dropoutDesc = DropoutDesc(0)
   inputMode = LINEAR_INPUT
   direction = UNIDIRECTIONAL
   algo = RNN_ALGO_STANDARD
-  @check ccall((:cudnnSetRNNDescriptor_v6,libcudnn), cudnnStatus_t, (Ptr{Void},Ptr{Void},Cint,Cint,Ptr{Void},Cint,Cint,Cint,Cint,Cint),
+  @check ccall((:cudnnSetRNNDescriptor_v6,libcudnn), cudnnStatus_t, (Ptr{Nothing},Ptr{Nothing},Cint,Cint,Ptr{Nothing},Cint,Cint,Cint,Cint,Cint),
     libcudnn_handle[],d[],hidden,layers,dropoutDesc,inputMode,direction,mode,algo,cudnnDataType(T))
 
   w = cuzeros(T, rnnParamSize(T, d[], input))
   # TODO: avoid reserve allocation here
   rd = RNNDesc{T}(mode, input, hidden, w, params(w, input, hidden, ngates(mode))..., d[])
   finalizer(rd, x ->
-    @check ccall((:cudnnDestroyRNNDescriptor,libcudnn),cudnnStatus_t,(Ptr{Void},),x))
+    @check ccall((:cudnnDestroyRNNDescriptor,libcudnn),cudnnStatus_t,(Ptr{Nothing},),x))
   return rd
 end
 
 function rnnWorkspaceSize(r::RNNDesc, seqlen, xdesc)
   size = Csize_t[0]
-  @check ccall((:cudnnGetRNNWorkspaceSize, libcudnn), cudnnStatus_t, (Ptr{Void},Ptr{Void},Cint,Ptr{Ptr{Void}},Ptr{Csize_t}),
+  @check ccall((:cudnnGetRNNWorkspaceSize, libcudnn), cudnnStatus_t, (Ptr{Nothing},Ptr{Nothing},Cint,Ptr{Ptr{Nothing}},Ptr{Csize_t}),
     libcudnn_handle[], r, seqlen, xdesc, size)
   return Int(size[])
 end
@@ -110,7 +110,7 @@ getworkspace(r::RNNDesc, seqlen, xdesc) =
 
 function rnnTrainingReserveSize(r::RNNDesc, seqlen, xdesc)
   size = Csize_t[0]
-  @check ccall((:cudnnGetRNNTrainingReserveSize,libcudnn), cudnnStatus_t, (Ptr{Void}, Ptr{Void}, Cint, Ptr{Ptr{Void}}, Ptr{Csize_t}),
+  @check ccall((:cudnnGetRNNTrainingReserveSize,libcudnn), cudnnStatus_t, (Ptr{Nothing}, Ptr{Nothing}, Cint, Ptr{Ptr{Nothing}}, Ptr{Csize_t}),
     libcudnn_handle[], r, seqlen, xdesc, size)
   return Int(size[])
 end
@@ -119,19 +119,19 @@ function cudnnRNNForward(rnn::RNNDesc{T}, seqlen, xd, x, hd, h, cd, c, wd, w, yd
                          workspace, reserve=nothing) where T
   if reserve == nothing
     @check ccall((:cudnnRNNForwardInference, libcudnn), cudnnStatus_t,
-                 (Ptr{Void}, Ptr{Void}, Cint,
-                  Ptr{Ptr{Void}}, Ptr{T}, Ptr{Void}, Ptr{T}, Ptr{Void}, Ptr{T},
-                  Ptr{Void}, Ptr{T}, Ptr{Ptr{Void}}, Ptr{T}, Ptr{Void}, Ptr{T},
-                  Ptr{Void}, Ptr{T},
-                  Ptr{Void}, Csize_t),
+                 (Ptr{Nothing}, Ptr{Nothing}, Cint,
+                  Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T},
+                  Ptr{Nothing}, Ptr{T}, Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T},
+                  Ptr{Nothing}, Ptr{T},
+                  Ptr{Nothing}, Csize_t),
                  libcudnn_handle[], rnn, seqlen,
                  xd, x, hd, h, cd, c, wd, w, yd, y, hod, ho, cod, co,
                  workspace, length(workspace))
   else
     @check ccall((:cudnnRNNForwardTraining, libcudnn), cudnnStatus_t,
-                 (Ptr{Void}, Ptr{Void}, Cint,
-                  Ptr{Ptr{Void}}, Ptr{T}, Ptr{Void}, Ptr{T}, Ptr{Void}, Ptr{T}, Ptr{Void}, Ptr{T}, Ptr{Ptr{Void}}, Ptr{T}, Ptr{Void}, Ptr{T}, Ptr{Void}, Ptr{T},
-                  Ptr{Void}, Csize_t, Ptr{Void}, Csize_t),
+                 (Ptr{Nothing}, Ptr{Nothing}, Cint,
+                  Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T},
+                  Ptr{Nothing}, Csize_t, Ptr{Nothing}, Csize_t),
                  libcudnn_handle[], rnn, seqlen,
                  xd, x, hd, h, cd, c, wd, w, yd, y, hod, ho, cod, co,
                  workspace, length(workspace), reserve, length(reserve))
@@ -140,7 +140,7 @@ end
 
 xDesc(x) = [TensorDesc(eltype(x), (1, size(x, 1), size(x, 2)))]
 
-hDesc(h::Void) = C_NULL, C_NULL
+hDesc(h::Nothing) = C_NULL, C_NULL
 hDesc(x::Integer) = (@assert x == 0; hDesc(nothing))
 function hDesc(h::CuArray)
   TensorDesc(eltype(h), (size(h, 1), size(h, 2), 1)), h
@@ -187,11 +187,11 @@ forwardTrain(rnn::RNNDesc{T}, x::CuArray{T}, h::CuArray{T}, c = nothing) where T
 function cudnnRNNBackwardData(rnn::RNNDesc{T}, seqlen, yd, y, dyd, dy, dhod, dho, dcod, dco,
                               wd, w, hd, h, cd, c, dxd, dx, dhd, dh, dcd, dc, ws, rs) where T
   @check ccall((:cudnnRNNBackwardData,libcudnn),cudnnStatus_t,
-               (Ptr{Void}, Ptr{Void}, Cint,
-                Ptr{Ptr{Void}}, Ptr{T}, Ptr{Ptr{Void}}, Ptr{T}, Ptr{Void}, Ptr{T},
-                Ptr{Void}, Ptr{T}, Ptr{Void}, Ptr{T}, Ptr{Void}, Ptr{T}, Ptr{Void},
-                Ptr{T}, Ptr{Ptr{Void}}, Ptr{T}, Ptr{Void}, Ptr{T}, Ptr{Void}, Ptr{T},
-                Ptr{Void}, Csize_t, Ptr{Void}, Csize_t),
+               (Ptr{Nothing}, Ptr{Nothing}, Cint,
+                Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T},
+                Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing},
+                Ptr{T}, Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T},
+                Ptr{Nothing}, Csize_t, Ptr{Nothing}, Csize_t),
                libcudnn_handle[], rnn, seqlen, yd, y, dyd, dy, dhod, dho, dcod, dco,
                wd, w, hd, h, cd, c, dxd, dx, dhd, dh, dcd, dc, ws, length(ws), rs, length(rs))
 end
@@ -217,13 +217,13 @@ backwardData(rnn, y, dy, dho, hx, reserve) =
 function cudnnRNNBackwardWeights(rnn::RNNDesc{T}, seqlen, xd, x, hd, h, yd, y, dwd, dw,
                                  workspace, reserve) where T
   @check ccall((:cudnnRNNBackwardWeights,libcudnn), cudnnStatus_t,
-               (Ptr{Void}, Ptr{Void}, Cint,  # handle, rnnDesc, seqLength
-                Ptr{Ptr{Void}}, Ptr{T}, #x
-                Ptr{Void}, Ptr{T}, #hx
-                Ptr{Ptr{Void}}, Ptr{T}, #y
-                Ptr{Void}, Csize_t, #ws
-                Ptr{Void}, Ptr{T}, #dw
-                Ptr{Void}, Csize_t), #rs
+               (Ptr{Nothing}, Ptr{Nothing}, Cint,  # handle, rnnDesc, seqLength
+                Ptr{Ptr{Nothing}}, Ptr{T}, #x
+                Ptr{Nothing}, Ptr{T}, #hx
+                Ptr{Ptr{Nothing}}, Ptr{T}, #y
+                Ptr{Nothing}, Csize_t, #ws
+                Ptr{Nothing}, Ptr{T}, #dw
+                Ptr{Nothing}, Csize_t), #rs
                libcudnn_handle[], rnn, seqlen, xd, x, hd, h, yd, y,
                workspace, length(workspace), dwd, dw, reserve, length(reserve))
 end

--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -198,7 +198,7 @@ end
 
 function backwardData(rnn::RNNDesc{T}, y, dy_, dho, dco, h, c, reserve) where T
   # Same as above, any more efficient way?
-  dy = dy_ isa Integer ? zeros(y) : dy_
+  dy = dy_ isa Integer ? zero(y) : dy_
   yd = xDesc(y)
   dx = y isa AbstractVector ? similar(dy, rnn.input) : similar(dy, rnn.input, size(dy, 2))
   dh = similar(h)
@@ -229,7 +229,7 @@ function cudnnRNNBackwardWeights(rnn::RNNDesc{T}, seqlen, xd, x, hd, h, yd, y, d
 end
 
 function backwardWeights(rnn::RNNDesc{T}, x, h, y, reserve) where T
-  dw = zeros(rnn.params)
+  dw = zero(rnn.params)
   cudnnRNNBackwardWeights(rnn, 1,
     xDesc(x), x, hDesc(h)..., xDesc(y), y,
     FilterDesc(T, (1, 1, length(dw))), dw,

--- a/src/data/cmudict.jl
+++ b/src/data/cmudict.jl
@@ -24,25 +24,25 @@ end
 
 function phones()
   load()
-  Symbol.(first.(split.(split(readstring(deps("cmudict", "cmudict.phones")),
-                        "\n", keep = false), "\t")))
+  Symbol.(first.(split.(split(read(deps("cmudict", "cmudict.phones"),String),
+                        "\n", keepempty = false), "\t")))
 end
 
 function symbols()
   load()
-  Symbol.(split(readstring(deps("cmudict", "cmudict.symbols")),
-                "\n", keep = false))
+  Symbol.(split(read(deps("cmudict", "cmudict.symbols"),String),
+                "\n", keepempty = false))
 end
 
 function rawdict()
   load()
   Dict(String(xs[1]) => Symbol.(xs[2:end]) for xs in
-       filter(!isempty, split.(split(readstring(deps("cmudict", "cmudict")), "\n"))))
+       filter(!isempty, split.(split(read(deps("cmudict", "cmudict"),String), "\n"))))
 end
 
-validword(s) = isascii(s) && ismatch(r"^[\w\-\.]+$", s)
+validword(s) = isascii(s) && occursin(r"^[\w\-\.]+$", s)
 
-cmudict() = filter((s, ps) -> validword(s), rawdict())
+cmudict() = filter(p -> validword(p.first), rawdict())
 
 alphabet() = ['A':'Z'..., '0':'9'..., '_', '-', '.']
 

--- a/src/data/cmudict.jl
+++ b/src/data/cmudict.jl
@@ -40,7 +40,7 @@ function rawdict()
        filter(!isempty, split.(split(readstring(deps("cmudict", "cmudict")), "\n"))))
 end
 
-validword(s) = ismatch(r"^[\w\-\.]+$", s)
+validword(s) = isascii(s) && ismatch(r"^[\w\-\.]+$", s)
 
 cmudict() = filter((s, ps) -> validword(s), rawdict())
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -73,7 +73,7 @@ function Dense(in::Integer, out::Integer, σ = identity;
   return Dense(param(initW(out, in)), param(initb(out)), σ)
 end
 
-treelike(Dense)
+@treelike Dense
 
 function (a::Dense)(x)
   W, b, σ = a.W, a.b, a.σ
@@ -104,7 +104,7 @@ end
 Diagonal(in::Integer; initα = ones, initβ = zeros) =
   Diagonal(param(initα(in)), param(initβ(in)))
 
-treelike(Diagonal)
+@treelike Diagonal
 
 function (a::Diagonal)(x)
   α, β = a.α, a.β

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -16,7 +16,7 @@ m(x) == m[2](m[1](x))
 `Chain` also supports indexing and slicing, e.g. `m[2]` or `m[1:end-1]`.
 `m[1:3](x)` will calculate the output of the first three layers.
 """
-type Chain
+struct Chain
   layers::Vector{Any}
   Chain(xs...) = new([xs...])
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -28,7 +28,7 @@ children(c::Chain) = c.layers
 mapchildren(f, c::Chain) = Chain(f.(c.layers)...)
 adapt(T, c::Chain) = Chain(map(x -> adapt(T, x), c.layers)...)
 
-(c::Chain)(x) = foldl((x, m) -> m(x), x, c.layers)
+(c::Chain)(x) = foldl((x, m) -> m(x), c.layers; init = x)
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i]...)
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -38,9 +38,6 @@ function Base.show(io::IO, c::Chain)
   print(io, ")")
 end
 
-# Seem to need this for `accumulate`; try removing on 0.7
-Base.rcum_promote_type(op, ::Type, ::Type{Any}) = Any
-
 activations(c::Chain, x) = accumulate((x, m) -> m(x), x, c.layers)
 
 """

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -35,7 +35,7 @@ Conv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity; init = 
   Conv(param(init(k..., ch...)), param(zeros(ch[2])), σ,
        stride = stride, pad = pad, dilation = dilation)
 
-Flux.treelike(Conv)
+@treelike Conv
 
 function (c::Conv)(x)
   # TODO: breaks gpu broadcast :(

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -32,7 +32,7 @@ Conv(w::AbstractArray{T,N}, b::AbstractVector{T}, σ = identity;
 
 Conv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity; init = initn,
      stride = 1, pad = 0, dilation = 1) where N =
-  Conv(param(init(k..., ch...)), param(zeros(ch[2])), σ,
+  Conv(param(init(k..., ch...)), param(zero(ch[2])), σ,
        stride = stride, pad = pad, dilation = dilation)
 
 @treelike Conv

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -135,8 +135,8 @@ function (BN::BatchNorm)(x)
 
     # update moving mean/std
     mtm = data(convert(T, BN.momentum))
-    BN.μ = (1 - mtm) .* BN.μ .+ mtm .* squeeze(data(μ), (axes...))
-    BN.σ = (1 - mtm) .* BN.σ .+ mtm .* squeeze(data(σ), (axes...)) .* m ./ (m - 1)
+    BN.μ = (1 - mtm) .* BN.μ .+ mtm .* squeeze(data(μ), (axes...,))
+    BN.σ = (1 - mtm) .* BN.σ .+ mtm .* squeeze(data(σ), (axes...,)) .* m ./ (m - 1)
   end
 
   let λ = BN.λ

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -58,7 +58,7 @@ end
 LayerNorm(h::Integer) =
   LayerNorm(Diagonal(h))
 
-treelike(LayerNorm)
+@treelike LayerNorm
 
 (a::LayerNorm)(x) = a.diag(normalise(x))
 

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -108,7 +108,7 @@ mutable struct BatchNorm{F,V,W,N}
 end
 
 BatchNorm(chs::Integer, λ = identity;
-          initβ = zeros, initγ = ones, ϵ = 1e-8, momentum = .1) =
+          initβ = (i) -> zeros(i), initγ = (i) -> ones(i), ϵ = 1e-8, momentum = .1) =
   BatchNorm(λ, param(initβ(chs)), param(initγ(chs)),
             zeros(chs), ones(chs), ϵ, momentum, true)
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -178,7 +178,7 @@ function (m::GRUCell)(h, x)
   r = σ.(gate(gx, o, 1) .+ gate(gh, o, 1) .+ gate(b, o, 1))
   z = σ.(gate(gx, o, 2) .+ gate(gh, o, 2) .+ gate(b, o, 2))
   h̃ = tanh.(gate(gx, o, 3) .+ r .* gate(gh, o, 3) .+ gate(b, o, 3))
-  h′ = (1.-z).*h̃ .+ z.*h
+  h′ = (1 .- z).*h̃ .+ z.*h
   return h′, h′
 end
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -38,7 +38,7 @@ function (m::Recur)(xs...)
   return y
 end
 
-treelike(Recur, (:cell, :init))
+@treelike Recur cell, init
 
 Base.show(io::IO, m::Recur) = print(io, "Recur(", m.cell, ")")
 
@@ -94,7 +94,7 @@ end
 
 hidden(m::RNNCell) = m.h
 
-treelike(RNNCell)
+@treelike RNNCell
 
 function Base.show(io::IO, l::RNNCell)
   print(io, "RNNCell(", size(l.Wi, 2), ", ", size(l.Wi, 1))
@@ -143,7 +143,7 @@ end
 
 hidden(m::LSTMCell) = (m.h, m.c)
 
-treelike(LSTMCell)
+@treelike LSTMCell
 
 Base.show(io::IO, l::LSTMCell) =
   print(io, "LSTMCell(", size(l.Wi, 2), ", ", size(l.Wi, 1)÷4, ")")
@@ -184,7 +184,7 @@ end
 
 hidden(m::GRUCell) = m.h
 
-treelike(GRUCell)
+@treelike GRUCell
 
 Base.show(io::IO, l::GRUCell) =
   print(io, "GRUCell(", size(l.Wi, 2), ", ", size(l.Wi, 1)÷3, ")")

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -122,7 +122,7 @@ end
 
 function LSTMCell(in::Integer, out::Integer;
                   init = glorot_uniform)
-  cell = LSTMCell(param(init(out*4, in)), param(init(out*4, out)), param(zeros(out*4)),
+  cell = LSTMCell(param(init(out*4, in)), param(init(out*4, out)), param(zero(out*4)),
                   param(initn(out)), param(initn(out)))
   cell.b.data[gate(out, 2)] = 1
   return cell
@@ -170,7 +170,7 @@ end
 
 GRUCell(in, out; init = glorot_uniform) =
   GRUCell(param(init(out*3, in)), param(init(out*3, out)),
-          param(zeros(out*3)), param(initn(out)))
+          param(zero(out*3)), param(initn(out)))
 
 function (m::GRUCell)(h, x)
   b, o = m.b, size(h, 1)

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -32,7 +32,7 @@ import Adapt.adapt
 
 adapt(T, xs::OneHotMatrix) = OneHotMatrix(xs.height, adapt(T, xs.data))
 
-@require CuArrays begin
+@init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
   import CuArrays: CuArray, cudaconvert
   Base.Broadcast._containertype(::Type{<:OneHotMatrix{<:CuArray}}) = CuArray
   cudaconvert(x::OneHotMatrix{<:CuArray}) = OneHotMatrix(x.height, cudaconvert(x.data))

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -39,13 +39,13 @@ adapt(T, xs::OneHotMatrix) = OneHotMatrix(xs.height, adapt(T, xs.data))
 end
 
 function onehot(l, labels)
-  i = findfirst(labels, l)
+  i = something(findfirst(isequal(l), labels), 0)
   i > 0 || error("Value $l is not in labels")
   OneHotVector(i, length(labels))
 end
 
 function onehot(l, labels, unk)
-  i = findfirst(labels, l)
+  i = something(findfirst(isequal(l), labels), 0)
   i > 0 || return onehot(unk, labels)
   OneHotVector(i, length(labels))
 end

--- a/src/optimise/Optimise.jl
+++ b/src/optimise/Optimise.jl
@@ -9,7 +9,7 @@ struct Param{T}
   Δ::T
 end
 
-Base.convert(::Type{Param}, x::AbstractArray) = Param(x, zeros(x))
+Base.convert(::Type{Param}, x::AbstractArray) = Param(x, zero(x))
 
 include("optimisers.jl")
 include("interface.jl")

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -14,7 +14,7 @@ function descentweightdecay(p::Param, η::Real,  γ::Real)
 end
 
 function momentum(p::Param, ρ, η)
-  v = zeros(p.x)
+  v = zero(p.x)
   function ()
     @. v = ρ * v - η * p.Δ
     @. p.Δ = -v
@@ -23,7 +23,7 @@ end
 
 # Ref. https://arxiv.org/pdf/1212.0901.pdf
 function nesterov(p::Param, ρ, η)
-  v = zeros(p.x)
+  v = zero(p.x)
   function ()
     d = @. ρ^2 * v - (1+ρ) * η * p.Δ
     @. v = ρ*v - η*p.Δ
@@ -32,7 +32,7 @@ function nesterov(p::Param, ρ, η)
 end
 
 function rmsprop(p::Param; η::Real = 0.001, ρ::Real = 0.9, ϵ::Real = 1e-8)
-  acc  = zeros(p.x)
+  acc  = zero(p.x)
   function ()
     @. acc = ρ * acc + (1 - ρ) * p.Δ^2
     @. p.Δ *= η / √(acc + ϵ)
@@ -40,7 +40,7 @@ function rmsprop(p::Param; η::Real = 0.001, ρ::Real = 0.9, ϵ::Real = 1e-8)
 end
 
 function adagrad(p::Param; η::Real = 0.01, ϵ::Real = 1e-8)
-  acc = zeros(p.x) .+ ϵ
+  acc = zero(p.x) .+ ϵ
   function ()
     @. acc += p.Δ^2
     @. p.Δ *= η / √(acc + ϵ)
@@ -48,8 +48,8 @@ function adagrad(p::Param; η::Real = 0.01, ϵ::Real = 1e-8)
 end
 
 function adadelta(p::Param; ρ::Real = 0.9, ϵ::Real = 1e-8)
-  acc = zeros(p.x)
-  Δacc = zeros(p.x)
+  acc = zero(p.x)
+  Δacc = zero(p.x)
   function ()
     @. acc = ρ * acc + (1 - ρ) * p.Δ^2
     @. p.Δ *= √(Δacc + ϵ) / √(acc + ϵ)
@@ -58,8 +58,8 @@ function adadelta(p::Param; ρ::Real = 0.9, ϵ::Real = 1e-8)
 end
 
 function adam(p::Param; η::Real = 0.001, β1::Real = 0.9, β2::Real = 0.999, ϵ::Real = 1e-8)
-  mt = zeros(p.x)
-  vt = zeros(p.x)
+  mt = zero(p.x)
+  vt = zero(p.x)
   β1p, β2p = β1, β2
   function ()
     @. mt = β1 * mt + (1 - β1) * p.Δ
@@ -71,8 +71,8 @@ function adam(p::Param; η::Real = 0.001, β1::Real = 0.9, β2::Real = 0.999, ϵ
 end
 
 function adamax(p::Param; η::Real = 0.002, β1::Real = 0.9, β2::Real = 0.999, ϵ::Real = 1e-8)
-  mt = zeros(p.x)
-  ut = zeros(p.x)
+  mt = zero(p.x)
+  ut = zero(p.x)
   β1p = β1
   function ()
     @. mt = β1 * mt + (1 - β1) * p.Δ
@@ -83,9 +83,9 @@ function adamax(p::Param; η::Real = 0.002, β1::Real = 0.9, β2::Real = 0.999, 
 end
 
 function amsgrad(p::Param; η::Real = 0.001, β1::Real = 0.9, β2::Real = 0.999, ϵ::Real = 1e-8)
-  mt = zeros(p.x)
-  vt = zeros(p.x) .+ ϵ
-  v̂t = zeros(p.x) .+ ϵ
+  mt = zero(p.x)
+  vt = zero(p.x) .+ ϵ
+  v̂t = zero(p.x) .+ ϵ
   function ()
     @. mt = β1 * mt + (1 - β1) * p.Δ
     @. vt = β2 * vt + (1 - β2) * p.Δ ^ 2
@@ -95,8 +95,8 @@ function amsgrad(p::Param; η::Real = 0.001, β1::Real = 0.9, β2::Real = 0.999,
 end
 
 function nadam(p::Param; η::Real = 0.001, β1::Real = 0.9, β2::Real = 0.999, ϵ::Real = 1e-8)
-  mt = zeros(p.x)
-  vt = zeros(p.x)
+  mt = zero(p.x)
+  vt = zero(p.x)
   β1p, β2p = β1, β2
   function ()
     @. mt = β1 * mt + (1 - β1) * p.Δ

--- a/src/tracker/Tracker.jl
+++ b/src/tracker/Tracker.jl
@@ -87,7 +87,7 @@ Hook into gradient backpropagation. `x` is unmodified, but when backpropagating
 the sign of the gradient applied to `x`.
 """
 hook(f, x) = istracked(x) ? track(hook, f, x) : x
-@grad hook(f, x) = x, Δ -> (nothing, f(Δ))
+@grad hook(f, x) = data(x), Δ -> (nothing, f(Δ))
 
 """
     checkpoint(f, args...)

--- a/src/tracker/Tracker.jl
+++ b/src/tracker/Tracker.jl
@@ -12,7 +12,7 @@ tracker(x) = nothing
 istracked(x) = tracker(x) ≠ nothing
 isleaf(x) = !istracked(x) || isleaf(tracker(x))
 grad(x) = grad(tracker(x))
-grad(::Void) = nothing
+grad(::Nothing) = nothing
 data(x) = x
 
 struct Call{F,As<:Tuple}
@@ -35,7 +35,7 @@ mutable struct Tracked{T}
   grad::T
   Tracked{T}(f::Call) where T = new(0, f, false)
   Tracked{T}(f::Call, grad::T) where T = new(0, f, false, grad)
-  Tracked{T}(f::Call{Void}, grad::T) where T = new(0, f, true, grad)
+  Tracked{T}(f::Call{Nothing}, grad::T) where T = new(0, f, true, grad)
 end
 
 istracked(x::Tracked) = true

--- a/src/tracker/Tracker.jl
+++ b/src/tracker/Tracker.jl
@@ -46,14 +46,7 @@ track(f::Call, x) = Tracked{typeof(x)}(f)
 
 function _forward end
 
-function track(f::F, xs...) where F
-  y, back = _forward(f, xs...)
-  ts = map(tracker, xs)
-  c = Call(back, ts)
-  track(c, y)
-end
-
-function track_kw(f::F, xs...; kw...) where F
+function track(f::F, xs...; kw...) where F
   y, back = _forward(f, xs...; kw...)
   track(Call(back, tracker.(xs)), y)
 end

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -1,6 +1,7 @@
 import Base: *, ==
 
-using LinearAlgebra
+import LinearAlgebra
+using LinearAlgebra: Transpose, Adjoint, diagm
 
 struct TrackedArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
   tracker::Tracked{A}

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -28,16 +28,12 @@ Base.eltype(x::Type{<:TrackedArray{T}}) where T <: Real = TrackedReal{T}
 Base.show(io::IO, ::Type{TrackedArray{T,N,A}}) where {T,N,A<:AbstractArray{T,N}} =
   print(io, "TrackedArray{…,$A}")
 
-function Base.showarray(io::IO, X::TrackedArray, repr::Bool = true; header = true)
-  if repr
-    print(io, "param(")
-    Base.showarray(io, data(X), true)
-    print(io, ")")
-  else
-    header && print(io, "Tracked ")
-    Base.showarray(io, data(X), false, header = header)
-  end
+function Base.summary(io::IO, x::TrackedArray)
+  print(io, "Tracked ")
+  summary(io, data(x))
 end
+
+Base.print_array(io::IO, x::TrackedArray) = Base.print_array(io, data(x))
 
 Base.setindex!(xs::TrackedArray, v, i...) =
   error("Can't differentiate `setindex!`")

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -165,11 +165,11 @@ Base.cat(a::AbstractArray, b::TrackedArray, c::AbstractArray...; dims) = track_k
 
 @grad function cat(Xs...; dims)
   cat(data.(Xs)..., dims = dims), function (Δ)
-    start = ntuple(i -> 0, Val{ndims(Δ)})
+    start = ntuple(i -> 0, Val(ndims(Δ)))
     Δs = [begin
       dim_xs = 1:ndims(xs)
-      till_xs = ntuple((i -> i in dims ? (i in dim_xs ? size(xs,i) : 1) : 0), Val{ndims(Δ)})
-      xs_in_Δ = ntuple(i -> till_xs[i] > 0 ? (start[i]+1:start[i]+till_xs[i]) : Colon(), Val{ndims(Δ)})
+      till_xs = ntuple((i -> i in dims ? (i in dim_xs ? size(xs,i) : 1) : 0), Val(ndims(Δ)))
+      xs_in_Δ = ntuple(i -> till_xs[i] > 0 ? (start[i]+1:start[i]+till_xs[i]) : Colon(), Val(ndims(Δ)))
       d = reshape(Δ[xs_in_Δ...],size(xs))
       start = start .+ till_xs
       d
@@ -350,13 +350,13 @@ end
 
 function ∇broadcast(f, args::Vararg{Any,N}) where N
   sizes = _size.(args)
-  dargs = map((x,i) -> dualify(data(x), ntuple(j -> i==j, Val{N})), args, ntuple(identity, Val{N}))
+  dargs = map((x,i) -> dualify(data(x), ntuple(j -> i==j, Val(N))), args, ntuple(identity, Val(N)))
   out = broadcast(f, dargs...)
   eltype(out) <: Dual || return out
   y = value.(out)
   back = function (Δ_)
     Δ = data(Δ_)
-    Δargs = ntuple(i -> getpartial.(Δ, out, i), Val{N})
+    Δargs = ntuple(i -> getpartial.(Δ, out, i), Val(N))
     dxs = map((x, Δ) -> unbroadcast(x, Δ), sizes, Δargs)
     nobacksies(:broadcast, dxs)
   end

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -233,10 +233,12 @@ dot(xs::TrackedVector, ys::AbstractVector) = track(dot, xs, ys)
 
 @grad dot(xs, ys) = dot(data(xs), data(ys)), Δ -> (Δ .* ys, Δ .* xs)
 
+using StatsBase
+
 # Hacks to get std working
-Base.std(x::TrackedArray; mean = Base.mean(x)) =
+StatsBase.std(x::TrackedArray; mean = Base.mean(x)) =
   sqrt.(sum((x .- mean).^2) ./ (length(x)-1))
-Base.std(x::TrackedArray, dim; mean = Base.mean(x, dim)) =
+StatsBase.std(x::TrackedArray, dim; mean = Base.mean(x, dim)) =
   sqrt.(sum((x .- mean).^2, dim) ./ (size(x, dim)-1))
 
 LinearAlgebra.vecnorm(x::TrackedArray, p::Real = 2) =

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -276,19 +276,28 @@ LinearAlgebra.diagm(x::TrackedVector) = track(diagm, x)
 @grad diagm(x) = diagm(data(x)), Δ -> (diag(Δ),)
 
 x::TrackedMatrix  * y::AbstractMatrix = track(*, x, y)
-y::AbstractMatrix * x::TrackedMatrix  = track(*, x, y)
+x::AbstractMatrix * y::TrackedMatrix  = track(*, x, y)
 x::TrackedMatrix  * y::TrackedMatrix  = track(*, x, y)
 
 x::TrackedMatrix  * y::AbstractVector = track(*, x, y)
-y::AbstractMatrix * x::TrackedVector  = track(*, x, y)
+x::AbstractMatrix * y::TrackedVector  = track(*, x, y)
 x::TrackedMatrix  * y::TrackedVector  = track(*, x, y)
 
 x::TrackedVector  * y::AbstractVector = track(*, x, y)
-y::AbstractVector * x::TrackedVector  = track(*, x, y)
+x::AbstractVector * y::TrackedVector  = track(*, x, y)
 x::TrackedVector  * y::TrackedVector  = track(*, x, y)
 
 @grad a::AbstractMatrix * b::AbstractVecOrMat =
   data(a)*data(b), Δ -> (Δ * transpose(b), transpose(a) * Δ)
+
+# @grad function (a::AbstractMatrix * b::AbstractVecOrMat)
+#   # @show size(a) size(b)
+#   data(a)*data(b), function (Δ)
+#     @show size(Δ) size(b) size(Δ*transpose(b)) size(Δ*transpose(data(b)))
+#     @show typeof(Δ) typeof(b)
+#     (Δ * transpose(b), transpose(a) * Δ)
+#   end
+# end
 
 # NNlib
 

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -96,7 +96,7 @@ end
 
 @forward Grads.grads Base.setindex!, Base.haskey
 
-accum!(g::Grads, x, Δ) = g[x] = haskey(g, x) ? g[x] + Δ : Δ
+accum!(g::Grads, x, Δ) = g[x] = haskey(g, x) ? g[x] .+ Δ : Δ
 
 function back_(g::Grads, c::Call, Δ)
   Δs = c.func(Δ)

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -79,14 +79,14 @@ function Base.show(io::IO, ps::Params)
 end
 
 struct Grads
-  grads::ObjectIdDict
+  grads::IdDict{Any,Any}
 end
 
 Base.show(io::IO, ps::Grads) = println(io, "Grads(...)")
 
-Grads() = Grads(ObjectIdDict())
+Grads() = Grads(IdDict())
 
-Grads(ps::Params) = Grads(ObjectIdDict(tracker(p) => init_grad(data(p)) for p in ps))
+Grads(ps::Params) = Grads(IdDict(tracker(p) => init_grad(data(p)) for p in ps))
 
 Base.getindex(g::Grads, x::Tracked) = g.grads[x]
 function Base.getindex(g::Grads, x)

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -26,7 +26,7 @@ function back_(c::Call, Δ)
   foreach(back, c.args, data.(Δs))
 end
 
-back_(::Call{Void}, Δ) = nothing
+back_(::Call{Nothing}, Δ) = nothing
 
 accum!(x, Δ) = x .+ Δ
 accum!(x::AbstractArray, Δ) = (x .+= Δ)
@@ -47,7 +47,7 @@ function back(x::Tracked, Δ)
   return
 end
 
-back(::Void, _) = return
+back(::Nothing, _) = return
 
 # Interface methods
 
@@ -105,7 +105,7 @@ function back_(g::Grads, c::Call, Δ)
   foreach((x, Δ) -> back(g, x, Δ), c.args, Δs)
 end
 
-back_(g::Grads, ::Call{Void}, Δ) = nothing
+back_(g::Grads, ::Call{Nothing}, Δ) = nothing
 
 function back(g::Grads, x::Tracked, Δ)
   x.isleaf && (accum!(g, x, Δ); return)
@@ -119,7 +119,7 @@ function back(g::Grads, x::Tracked, Δ)
   return
 end
 
-back(::Grads, ::Void, _) = return
+back(::Grads, ::Nothing, _) = return
 
 function forward(f, ps::Params)
   y = f()

--- a/src/tracker/idset.jl
+++ b/src/tracker/idset.jl
@@ -3,15 +3,15 @@ struct IdSet{T} <: AbstractSet{T}
   IdSet{T}() where T = new(IdDict{T,Nothing}())
 end
 
-Base.eltype{T}(::IdSet{T}) = T
+Base.eltype(::IdSet{T}) where T = T
 
 IdSet() = IdSet{Any}()
 
-Base.push!{T}(s::IdSet{T}, x::T) = (s.dict[x] = nothing; s)
-Base.delete!{T}(s::IdSet{T}, x::T) = (delete!(s.dict, x); s)
+Base.push!(s::IdSet{T}, x::T) where T = (s.dict[x] = nothing; s)
+Base.delete!(s::IdSet{T}, x::T) where T = (delete!(s.dict, x); s)
 Base.in(x, s::IdSet) = haskey(s.dict, x)
 
-(::Type{IdSet{T}}){T}(xs) = push!(IdSet{T}(), xs...)
+(::Type{IdSet{T}})(xs) where T = push!(IdSet{T}(), xs...)
 
 IdSet(xs) = IdSet{eltype(xs)}(xs)
 

--- a/src/tracker/idset.jl
+++ b/src/tracker/idset.jl
@@ -1,6 +1,6 @@
 struct IdSet{T} <: AbstractSet{T}
-  dict::ObjectIdDict
-  IdSet{T}() where T = new(ObjectIdDict())
+  dict::IdDict{T,Nothing}
+  IdSet{T}() where T = new(IdDict{T,Nothing}())
 end
 
 Base.eltype{T}(::IdSet{T}) = T

--- a/src/tracker/numeric.jl
+++ b/src/tracker/numeric.jl
@@ -1,5 +1,5 @@
 function ngradient(f, xs::AbstractArray...)
-  grads = zeros.(xs)
+  grads = zero.(xs)
   for (x, Δ) in zip(xs, grads), i in 1:length(x)
     δ = sqrt(eps())
     tmp = x[i]

--- a/src/treelike.jl
+++ b/src/treelike.jl
@@ -7,11 +7,22 @@ mapchildren(f, x) = x
 children(x::Tuple) = x
 mapchildren(f, x::Tuple) = map(f, x)
 
-function treelike(T, fs = fieldnames(T))
-  @eval current_module() begin
+function treelike(m::Module, T, fs = fieldnames(T))
+  @eval m begin
     Flux.children(x::$T) = ($([:(x.$f) for f in fs]...),)
     Flux.mapchildren(f, x::$T) = $T(f.($children(x))...)
   end
+end
+
+function treelike(T, fs = fieldnames(T))
+  Base.depwarn("`treelike(T)` is deprecated, use `@treelike T`", :treelike)
+  treelike(Base._current_module(), T, fs)
+end
+
+macro treelike(T, fs = nothing)
+  fs == nothing || isexpr(fs, :tuple) || error("@treelike T (a, b)")
+  fs = fs == nothing ? [] : [:($(map(QuoteNode, fs.args)...),)]
+  :(treelike(@__MODULE__, $(esc(T)), $(fs...)))
 end
 
 isleaf(x) = isempty(children(x))

--- a/src/treelike.jl
+++ b/src/treelike.jl
@@ -16,7 +16,7 @@ end
 
 isleaf(x) = isempty(children(x))
 
-function mapleaves(f, x; cache = ObjectIdDict())
+function mapleaves(f, x; cache = IdDict())
   haskey(cache, x) && return cache[x]
   cache[x] = isleaf(x) ? f(x) : mapchildren(x -> mapleaves(f, x, cache = cache), x)
 end

--- a/src/treelike.jl
+++ b/src/treelike.jl
@@ -53,7 +53,7 @@ cpu(m) = mapleaves(x -> adapt(Array, x), m)
 
 gpu_adaptor = identity
 
-@require CuArrays begin
+@init @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
   global gpu_adaptor = CuArrays.cu
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 # Arrays
 
 initn(dims...) = randn(dims...)/100
-glorot_uniform(dims...) = (rand(dims...) - 0.5)*sqrt(24.0/(sum(dims)))
-glorot_normal(dims...) = (randn(dims...)*sqrt(2.0/sum(dims)))
+glorot_uniform(dims...) = (rand(dims...) .- 0.5) .* sqrt(24.0/(sum(dims)))
+glorot_normal(dims...) = randn(dims...) .* sqrt(2.0/sum(dims))
 
 unsqueeze(xs, dim) = reshape(xs, (size(xs)[1:dim-1]..., 1, size(xs)[dim:end]...))
 
@@ -145,7 +145,7 @@ function jacobian(m,x)
     y  = m(xp)
     k  = length(y)
     n  = length(x)
-    J  = Matrix{eltype(x)}(n,k)
+    J  = Matrix{eltype(x)}(undef,n,k)
     for i = 1:k
         Flux.back!(y[i]) # Populate gradient accumulator
         J[:,i] = xp.grad

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -119,7 +119,7 @@ function throttle(f, timeout; leading=true, trailing=false)
       end
 
       cooldown = false
-      @schedule try
+      @async try
         while (sleep(timeout); later != nothing)
           later()
           later = nothing

--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -1,4 +1,4 @@
-using Flux, Flux.Tracker, CuArrays, Base.Test
+using Flux, Flux.Tracker, CuArrays, Test
 using Flux: gpu
 
 info("Testing Flux/GPU")

--- a/test/cuda/cudnn.jl
+++ b/test/cuda/cudnn.jl
@@ -1,4 +1,4 @@
-using Flux, CuArrays, Base.Test
+using Flux, CuArrays, Test
 
 info("Testing Flux/CUDNN")
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,5 +1,5 @@
 using Flux.Data
-using Base.Test
+using Test
 
 @test cmudict()["CATASTROPHE"] == :[K,AH0,T,AE1,S,T,R,AH0,F,IY0].args
 

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -4,7 +4,7 @@ using Flux: testmode!
   x = [1.,2.,3.]
   @test x == testmode!(Dropout(0.1))(x)
   @test x == Dropout(0)(x)
-  @test zeros(x) == Dropout(1)(x)
+  @test zero(x) == Dropout(1)(x)
 
   x = rand(100)
   m = Dropout(0.9)

--- a/test/layers/stateless.jl
+++ b/test/layers/stateless.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 using Flux: onehotbatch, mse, crossentropy, logitcrossentropy,
             σ, binarycrossentropy, logitbinarycrossentropy
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,8 +11,8 @@ include("layers/stateless.jl")
 include("optimise.jl")
 include("data.jl")
 
-if Base.find_in_path("CuArrays") ≠ nothing
-  include("cuda/cuda.jl")
-end
+# if Base.find_in_path("CuArrays") ≠ nothing
+#   include("cuda/cuda.jl")
+# end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Flux, Base.Test
+using Flux, Test, Random
 
 srand(0)
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -111,10 +111,6 @@ end
 
 @test gradtest(x -> permutedims(x, [3,1,2]), rand(4,5,6))
 
-# TODO unreliable
-@test gradtest(x -> repmat(x, 5,5), rand(4,5))
-@test gradtest(x -> repmat(x, 5), rand(4,5))
-
 @test gradtest(x -> repeat(x; inner=2, outer=3), rand(5))
 @test gradtest(x -> repeat(x; inner=(2,2,1), outer=(1,1,3)), rand(5,4,3))
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -209,9 +209,6 @@ end
 @testset "Fallbacks" begin
   xs = param([1 2; 3 4])
   @test similar(xs) isa Matrix{Float64}
-  # Remove this test if we do LowerTriangular properly
-  L = LowerTriangular(xs)
-  @test L*L' isa Matrix{TrackedReal{Float64}}
 end
 
 @test @sprintf("%.2f", sum(param([1,2,3]))) == "6.00"

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -1,6 +1,7 @@
 using Flux.Tracker, Base.Test, NNlib
 using Flux.Tracker: TrackedReal, gradcheck, grad, derivative, checkpoint
 using NNlib: conv
+using StatsBase
 
 gradtest(f, xs::AbstractArray...) = gradcheck((xs...) -> sum(sin.(f(xs...))), xs...)
 gradtest(f, dims...) = gradtest(f, rand.(dims)...)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,6 @@
 using Flux: throttle, initn, glorot_uniform, glorot_normal, jacobian
 using StatsBase: std
+using Dates
 
 @testset "Throttle" begin
   @testset "default behaviour" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,5 @@
 using Flux: throttle, initn, glorot_uniform, glorot_normal, jacobian
+using StatsBase: std
 
 @testset "Throttle" begin
   @testset "default behaviour" begin


### PR DESCRIPTION
You can try this out with `add Flux#julia-0.7`.

- [x] Updates to handle 0.7 broadcast machinery
- [x] Fixes to tracked array show
- [x] ~~NNlib [branch](https://github.com/FluxML/NNlib.jl/pull/47)~~
- [x] ~~AbstractTrees#master (https://github.com/Keno/AbstractTrees.jl/issues/17)~~
- [ ] Depwarns

CuArrays also needs updates, but Flux itself will work fine without that for now.