### PR TITLE
Add ADAMW "Fixing Weight Decay Regularization in Adam"

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -22,7 +22,7 @@ export Tracker, TrackedArray, TrackedVector, TrackedMatrix, param
 include("optimise/Optimise.jl")
 using .Optimise
 using .Optimise: @epochs
-export SGD, ADAM, AdaMax, Momentum, Nesterov,
+export SGD, ADAM, ADAMW, AdaMax, Momentum, Nesterov,
        RMSProp, ADAGrad, ADADelta, AMSGrad
 
 include("utils.jl")

--- a/src/optimise/Optimise.jl
+++ b/src/optimise/Optimise.jl
@@ -1,7 +1,7 @@
 module Optimise
 
 export train!,
-  SGD, ADAM, AdaMax, Momentum, Nesterov, RMSProp, ADAGrad, ADADelta, AMSGrad
+  SGD, ADAM, ADAMW, AdaMax, Momentum, Nesterov, RMSProp, ADAGrad, ADADelta, AMSGrad
 
 struct Param{T}
   x::T

--- a/src/optimise/interface.jl
+++ b/src/optimise/interface.jl
@@ -1,7 +1,7 @@
 call(f, xs...) = f(xs...)
 
 # note for optimisers: set to zero
-# p.Δ at the end of the weigths update
+# p.Δ at the end of the weights update
 function optimiser(ps, fs...)
   ps = [Param(p) for p in ps]
   fs = map(ps) do p
@@ -55,6 +55,14 @@ RMSProp(ps, η = 0.001; ρ = 0.9, ϵ = 1e-8, decay = 0) =
 """
 ADAM(ps, η = 0.001; β1 = 0.9, β2 = 0.999, ϵ = 1e-08, decay = 0) =
   optimiser(ps, p->adam(p; η=η, β1=β1, β2=β2, ϵ=ϵ), p->invdecay(p,decay), p->descent(p,1))
+
+"""
+   ADAMW((params, η = 0.001; β1 = 0.9, β2 = 0.999, ϵ = 1e-08, decay = 0)
+
+[ADAMW](https://arxiv.org/abs/1711.05101) fixing weight decay regularization in Adam.
+"""
+ADAMW(ps, η = 0.001; β1 = 0.9, β2 = 0.999, ϵ = 1e-08, decay = 0) =
+  optimiser(ps, p->adam(p; η=η, β1=β1, β2=β2, ϵ=ϵ), p->descentweightdecay(p,1,decay))
 
 """
     AdaMax(params, η = 0.001; β1 = 0.9, β2 = 0.999, ϵ = 1e-08, decay = 0)

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -5,6 +5,14 @@ function descent(p::Param, η::Real)
   end
 end
 
+# Ref: https://arxiv.org/abs/1711.05101.pdf
+function descentweightdecay(p::Param, η::Real,  γ::Real)
+  function ()
+    @. p.x = p.x - η * (p.Δ + γ * p.x) 
+    @. p.Δ = 0
+  end
+end
+
 function momentum(p::Param, ρ, η)
   v = zeros(p.x)
   function ()


### PR DESCRIPTION
I really don't know what I'm doing, so this code may be all wrong. 

The motivation behind this method is in this blog post:
http://www.fast.ai/2018/07/02/adam-weight-decay/
And the original paper:
https://arxiv.org/abs/1711.05101.pdf

I just tried to add the relevant bits in Algorithm 2 of the paper. It moves the application of decay to the parameter update. (i.e. it becomes a mixing parameter). 

The paper argues that the L2 regularisation (which is what I believe `invdecay` is doing) are not equivalent to proper weight decay, are not equivalent when you have adaptive gradients.

Just an hours fun hacking one morning - I tested it against a toy Char-RNN I found on my harddrive, and it seems to improve the learning rate epoch-by-epoch over ADAM with the same decay parameter.