### PR TITLE
Local Response Normalization[W.I.P]

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -8,7 +8,7 @@ using Juno, Requires, Reexport
 using MacroTools: @forward
 
 export Chain, Dense, RNN, LSTM, GRU, Conv,
-       Dropout, LayerNorm, BatchNorm,
+       Dropout, LayerNorm, BatchNorm, LRNorm,
        params, mapleaves, cpu, gpu
 
 @reexport using NNlib

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -183,25 +183,16 @@ end
 function (LRN::LRNorm)(x)
   w,h,C,N = size(x)
   temp = zeros(size(x))
-  for z_=1:N
-    for x_=1:w
-      for y_=1:h
-        for i=1:C
-          constant = LRN.k
-          for j=max(1,i-div(LRN.n,2)): min(C, i+div(LRN.n,2))
-            constant += LRN.α * (x[x_,y_,j,z_]^2)
-          end
-          constant = constant^LRN.β
-          temp[x_,y_,i,z_] = x[x_,y_,i,z_] / constant
-        end
-      end
+  for z_=1:N, x_=1:w ,y_=1:h, i=1:C
+    constant = LRN.k
+    for j=max(1,i-div(LRN.n,2)): min(C, i+div(LRN.n,2))
+      constant += LRN.α * (x[x_,y_,j,z_]^2)
     end
+    constant = constant^LRN.β
+    temp[x_,y_,i,z_] = x[x_,y_,i,z_] / constant
   end
   return temp
 end 
-       
-children(LRN::LRNorm) =
-  (LRN.k, LRN,n, LRN.α, LRN.β)
 
-mapchildren(f, LRN::LRNorm) =  
-  LRNorm(f(LRN.k), LRN.n, f(LRN.α), f(LRN.β))
+treelike(LRNorm)
+  

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -96,3 +96,8 @@ end
     @test m(x) == y
   end
 end
+
+@testset "LRNorm" begin
+  x = rand(2,3,4,5)
+  @test size(x) == LRNorm(0.2, 5, 0.5, 2)(x) |> size
+end


### PR DESCRIPTION
Added a new LRNorm struct, which takes four hyper parameters and returns the normalized output.
Implemented by referring to the ImageNet paper which can be found [here](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf). 