### PR TITLE
AD Overhaul

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6.0
-DataFlow 0.2.1
 Juno
 MacroTools 0.3.3
 NNlib

--- a/docs/src/models/recurrence.md
+++ b/docs/src/models/recurrence.md
@@ -103,7 +103,7 @@ m.(seq)
 
 ## Truncating Gradients
 
-By default, calculating the gradients in a recurrent layer involves the entire history. For example, if we call the model on 100 inputs, calling `back!` will calculate the gradient for those 100 calls. If we then calculate another 10 inputs we have to calculate 110 gradients – this accumulates and quickly becomes expensive.
+By default, calculating the gradients in a recurrent layer involves its entire history. For example, if we call the model on 100 inputs, we'll have to calculate the gradient for those 100 calls. If we then calculate another 10 inputs we have to calculate 110 gradients – this accumulates and quickly becomes expensive.
 
 To avoid this we can *truncate* the gradient calculation, forgetting the history.
 

--- a/docs/src/training/optimisers.md
+++ b/docs/src/training/optimisers.md
@@ -3,6 +3,8 @@
 Consider a [simple linear regression](../models/basics.md). We create some dummy data, calculate a loss, and backpropagate to calculate gradients for the parameters `W` and `b`.
 
 ```julia
+using Flux.Tracker
+
 W = param(rand(2, 5))
 b = param(rand(2))
 
@@ -11,7 +13,9 @@ loss(x, y) = sum((predict(x) .- y).^2)
 
 x, y = rand(5), rand(2) # Dummy data
 l = loss(x, y) # ~ 3
-back!(l)
+
+params = Params([W, b])
+grads = Tracker.gradient(() -> loss(x, y), params)
 ```
 
 We want to update each parameter, using the gradient, in order to improve (reduce) the loss. Here's one way to do that:
@@ -22,7 +26,7 @@ using Flux.Tracker: grad, update!
 function sgd()
   η = 0.1 # Learning Rate
   for p in (W, b)
-    update!(p, -η * grad(p))
+    update!(p, -η * grads[p])
   end
 end
 ```

--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -340,33 +340,33 @@ function accum_transpose!(dst::CuArray, src::CuArray)
   return dst
 end
 
-function back_(m::RNNCall{<:Union{CuRNN,CuGRU}}, y_, Δ, x, h)
-  y, ho = y_
-  dy, dho = Δ
-  h_ = hBatch(x, data(h))
-  dx, dh = backwardData(descs[m.rnn], y, dy, dho, h_, m.reserve)
-  @back(x, dx)
-  @back(h, unbroadcast(h, dh))
-  (dWi, dWh), db = backwardWeights(descs[m.rnn], data(x), h_, y, m.reserve)
-  # We don't have to make this assumption, it's just slightly more complex.
-  @assert all(isleaf.((m.rnn.Wi, m.rnn.Wh, m.rnn.b)))
-  istracked(m.rnn.Wi) && accum_transpose!(m.rnn.Wi.grad, dWi)
-  istracked(m.rnn.Wh) && accum_transpose!(m.rnn.Wh.grad, dWh)
-  istracked(m.rnn.b) && accum_transpose!(m.rnn.b.grad, db)
-end
+# function back_(m::RNNCall{<:Union{CuRNN,CuGRU}}, y_, Δ, x, h)
+#   y, ho = y_
+#   dy, dho = Δ
+#   h_ = hBatch(x, data(h))
+#   dx, dh = backwardData(descs[m.rnn], y, dy, dho, h_, m.reserve)
+#   @back(x, dx)
+#   @back(h, unbroadcast(h, dh))
+#   (dWi, dWh), db = backwardWeights(descs[m.rnn], data(x), h_, y, m.reserve)
+#   # We don't have to make this assumption, it's just slightly more complex.
+#   @assert all(isleaf.((m.rnn.Wi, m.rnn.Wh, m.rnn.b)))
+#   istracked(m.rnn.Wi) && accum_transpose!(m.rnn.Wi.grad, dWi)
+#   istracked(m.rnn.Wh) && accum_transpose!(m.rnn.Wh.grad, dWh)
+#   istracked(m.rnn.b) && accum_transpose!(m.rnn.b.grad, db)
+# end
 
-function back_(m::RNNCall{<:CuLSTM}, y_, Δ, x, h, c)
-  y, ho, co = y_
-  dy, dho, dco = Δ
-  h_ = hBatch(x, data(h))
-  c_ = hBatch(x, data(c))
-  dx, dh, dc = backwardData(descs[m.rnn], y, dy, dho, dco, h_, c_, m.reserve)
-  @back(x, dx)
-  @back(h, unbroadcast(h, dh))
-  @back(c, unbroadcast(h, dc))
-  (dWi, dWh), db = backwardWeights(descs[m.rnn], data(x), h_, y, m.reserve)
-  @assert all(isleaf.((m.rnn.Wi, m.rnn.Wh, m.rnn.b)))
-  istracked(m.rnn.Wi) && accum_transpose!(m.rnn.Wi.grad, dWi)
-  istracked(m.rnn.Wh) && accum_transpose!(m.rnn.Wh.grad, dWh)
-  istracked(m.rnn.b) && accum_transpose!(m.rnn.b.grad, db)
-end
+# function back_(m::RNNCall{<:CuLSTM}, y_, Δ, x, h, c)
+#   y, ho, co = y_
+#   dy, dho, dco = Δ
+#   h_ = hBatch(x, data(h))
+#   c_ = hBatch(x, data(c))
+#   dx, dh, dc = backwardData(descs[m.rnn], y, dy, dho, dco, h_, c_, m.reserve)
+#   @back(x, dx)
+#   @back(h, unbroadcast(h, dh))
+#   @back(c, unbroadcast(h, dc))
+#   (dWi, dWh), db = backwardWeights(descs[m.rnn], data(x), h_, y, m.reserve)
+#   @assert all(isleaf.((m.rnn.Wi, m.rnn.Wh, m.rnn.b)))
+#   istracked(m.rnn.Wi) && accum_transpose!(m.rnn.Wi.grad, dWi)
+#   istracked(m.rnn.Wh) && accum_transpose!(m.rnn.Wh.grad, dWh)
+#   istracked(m.rnn.b) && accum_transpose!(m.rnn.b.grad, db)
+# end

--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -286,41 +286,28 @@ function desc(rnn)
   return d
 end
 
-import Flux.Tracker: data, isleaf, istracked, track, back_, @back, unbroadcast
-
-mutable struct RNNCall{R}
-  rnn::R
-  reserve::CuVector{UInt8}
-  RNNCall{R}(rnn::R) where R = new(rnn)
-end
-
-RNNCall(rnn) = RNNCall{typeof(rnn)}(rnn)
-
-function (c::RNNCall)(args...)
-  rs, result = forwardTrain(desc(c.rnn), args...)
-  c.reserve = rs
-  return result
-end
+import Flux.Tracker
+import Flux.Tracker: data, istracked, track, unbroadcast, @grad, nobacksies
 
 istrain(m::CuRNNs, args...) = any(x -> x isa TrackedArray, (m.Wi, m.Wh, m.b, args...))
 
 function (m::CuRNN{T})(h::CuParam{T}, x::CuParam{T}) where T <: Union{Float32,Float64}
   result = istrain(m, h, x) ?
-    track(RNNCall(m), x, h) :
+    track(m, x, h, m.Wi, m.Wh, m.b) :
     forward(desc(m), x, h)
   return result[2], result[1]
 end
 
 function (m::CuGRU{T})(h::CuParam{T}, x::CuParam{T}) where T <: Union{Float32,Float64}
   result = istrain(m, h, x) ?
-    track(RNNCall(m), x, h) :
+    track(m, x, h, m.Wi, m.Wh, m.b) :
     forward(desc(m), x, h)
   return result[2], result[1]
 end
 
 function (m::CuLSTM{T})(h::NTuple{2,CuParam{T}}, x::CuParam{T}) where T <: Union{Float32,Float64}
   result = istrain(m, h, x) ?
-    track(RNNCall(m), x, h[1], h[2]) :
+    track(m, x, h[1], h[2], m.Wi, m.Wh, m.b) :
     forward(desc(m), x, h[1], h[2])
   return (result[2], result[3]), result[1]
 end
@@ -329,44 +316,29 @@ end
 (m::CuGRU{T})(h::CuParam{T}, x) where T <: Union{Float32,Float64} = m(h, CuArray{T}(x))
 (m::CuLSTM{T})(h::NTuple{2,CuParam{T}}, x) where T <: Union{Float32,Float64} = m(h, CuArray{T}(x))
 
-function accum_transpose!(dst::CuArray, src::CuArray)
-  function kernel(dst, src)
-    I = @cuindex dst
-    dst[I...] += src[reverse(I)...]
-    return
+@grad function (m::Union{CuRNN,CuGRU})(x, h, Wi, Wh, b)
+  reserve, result = forwardTrain(desc(m), data(x), data(h))
+  result, function (Δ)
+    y, ho = result
+    dy, dho = Δ
+    h_ = hBatch(x, data(h))
+    dx, dh = backwardData(descs[m], y, dy, dho, h_, reserve)
+    (dWi, dWh), db = backwardWeights(descs[m], data(x), h_, y, reserve)
+    nobacksies(:RNN, (dx, unbroadcast(size(h), dh), dWi.', dWh.', db))
   end
-  blk, thr = cudims(dst)
-  @cuda (blk, thr) kernel(dst, src)
-  return dst
 end
 
-# function back_(m::RNNCall{<:Union{CuRNN,CuGRU}}, y_, Δ, x, h)
-#   y, ho = y_
-#   dy, dho = Δ
-#   h_ = hBatch(x, data(h))
-#   dx, dh = backwardData(descs[m.rnn], y, dy, dho, h_, m.reserve)
-#   @back(x, dx)
-#   @back(h, unbroadcast(h, dh))
-#   (dWi, dWh), db = backwardWeights(descs[m.rnn], data(x), h_, y, m.reserve)
-#   # We don't have to make this assumption, it's just slightly more complex.
-#   @assert all(isleaf.((m.rnn.Wi, m.rnn.Wh, m.rnn.b)))
-#   istracked(m.rnn.Wi) && accum_transpose!(m.rnn.Wi.grad, dWi)
-#   istracked(m.rnn.Wh) && accum_transpose!(m.rnn.Wh.grad, dWh)
-#   istracked(m.rnn.b) && accum_transpose!(m.rnn.b.grad, db)
-# end
-
-# function back_(m::RNNCall{<:CuLSTM}, y_, Δ, x, h, c)
-#   y, ho, co = y_
-#   dy, dho, dco = Δ
-#   h_ = hBatch(x, data(h))
-#   c_ = hBatch(x, data(c))
-#   dx, dh, dc = backwardData(descs[m.rnn], y, dy, dho, dco, h_, c_, m.reserve)
-#   @back(x, dx)
-#   @back(h, unbroadcast(h, dh))
-#   @back(c, unbroadcast(h, dc))
-#   (dWi, dWh), db = backwardWeights(descs[m.rnn], data(x), h_, y, m.reserve)
-#   @assert all(isleaf.((m.rnn.Wi, m.rnn.Wh, m.rnn.b)))
-#   istracked(m.rnn.Wi) && accum_transpose!(m.rnn.Wi.grad, dWi)
-#   istracked(m.rnn.Wh) && accum_transpose!(m.rnn.Wh.grad, dWh)
-#   istracked(m.rnn.b) && accum_transpose!(m.rnn.b.grad, db)
-# end
+@grad function (m::CuLSTM)(x, h, c, Wi, Wh, b)
+  reserve, result = forwardTrain(desc(m), data.((x, h, c))...)
+  result, function (Δ)
+    y, ho = result
+    dy, dho, dco = Δ
+    h_ = hBatch(x, data(h))
+    c_ = hBatch(x, data(c))
+    dx, dh, dc = backwardData(descs[m], y, dy, dho, dco, h_, c_, reserve)
+    (dWi, dWh), db = backwardWeights(descs[m], data(x), h_, y, reserve)
+    nobacksies(:RNN,
+      (dx, unbroadcast(size(h), dh), unbroadcast(size(c), dc),
+       dWi.', dWh.', db))
+  end
+end

--- a/src/tracker/Tracker.jl
+++ b/src/tracker/Tracker.jl
@@ -5,7 +5,7 @@ using MacroTools: @q, @forward
 
 import Base: ==
 
-export TrackedArray, TrackedVector, TrackedMatrix, param, back!
+export TrackedArray, TrackedVector, TrackedMatrix, Params, param, back!
 
 tracker(x) = nothing
 
@@ -61,7 +61,7 @@ macro grad(ex)
 end
 
 function update!(x, Δ)
-  tracker(x).data += Δ
+  x.data .+= data(Δ)
   tracker(x).grad .= 0
   return x
 end

--- a/src/tracker/Tracker.jl
+++ b/src/tracker/Tracker.jl
@@ -87,6 +87,22 @@ the sign of the gradient applied to `x`.
 hook(f, x) = istracked(x) ? track(hook, f, x) : x
 @grad hook(f, x) = x, Δ -> (nothing, f(Δ))
 
+"""
+    checkpoint(f, args...)
+
+Behaves like `f(args...)`, but avoids storing the intermediate values needed for
+calculating gradients. Instead, `f(args...)` will be called again during the
+backward pass. This can be used to save memory in larger models.
+"""
+checkpoint(f, args...) = track(checkpoint, f, args...)
+
+@grad function checkpoint(f, args...)
+  data(f(args...)), function (Δ)
+    y, back = forward(f, args...)
+    (nothing, back(Δ)...)
+  end
+end
+
 param(x::Number) = TrackedReal(float(x))
 param(xs::AbstractArray) = TrackedArray(float.(xs))
 

--- a/src/tracker/Tracker.jl
+++ b/src/tracker/Tracker.jl
@@ -1,7 +1,7 @@
 module Tracker
 
 using MacroTools
-using MacroTools: @q
+using MacroTools: @q, @forward
 
 import Base: ==
 
@@ -71,6 +71,7 @@ function update!(x, Δ)
   return x
 end
 
+include("idset.jl")
 include("back.jl")
 include("scalar.jl")
 include("array.jl")

--- a/src/tracker/Tracker.jl
+++ b/src/tracker/Tracker.jl
@@ -55,7 +55,8 @@ macro grad(ex)
   @capture(shortdef(ex), (name_(args__) = body_) |
                          (name_(args__) where {T__} = body_)) || error("Need a function definition")
   T == nothing && (T = [])
-  insert!(args, 1+isexpr(args[1], :parameters) , :(::typeof($name)))
+  isexpr(name, :(::)) || (name = :(::typeof($name)))
+  insert!(args, 1+isexpr(args[1], :parameters) , name)
   @q(Tracker._forward($(args...)) where $(T...) = $body) |> esc
 end
 

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -62,45 +62,47 @@ Base.:(==)(x::TrackedArray, y::TrackedArray) = data(x) == data(y)
 
 Base.getindex(xs::TrackedArray, i...) = track(getindex, xs, i...)
 
-function back(::typeof(getindex), Δ, xs::TrackedArray, i...)
-  Δ′ = zeros(xs.data)
-  Δ′[i...] = Δ
-  @back(xs, Δ′)
+@grad function getindex(xs, i...)
+  data(xs)[i...], function (Δ)
+    Δ′ = zeros(xs)
+    Δ′[i...] = Δ
+    (Δ′, map(_->nothing, i)...)
+  end
 end
 
 Base.:-(xs::TrackedArray) = track(-, xs)
 
-back(::typeof(-), Δ, xs::TrackedArray) = back(xs, -Δ)
+@grad -(xs) = -xs, Δ -> (-Δ,)
 
 Base.transpose(xs::TrackedArray) = track(transpose, xs)
 Base.ctranspose(xs::TrackedArray) = track(ctranspose, xs)
 
-back(::typeof(transpose), Δ, xs) = @back(xs, trim(xs, Δ.'))
-back(::typeof(ctranspose), Δ, xs) = @back(xs, trim(xs, Δ'))
+@grad transpose(xs) = xs.', Δ -> (trim(xs, Δ.'),)
+@grad ctranspose(xs) = xs', Δ -> (trim(xs, Δ'),)
 
 Base.repmat(x::TrackedVecOrMat, a::Integer...) = track(repmat, x, a...)
 Base.repmat(x::TrackedVecOrMat, a::Int64...) = track(repmat, x, a...)
 
-function back(::typeof(repmat), Δ, xs::TrackedVecOrMat, m, n=1)
-    Δ′ = similar(xs.data)
-    S = size(xs.data)
+@grad function repmat(xs, m, n = 1)
+  repmat(xs, m, n), function (Δ)
+    Δ′ = similar(xs)
+    S = size(xs)
     for (i,v) in enumerate(Δ)
         d1 = divrem(i-1, S[1]*m)
         x = d1[2] % S[1]+1
         y = d1[1] % S[2]+1
         Δ′[x, y] += v
     end
-    back(xs, Δ′)
+    return (Δ′, nothing, nothing)
+  end
 end
 
+Base.repeat(A::TrackedArray; kw...) = track(repeat, A; kw...)
 
-_repeat(A, inner, outer) = Base.repeat(A; inner=inner, outer=outer)
-Base.repeat(A::TrackedArray; inner=ntuple(x->1, ndims(A)), outer=ntuple(x->1, ndims(A))) = track(_repeat, A, inner, outer)
-
-function back(::typeof(_repeat), Δ, xs::TrackedArray, inner, outer)
-    Δ′ = similar(xs.data)
-    Δ′ .= 0
-    S = size(xs.data)
+@grad function repeat(xs; inner=ntuple(x->1, ndims(A)), outer=ntuple(x->1, ndims(A)))
+  repeat(xs, inner = inner, outer = outer), function (Δ)
+    Δ′ = zero(xs)
+    S = size(xs)
 
     # Loop through each element of Δ, calculate source dimensions, accumulate into Δ′
     for (dest_idx, val) in enumerate(IndexCartesian(), Δ)
@@ -109,7 +111,8 @@ function back(::typeof(_repeat), Δ, xs::TrackedArray, inner, outer)
         src_idx = [mod1(div(dest_idx[dim] - 1, inner[dim]) + 1, S[dim]) for dim in 1:length(S)]
         Δ′[src_idx...] += val
     end
-    back(xs, Δ′)
+    (Δ′,)
+  end
 end
 
 
@@ -138,42 +141,51 @@ for f in [:vcat, :hcat]
   end
 end
 
-function back(::typeof(vcat), Δ, xs...)
-  start = 0
-  for xsi in xs
-    i = map(_ -> :, size(xsi)) |> Base.tail
-    @back(xsi, Δ[start+1:start+size(xsi,1), i...])
-    start += size(xsi, 1)
+@grad function vcat(xs...)
+  vcat(xs...), function (Δ)
+    start = 0
+    Δs = [begin
+      i = map(_ -> :, size(xsi)) |> Base.tail
+      d = Δ[start+1:start+size(xsi,1), i...]
+      start += size(xsi, 1)
+      d
+    end for xsi in xs]
+    return (Δs...,)
   end
 end
 
-function back(::typeof(hcat), Δ, xs...)
-  start = 0
-  for xsi in xs
-    if ndims(xsi) == 1
-      @back(xsi, Δ[:, start+1])
-    else
-      i = map(_ -> :, size(xsi)) |> Base.tail |> Base.tail
-      @back(xsi, Δ[:, start+1:start+size(xsi,2), i...])
-    end
-    start += size(xsi, 2)
+@grad function hcat(xs...)
+  hcat(xs...), function (Δ)
+    start = 0
+    Δs = [begin
+      d = if ndims(xsi) == 1
+        Δ[:, start+1]
+      else
+        i = map(_ -> :, size(xsi)) |> Base.tail |> Base.tail
+        Δ[:, start+1:start+size(xsi,2), i...]
+      end
+      start += size(xsi, 2)
+      d
+    end for xsi in xs]
+    return (Δs...,)
   end
 end
 
 Base.cat(dims, a::TrackedArray, b::AbstractArray...) = track(cat, dims, a, b...)
 Base.cat(dims, a::Union{RowVector,Array}, b::TrackedArray, c::AbstractArray...) = track(cat, dims, a, b, c...)
 
-function back(::typeof(cat), Δ, dims, Xs...)
-  start = ntuple(i -> 0, Val{ndims(Δ)})
-  for xs in Xs
-    dim_xs = 1:ndims(xs)
-    till_xs = ntuple((i -> i in dims ? (i in dim_xs ? size(xs,i) : 1) : 0), Val{ndims(Δ)})
-
-    xs_in_Δ = ntuple(i -> till_xs[i] > 0 ? (start[i]+1:start[i]+till_xs[i]) : Colon(), Val{ndims(Δ)})
-
-    @back(xs, reshape(Δ[xs_in_Δ...],size(xs)))
-
-    start = start .+ till_xs
+@grad function cat(dims, Xs...)
+  cat(dims, Xs...), function (Δ)
+    start = ntuple(i -> 0, Val{ndims(Δ)})
+    Δs = [begin
+      dim_xs = 1:ndims(xs)
+      till_xs = ntuple((i -> i in dims ? (i in dim_xs ? size(xs,i) : 1) : 0), Val{ndims(Δ)})
+      xs_in_Δ = ntuple(i -> till_xs[i] > 0 ? (start[i]+1:start[i]+till_xs[i]) : Colon(), Val{ndims(Δ)})
+      d = reshape(Δ[xs_in_Δ...],size(xs))
+      start = start .+ till_xs
+      d
+    end for xs in Xs]
+    return (nothing, Δs...,)
   end
 end
 
@@ -181,11 +193,10 @@ Base.reshape(xs::TrackedArray, dims::Union{Colon,Int64}...) = reshape(xs, dims)
 Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Union{Int64,Colon}}}) = reshape(xs, Base._reshape_uncolon(xs, dims))
 Base.reshape(xs::TrackedArray, dims::Tuple{Vararg{Int64}}) = track(reshape, xs, dims)
 
-back(::typeof(reshape), Δ, xs::TrackedArray, _...) =
-  back(xs, reshape(Δ, size(xs)))
+@grad reshape(xs, dims) = reshape(xs, dims), Δ -> (reshape(Δ, size(xs)),nothing)
 
 Base.permutedims(xs::TrackedArray, dims) = track(permutedims, xs, dims)
-back(::typeof(permutedims), Δ, xs::TrackedArray, dims) = back(xs, permutedims(Δ, invperm(dims)))
+@grad permutedims(xs, dims) = permutedims(xs, dims), Δ -> (permutedims(Δ, invperm(dims)),nothing)
 
 function _kron(mat1::AbstractMatrix,mat2::AbstractMatrix)
     m1, n1 = size(mat1)
@@ -207,14 +218,16 @@ Base.sum(xs::TrackedArray, dim) = track(sum, xs, dim)
 Base.sum(xs::TrackedArray) = track(sum, xs)
 Base.sum(f::Union{Function,Type},xs::TrackedArray) = sum(f.(xs))
 
-back(::typeof(sum), Δ, xs::TrackedArray, dim...) = back(xs, similar(xs.data) .= Δ)
+@grad sum(xs, dim...) = sum(xs, dim...),
+  Δ -> (similar(xs) .= Δ, map(_->nothing,dim)...)
 
 Base.prod(xs::TrackedArray, dim) = track(prod, xs, dim)
 Base.prod(xs::TrackedArray) = track(prod, xs)
 Base.prod(f::Union{Function, Type}, xs::TrackedArray) = prod(f.(xs))
 
-back(::typeof(prod), Δ, xs::TrackedArray, dim...) = back(xs, similar(xs.data) .= (prod(xs.data, dim...) ./ xs.data) .* Δ)
-back(::typeof(prod), Δ, xs::TrackedArray) = back(xs, similar(xs.data) .= (reshape(.*(circshift.([reshape(xs.data, length(xs.data))], 1:length(xs.data)-1)...), size(xs.data))) .* Δ)
+@grad prod(xs) = prod(xs), Δ -> (similar(xs) .= (prod(xs) ./ xs) .* Δ,)
+@grad prod(xs, dim) = prod(xs, dim),
+  Δ -> (similar(xs) .= (reshape(.*(circshift.([reshape(xs, length(xs))], 1:length(xs)-1)...), size(xs))) .* Δ,nothing)
 
 Base.findfirst(xs::TrackedArray, args...) = findfirst(xs.data, args...)
 
@@ -230,10 +243,7 @@ LinAlg.dot(xs::TrackedVector, ys::TrackedVector) = track(dot, xs, ys)
 LinAlg.dot(xs::AbstractVector, ys::TrackedVector) = track(dot, xs, ys)
 LinAlg.dot(xs::TrackedVector, ys::AbstractVector) = track(dot, xs, ys)
 
-function back(::typeof(dot), Δ, xs, ys)
-  @back(xs, Δ.*data(ys))
-  @back(ys, Δ.*data(xs))
-end
+@grad dot(xs, ys) = dot(xs, ys), Δ -> (Δ .* ys, Δ .* xs)
 
 # Hacks to get std working
 Base.std(x::TrackedArray; mean = Base.mean(x)) =
@@ -244,39 +254,30 @@ Base.std(x::TrackedArray, dim; mean = Base.mean(x, dim)) =
 Base.vecnorm(x::TrackedArray, p::Real = 2) =
   sum(abs.(x).^p .+ eps(0f0))^(1/p) # avoid d(sqrt(x))/dx == Inf at 0
 
-back(::typeof(mean), Δ, xs::TrackedArray) = back(xs, similar(xs.data) .= Δ ./ length(xs.data))
-back(::typeof(mean), Δ, xs::TrackedArray, region) =
-  back(xs, similar(xs.data) .= Δ ./ prod(size(xs.data, region...)))
+@grad mean(xs) = mean(xs), Δ -> (similar(xs) .= Δ ./ length(xs),)
+@grad mean(xs, region) = mean(xs, region), Δ -> (similar(xs) .= Δ ./ prod(size(xs, region...)),nothing)
 
-function back(::typeof(maximum), Δ, xs::TrackedArray)
-    Δ′    = zeros(xs.data)
-    _, i  = findmax(xs.data)
+@grad function maximum(xs, r...)
+  maximum(xs, r...), function (Δ)
+    Δ′ = zeros(xs)
+    _, i = findmax(xs, r...)
     Δ′[i] = Δ
-    @back(xs, Δ′)
+    return (Δ′,map(_->nothing,r)...)
+  end
 end
-function back(::typeof(maximum), Δ, xs::TrackedArray, region)
-    Δ′     = zeros(xs.data)
-    _, is  = findmax(xs.data, region)
-    Δ′[is] = Δ
-    @back(xs, Δ′)
-end
-function back(::typeof(minimum), Δ, xs::TrackedArray)
-    Δ′    = zeros(xs.data)
-    _, i  = findmin(xs.data)
+@grad function minimum(xs, r...)
+  minimum(xs, r...), function (Δ)
+    Δ′ = zeros(xs)
+    _, i = findmin(xs, r...)
     Δ′[i] = Δ
-    @back(xs, Δ′)
-end
-function back(::typeof(minimum), Δ, xs::TrackedArray, region)
-    Δ′     = zeros(xs.data)
-    _, is  = findmin(xs.data, region)
-    Δ′[is] = Δ
-    @back(xs, Δ′)
+    return (Δ′,map(_->nothing,r)...)
+  end
 end
 
 # BLAS
 
 Base.diagm(x::TrackedVector) = track(diagm, x)
-back(::typeof(diagm), Δ, x) = @back(x, diag(Δ))
+@grad diagm(x) = diagm(x), Δ -> (diag(Δ),)
 
 for f in :[*, Ac_mul_B, A_mul_Bc].args
   @eval begin
@@ -295,30 +296,11 @@ for f in :[*, Ac_mul_B, A_mul_Bc].args
   end
 end
 
-function back(::typeof(*), Δ, a::AbstractMatrix, b::AbstractVecOrMat)
-  @back(a, A_mul_Bt(Δ, data(b)))
-  @back(b, At_mul_B(data(a), Δ))
-end
+@grad a::AbstractMatrix * b::AbstractVecOrMat =
+  a*b, Δ -> (A_mul_Bt(Δ, b), At_mul_B(a, Δ))
 
-function back(::typeof(Ac_mul_B), Δ, a::AbstractVecOrMat{<:Real}, b::AbstractVecOrMat{<:Real})
-  @back(a, A_mul_Bt(Δ, data(b))')
-  @back(b, data(a)*Δ)
-end
-
-function back(::typeof(A_mul_Bc), Δ, a::AbstractVecOrMat{<:Real}, b::AbstractVecOrMat{<:Real})
-  @back(a, Δ * data(b))
-  @back(b, At_mul_B(data(a), Δ)')
-end
-
-# Fast path for matrix-vector
-function back(::typeof(*), Δ::AbstractVector, W::TrackedMatrix, x::AbstractVector)
-  if isleaf(W)
-    W.grad .+= Δ .* data(x).'
-  else
-    back(W, A_mul_Bt(Δ, data(x)))
-  end
-  @back(x, At_mul_B(data(W), Δ))
-end
+@grad Ac_mul_B(a, b) = Ac_mul_B(a, b), Δ -> (A_mul_Bt(Δ, b)', a*Δ)
+@grad A_mul_Bc(a, b) = A_mul_Bc(a, b), Δ -> (Δ * b, At_mul_B(a, Δ)')
 
 # NNlib
 
@@ -327,65 +309,42 @@ import NNlib: softmax, ∇softmax, logsoftmax, ∇logsoftmax, conv, maxpool, mea
 
 softmax(xs::TrackedArray) = track(softmax, xs)
 
-back(::typeof(softmax), Δ, xs) = @back(xs, ∇softmax(Δ, data(xs)))
+@grad softmax(xs) = softmax(xs), Δ -> (∇softmax(Δ, xs),)
 
 logsoftmax(xs::TrackedArray) = track(logsoftmax, xs)
 
-back(::typeof(logsoftmax), Δ, xs) = @back(xs, ∇logsoftmax(Δ, data(xs)))
+@grad logsoftmax(xs) = logsoftmax(xs), Δ -> (∇logsoftmax(Δ, xs),)
 
-# TODO: can store kwargs efficiently in namedtuples
-_conv(x, w, stride, pad, dilation) = conv(x, w, stride = stride, pad = pad, dilation = dilation)
+conv(x::TrackedArray,  w::TrackedArray;  kw...) = track(conv, x, w; kw...)
+conv(x::AbstractArray, w::TrackedArray;  kw...) = track(conv, x, w; kw...)
+conv(x::TrackedArray,  w::AbstractArray; kw...) = track(conv, x, w; kw...)
 
-conv(x::TrackedArray{<:Real,N}, w::TrackedArray{<:Real,N}; stride = 1, pad = 0, dilation = 1) where N =
-  track(_conv, x, w, stride, pad, dilation)
-conv(x::AbstractArray{<:Real,N}, w::TrackedArray{<:Real,N}; stride = 1, pad = 0, dilation = 1) where N =
-  track(_conv, x, w, stride, pad, dilation)
-conv(x::TrackedArray{<:Real,N}, w::AbstractArray{<:Real,N}; stride = 1, pad = 0, dilation = 1) where N =
-  track(_conv, x, w, stride, pad, dilation)
+@grad conv(x, w; kw...) =
+  conv(x, w; kw...),
+    Δ -> (NNlib.∇conv_data(Δ, x, w; kw...),
+          NNlib.∇conv_filter(Δ, x, w; kw...))
 
-function back(::typeof(_conv), Δ, x, w, stride, pad, dilation)
-  @back(x, NNlib.∇conv_data(Δ, data(x), data(w); stride = stride, pad = pad, dilation = dilation))
-  @back(w, NNlib.∇conv_filter(Δ, data(x), data(w); stride = stride, pad = pad, dilation = dilation))
+maxpool(x::TrackedArray, k; kw...) = track(maxpool, x, k; kw...)
+
+@grad function maxpool(x, k; kw...)
+  y = maxpool(x, k; kw...)
+  y, Δ -> (NNlib.∇maxpool(Δ, y, x, k; kw...), nothing)
 end
 
-_maxpool(x, k, pad, stride) = maxpool(x, k; pad = pad, stride = stride)
+meanpool(x::TrackedArray, k; kw...) = track(meanpool, x, k; kw...)
 
-maxpool(x::TrackedArray, k; pad = map(_->0,k), stride = k) =
-  track(_maxpool, x, k, pad, stride)
-
-back_(::typeof(_maxpool), y, Δ, x, k, pad, stride) =
-  back(x, NNlib.∇maxpool(Δ, y, data(x), k, pad=pad, stride=stride))
-
-_meanpool(x, k, pad, stride) = meanpool(x, k; pad = pad, stride = stride)
-
-meanpool(x::TrackedArray, k; pad = map(_->0,k), stride = k) =
-  track(_meanpool, x, k, pad, stride)
-
-back_(::typeof(_meanpool), y, Δ, x, k, pad, stride) =
-  back(x, NNlib.∇meanpool(Δ, y, data(x), k, pad=pad, stride=stride))
+@grad function meanpool(x, k; kw...)
+  y = meanpool(x, k; kw...)
+  y, Δ -> (NNlib.∇meanpool(Δ, y, x, k; kw...), nothing)
+end
 
 # Broadcasting
 
-using ForwardDiff: Dual, partials
-
-struct Broadcasted{F,T}
-  f::F
-  data::T
-end
-
-(b::Broadcasted)(xs...) = map(x -> x.value, b.data)
+using ForwardDiff: Dual, partials, value
 
 dualify(xs, n) = xs
-dualify(xs::TrackedArray, ps) = map(x -> Dual(x, ps), data(xs))
-dualify(xs::TrackedReal, ps) = Dual(data(xs), ps)
-
-function tracked_broadcast(f, args::Vararg{Any,N}) where N
-  dargs = map((x,i) -> dualify(x, ntuple(j -> i==j, Val{N})), args, ntuple(identity, Val{N}))
-  out = broadcast(f, dargs...)
-  eltype(out) <: Dual || return out
-  b = Broadcasted(f, out)
-  track(Call(b, args...), b())
-end
+dualify(xs::AbstractArray, ps) = map(x -> Dual(x, ps), xs)
+dualify(xs::Real, ps) = Dual(xs, ps)
 
 trim(x, Δ) = reshape(Δ, ntuple(i -> size(Δ, i), Val{ndims(x)}))
 
@@ -400,9 +359,17 @@ function getpartial(Δ, x, i)
   return Δ * p
 end
 
-function back(b::Broadcasted, Δ, args::Vararg{Any,N}) where N
-  Δargs = ntuple(i -> getpartial.(Δ, b.data, i), Val{N})
-  foreach((x, Δ) -> @back(x, unbroadcast(x, Δ)), args, Δargs)
+function ∇broadcast(f, args::Vararg{Any,N}) where N
+  dargs = map((x,i) -> dualify(data(x), ntuple(j -> i==j, Val{N})), args, ntuple(identity, Val{N}))
+  out = broadcast(f, dargs...)
+  eltype(out) <: Dual || return out
+  y = value.(out)
+  back = function (Δ)
+    Δargs = ntuple(i -> getpartial.(Δ, out, i), Val{N})
+    map((x, Δ) -> unbroadcast(x, Δ), args, Δargs)
+  end
+  # So we can return non-tracked arrays
+  track(Call(back, args), y)
 end
 
 Base.Broadcast._containertype(::Type{<:TrackedReal}) = TrackedArray
@@ -415,4 +382,4 @@ Base.Broadcast.promote_containertype(ct, ::Type{TrackedArray}) = TrackedArray
 Base.Broadcast.broadcast_indices(::Type{TrackedArray}, A::Ref) = ()
 Base.Broadcast.broadcast_indices(::Type{TrackedArray}, A) = indices(A)
 
-Base.Broadcast.broadcast_c(f, ::Type{TrackedArray}, A, Bs...) = tracked_broadcast(f, A, Bs...)
+Base.Broadcast.broadcast_c(f, ::Type{TrackedArray}, A, Bs...) = ∇broadcast(f, A, Bs...)

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -66,7 +66,7 @@ Base.:(==)(x::TrackedArray, y::TrackedArray) = data(x) == data(y)
 
 Base.getindex(xs::TrackedArray, i...) = track(getindex, xs, i...)
 
-@grad function getindex(xs, i...)
+@grad function getindex(xs::AbstractArray, i...)
   data(xs)[i...], function (Δ)
     Δ′ = zero(xs)
     Δ′[i...] = data(Δ)

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -20,7 +20,7 @@ TrackedArray(c::Call, x::A) where A <: AbstractArray =
 TrackedArray(c::Call, x::A, Δ::A) where A <: AbstractArray =
   TrackedArray{eltype(A),ndims(A),A}(Tracked{A}(c, x, Δ), x, Δ)
 
-TrackedArray(x::AbstractArray) = TrackedArray(Call(nothing), x, zeros(x))
+TrackedArray(x::AbstractArray) = TrackedArray(Call(), x, zeros(x))
 
 Base.eltype(x::Type{<:TrackedArray{T}}) where T <: Real = TrackedReal{T}
 
@@ -101,7 +101,7 @@ function back(::typeof(_repeat), Δ, xs::TrackedArray, inner, outer)
     Δ′ = similar(xs.data)
     Δ′ .= 0
     S = size(xs.data)
-    
+
     # Loop through each element of Δ, calculate source dimensions, accumulate into Δ′
     for (dest_idx, val) in enumerate(IndexCartesian(), Δ)
         # First, round dest_idx[dim] to nearest gridpoint defined by inner[dim], then

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -23,7 +23,7 @@ end
 
 function back_(c::Call, Δ)
   Δs = c.func(Δ)
-  (Δs isa Tuple && length(Δs) == length(c.args)) ||
+  (Δs isa Tuple && length(Δs) >= length(c.args)) ||
     error("Gradient is not a tuple of length $(length(c.args))")
   foreach((x, Δ) -> istracked(x) && back(x, Δ), c.args, Δs)
 end
@@ -47,13 +47,6 @@ end
 
 back(x, Δ) = back(tracker(x), Δ)
 back(x::Void, Δ) = error("Can't backpropagate through `nothing`")
-
-macro back(x, Δ)
-  quote
-    x = $(esc(x))
-    istracked(x) && back(x, $(esc(Δ)))
-  end
-end
 
 # Interface methods
 

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -52,6 +52,8 @@ back(x::Void, Δ) = error("Can't backpropagate through `nothing`")
 
 # TODO: if an error occurs in `back` the refcounts will be broken
 # and `back` will silently fail to update.
+# Refcounts are also probably not safe in some situations (e.g. back called
+# from within a backpropagator)
 
 function back!(x::Tracked, Δ)
   scan(x)
@@ -59,3 +61,88 @@ function back!(x::Tracked, Δ)
 end
 
 back!(x, Δ) = back!(tracker(x), Δ)
+
+# Out-of-place gradients
+
+struct Params
+  params::IdSet
+  Params(xs) = new(IdSet(xs))
+end
+
+@forward Params.params Base.start, Base.next, Base.done
+
+struct Grads
+  grads::ObjectIdDict
+end
+
+Grads() = Grads(ObjectIdDict())
+
+Base.getindex(g::Grads, x::Tracked) = g.grads[x]
+function Base.getindex(g::Grads, x)
+  istracked(x) || error("Object not tracked: $x")
+  g[tracker(x)]
+end
+
+@forward Grads.grads Base.setindex!, Base.haskey
+
+accum!(g::Grads, x, Δ) = g[x] = haskey(g, x) ? g[x] + Δ : Δ
+
+function back_(g::Grads, c::Call, Δ)
+  Δs = c.func(Δ)
+  (Δs isa Tuple && length(Δs) >= length(c.args)) ||
+    error("Gradient is not a tuple of length $(length(c.args))")
+  foreach((x, Δ) -> istracked(x) && back(g, x, Δ), c.args, Δs)
+end
+
+back_(g::Grads, ::Call{Void}, Δ) = nothing
+
+function back(g::Grads, x::Tracked, Δ)
+  x.isleaf && (accum!(g, x, Δ); return)
+  ref = x.ref -= 1
+  if ref > 0 || haskey(g, x)
+    accum!(g, x, Δ)
+    ref == 0 && back_(g, x.f, g[x])
+  else
+    ref == 0 && back_(g, x.f, Δ)
+  end
+  return
+end
+
+back(g::Grads, x, Δ) = back(g, tracker(x), Δ)
+back(g::Grads, x::Void, Δ) = error("Can't backpropagate through `nothing`")
+
+function forward(f, ps::Params)
+  y = f()
+  y, function (Δ)
+    g = Grads()
+    if istracked(y)
+      scan(y)
+      back(g, y, Δ)
+    end
+    for p in ps
+      haskey(g, tracker(p)) ||
+        (g[tracker(p)] = init_grad(data(p)))
+    end
+    return g
+  end
+end
+
+function forward(f, args...)
+  args = param.(args)
+  y, back = forward(() -> f(args...), Params(args))
+  y, Δ -> getindex.(back(Δ), args)
+end
+
+function losscheck(x)
+  x isa Real || error("Function output is not scalar")
+  isinf(x) && error("Loss is infinite")
+  isnan(x) && error("Loss is NaN")
+end
+
+function gradient(f, args...)
+  y, back = forward(f, args...)
+  losscheck(y)
+  return back(1)
+end
+
+derivative(f, x) = gradient(f, x)[1]

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -72,9 +72,17 @@ end
 
 @forward Params.params Base.start, Base.next, Base.done
 
+function Base.show(io::IO, ps::Params)
+  print(io, "Params([")
+  join(io, ps.params, ", ")
+  print(io, "])")
+end
+
 struct Grads
   grads::ObjectIdDict
 end
+
+Base.show(io::IO, ps::Grads) = println(io, "Grads(...)")
 
 Grads() = Grads(ObjectIdDict())
 

--- a/src/tracker/idset.jl
+++ b/src/tracker/idset.jl
@@ -1,0 +1,25 @@
+struct IdSet{T} <: AbstractSet{T}
+  dict::ObjectIdDict
+  IdSet{T}() where T = new(ObjectIdDict())
+end
+
+Base.eltype{T}(::IdSet{T}) = T
+
+IdSet() = IdSet{Any}()
+
+Base.push!{T}(s::IdSet{T}, x::T) = (s.dict[x] = nothing; s)
+Base.delete!{T}(s::IdSet{T}, x::T) = (delete!(s.dict, x); s)
+Base.in(x, s::IdSet) = haskey(s.dict, x)
+
+(::Type{IdSet{T}}){T}(xs) = push!(IdSet{T}(), xs...)
+
+IdSet(xs) = IdSet{eltype(xs)}(xs)
+
+Base.collect(s::IdSet) = Base.collect(keys(s.dict))
+Base.similar(s::IdSet, T::Type) = IdSet{T}()
+
+@forward IdSet.dict Base.length
+
+Base.start(s::IdSet) = start(keys(s.dict))
+Base.next(s::IdSet, st) = next(keys(s.dict), st)
+Base.done(s::IdSet, st) = done(keys(s.dict), st)

--- a/src/tracker/numeric.jl
+++ b/src/tracker/numeric.jl
@@ -15,4 +15,4 @@ end
 
 gradcheck(f, xs...) =
   all(isapprox.(ngradient(f, xs...),
-                gradient(f, xs...), rtol = 1e-5, atol = 1e-5))
+                data.(gradient(f, xs...)), rtol = 1e-5, atol = 1e-5))

--- a/src/tracker/numeric.jl
+++ b/src/tracker/numeric.jl
@@ -1,9 +1,3 @@
-function gradient(f, xs...)
-  xs = param.(xs)
-  back!(f(xs...))
-  grad.(xs)
-end
-
 function ngradient(f, xs::AbstractArray...)
   grads = zeros.(xs)
   for (x, Δ) in zip(xs, grads), i in 1:length(x)

--- a/src/tracker/scalar.jl
+++ b/src/tracker/scalar.jl
@@ -50,17 +50,17 @@ for (M, f, arity) in DiffRules.diffrules()
   arity == 1 || continue
   @eval begin
     @grad $M.$f(a::Real) =
-      $M.$f(a), Δ -> (Δ * $(DiffRules.diffrule(M, f, :(data(a)))),)
+      $M.$f(data(a)), Δ -> (Δ * $(DiffRules.diffrule(M, f, :a)),)
     $M.$f(a::TrackedReal) = track($M.$f, a)
   end
 end
 
 for (M, f, arity) in DiffRules.diffrules()
   arity == 2 || continue
-  da, db = DiffRules.diffrule(M, f, :(data(a)), :(data(b)))
+  da, db = DiffRules.diffrule(M, f, :a, :b)
   f = :($M.$f)
   @eval begin
-    @grad $f(a::Real, b::Real) = $f(a, b), Δ -> (Δ * $da, Δ * $db)
+    @grad $f(a::Real, b::Real) = $f(data(a), data(b)), Δ -> (Δ * $da, Δ * $db)
     $f(a::TrackedReal, b::TrackedReal)  = track($f, a, b)
     $f(a::TrackedReal, b::Real) = track($f, a, b)
     $f(a::Real, b::TrackedReal) = track($f, a, b)
@@ -111,5 +111,5 @@ function scan(c::Call{typeof(collect)})
 end
 
 function back_(c::Call{typeof(collect)}, Δ)
-  foreach(back, c.args[1], Δ)
+  foreach(back, c.args[1], data(Δ))
 end

--- a/src/tracker/scalar.jl
+++ b/src/tracker/scalar.jl
@@ -100,13 +100,13 @@ back(::typeof(getindex), Δ, t, i) =
 
 function collect(xs)
   xs = Base.collect(xs)
-  track(Call(collect, xs), data.(xs))
+  track(Call(collect, (xs,)), data.(xs))
 end
 
 function scan(c::Call{typeof(collect)})
   foreach(scan, c.args[1])
 end
 
-function back(::typeof(collect), Δ, xs)
-  foreach((x, Δ) -> @back(x, Δ), xs, Δ)
+function back_(c::Call{typeof(collect)}, Δ)
+  foreach((x, Δ) -> istracked(x) && back(x, Δ), c.args[1], Δ)
 end

--- a/src/treelike.jl
+++ b/src/treelike.jl
@@ -1,4 +1,5 @@
 import Adapt: adapt
+import .Tracker: IdSet
 
 children(x) = ()
 mapchildren(f, x) = x
@@ -20,9 +21,7 @@ function mapleaves(f, x; cache = ObjectIdDict())
   cache[x] = isleaf(x) ? f(x) : mapchildren(x -> mapleaves(f, x, cache = cache), x)
 end
 
-using DataFlow: OSet
-
-function prefor(f, x; seen = OSet())
+function prefor(f, x; seen = IdSet())
   x ∈ seen && return
   f(x)
   foreach(x -> prefor(f, x, seen = seen), children(x))

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -1,5 +1,5 @@
 using Flux.Tracker, Base.Test, NNlib
-using Flux.Tracker: TrackedReal, gradcheck, grad
+using Flux.Tracker: TrackedReal, gradcheck, grad, derivative, checkpoint
 using NNlib: conv
 
 gradtest(f, xs::AbstractArray...) = gradcheck((xs...) -> sum(sin.(f(xs...))), xs...)
@@ -239,6 +239,18 @@ end
   y = Tracker.hook(-, x)
   back!(y)
   @test grad(x) == -1
+end
+
+@testset "Checkpointing" begin
+  count = 0
+  function mul(a, b)
+    count += 1
+    a * b
+  end
+  @test derivative(x -> mul(5, x), 3) == 5
+  @test count == 1
+  @test derivative(x -> checkpoint(mul, 5, x), 3) == 5
+  @test count == 3
 end
 
 end #testset

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -111,6 +111,7 @@ end
 
 @test gradtest(x -> permutedims(x, [3,1,2]), rand(4,5,6))
 
+# TODO unreliable
 @test gradtest(x -> repmat(x, 5,5), rand(4,5))
 @test gradtest(x -> repmat(x, 5), rand(4,5))
 
@@ -230,6 +231,14 @@ Tracker.back!(b)
   z = xy[1]*xy[2]
   back!(z)
   @test grad.((x,y)) == (3, 2)
+end
+
+# Gradient Hooks
+@testset "Hooks" begin
+  x = param(2)
+  y = Tracker.hook(-, x)
+  back!(y)
+  @test grad(x) == -1
 end
 
 end #testset


### PR DESCRIPTION
This is something of a PSA, as this patch is badly breaking for any custom derivative implementations. I don't think this is overly common, so I think it's best if we just help fix those up as they come along.

I've overhauled the internal gradient definition API to more cleanly separate gradient definitions from `Tracked` interception. This should make the eventual switch to a better AD non-breaking (just clean out the interception cruft and you're done).

- [x] CUDNN
- [x] Docs updates