### PR TITLE
WIP - NNPACK support

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -39,4 +39,9 @@ include("data/Data.jl")
 
 @require CuArrays include("cuda/cuda.jl")
 
+if NNlib.nnpack_available()
+	info("NNPACK found.")
+	include("NNPACK.jl")
+end
+
 end # module

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -40,7 +40,7 @@ include("data/Data.jl")
 @require CuArrays include("cuda/cuda.jl")
 
 if NNlib.nnpack_available()
-	info("NNPACK found.")
+	println("NNPACK found.")
 	include("NNPACK.jl")
 end
 

--- a/src/NNPACK.jl
+++ b/src/NNPACK.jl
@@ -1,10 +1,11 @@
 function (c::Conv)(x)
   # TODO: breaks gpu broadcast :(
   # ndims(x) == ndims(c.weight)-1 && return squeezebatch(c(reshape(x, size(x)..., 1)))
+  σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
 
-  if c.σ == Flux.relu
+  if σ == Flux.relu
   	NNlib.NNPACK.conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 1, bias = c.bias)
   else
-  	c.σ.(NNlib.NNPACK.conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 0, bias = c.bias))
+  	σ.(NNlib.NNPACK.conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 0, bias = c.bias))
   end
 end

--- a/src/NNPACK.jl
+++ b/src/NNPACK.jl
@@ -14,9 +14,9 @@ function (c::Conv)(x)
   # ndims(x) == ndims(c.weight)-1 && return squeezebatch(c(reshape(x, size(x)..., 1)))
   σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
   wt = copy(c.weight.data)
-  @show σ
+  # @show σ
   if σ == NNlib.relu
-  	println("Here")
+  	# println("Here")
   	NNlib.NNPACK.convo(x, wt, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 1)
   else
   	println("There")

--- a/src/NNPACK.jl
+++ b/src/NNPACK.jl
@@ -1,0 +1,10 @@
+function (c::Conv)(x)
+  # TODO: breaks gpu broadcast :(
+  # ndims(x) == ndims(c.weight)-1 && return squeezebatch(c(reshape(x, size(x)..., 1)))
+
+  if c.σ == Flux.relu
+  	NNlib.NNPACK.conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 1, bias = c.bias)
+  else
+  	c.σ.(NNlib.NNPACK.conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 0, bias = c.bias))
+  end
+end

--- a/src/NNPACK.jl
+++ b/src/NNPACK.jl
@@ -1,6 +1,10 @@
+import Flux.Tracker: istracked, back, @back
+import NNlib.NNPACK.convo
+import NNlib.NNPACK.∇conv_data
+import NNlib.NNPACK.∇conv_filter
 import NNlib.conv
-using NNlib: NNPACK
-using Flux: Tracker
+# import NNlib: NNPACK
+# import NNlib: NNPACK.∇conv_data, NNPACK.∇conv_filter
 
 struct Conv{N,F,A,V}
   σ::F
@@ -11,14 +15,26 @@ struct Conv{N,F,A,V}
   dilation::NTuple{N,Int}
 end
 
-_conv(x, w, stride, pad, dilation, activation, bias) = NNlib.NNPACK.convo(x, w, bias, stride = stride, pad = pad, dilation = dilation, activation = activation)
+macro back(x, Δ)
+  quote
+    x = $(esc(x))
+    istracked(x) && back(x, $(esc(Δ)))
+  end
+end
 
-conv(x::TrackedArray{<:Real,N}, w::TrackedArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
+function _conv(x, w, stride, pad, dilation, activation, bias) 
+	println("here 2")
+	NNlib.NNPACK.convo(x, w, bias, stride = stride, pad = pad, dilation = dilation, activation = activation)
+end
+
+function conv(x, w, bias; stride = 1, pad = 0, dilation = 1, activation = 0)
+  println("here 1")
   Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
-conv(x::AbstractArray{<:Real,N}, w::TrackedArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
-  Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
-conv(x::TrackedArray{<:Real,N}, w::AbstractArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
-  Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
+end
+# conv(x::AbstractArray{<:Real,N}, w::Tracker.TrackedArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
+#   Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
+# conv(x::Tracker.TrackedArray{<:Real,N}, w::AbstractArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
+#   Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
 
 function (c::Conv)(x)
   # TODO: breaks gpu broadcast :(
@@ -34,8 +50,15 @@ function (c::Conv)(x)
   end
 end
 
-
-function back(::typeof(_conv), Δ, x, w, stride, pad, dilation)
-  Tracker.@back(x, NNlib.NNPACK.∇conv_data(Δ, data(x), data(w); stride = stride, pad = pad, dilation = dilation))
-  Tracker.@back(w, NNlib.NNPACK.∇conv_filter(Δ, data(x), data(w); stride = stride, pad = pad, dilation = dilation))
+function back(::typeof(_conv), Δ, x, w, stride, pad, dilation, extras...)
+  println("here 3")
+  @show stride
+  @show pad
+  @show dilation
+  @show extras[2]
+  # a = ∇conv_data(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1])
+  println("here 4")
+  # @show a
+  @back(x, NNlib.NNPACK.∇conv_data(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1]))
+  @back(w, NNlib.NNPACK.∇conv_filter(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1]))
 end

--- a/src/NNPACK.jl
+++ b/src/NNPACK.jl
@@ -23,12 +23,12 @@ macro back(x, Δ)
 end
 
 function _conv(x, w, stride, pad, dilation, activation, bias) 
-	println("here 2")
+	# println("here 2")
 	NNlib.NNPACK.convo(x, w, bias, stride = stride, pad = pad, dilation = dilation, activation = activation)
 end
 
 function conv(x, w, bias; stride = 1, pad = 0, dilation = 1, activation = 0)
-  println("here 1")
+  # println("here 1")
   Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
 end
 # conv(x::AbstractArray{<:Real,N}, w::Tracker.TrackedArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
@@ -45,20 +45,20 @@ function (c::Conv)(x)
   	# println("Here")
   	conv(x, c.weight, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 1)
   else
-  	println("There")
+  	# println("There")
   	σ.(conv(x, c.weight, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 0))
   end
 end
 
 function back(::typeof(_conv), Δ, x, w, stride, pad, dilation, extras...)
-  println("here 3")
-  @show stride
-  @show pad
-  @show dilation
-  @show extras[2]
+  # println("here 3")
+  # @show stride
+  # @show pad
+  # @show dilation
+  # @show extras[2]
   # a = ∇conv_data(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1])
-  println("here 4")
+  # println("here 4")
   # @show a
   @back(x, NNlib.NNPACK.∇conv_data(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1], activation = extras[1]))
-  @back(w, NNlib.NNPACK.∇conv_filter(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1]))
+  @back(w, NNlib.NNPACK.∇conv_filter(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1], activation = extras[1]))
 end

--- a/src/NNPACK.jl
+++ b/src/NNPACK.jl
@@ -1,11 +1,25 @@
+using NNlib: NNPACK
+
+struct Conv{N,F,A,V}
+  σ::F
+  weight::A
+  bias::V
+  stride::NTuple{N,Int}
+  pad::NTuple{N,Int}
+  dilation::NTuple{N,Int}
+end
+
 function (c::Conv)(x)
   # TODO: breaks gpu broadcast :(
   # ndims(x) == ndims(c.weight)-1 && return squeezebatch(c(reshape(x, size(x)..., 1)))
   σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
-
-  if σ == Flux.relu
-  	NNlib.NNPACK.conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 1, bias = c.bias)
+  wt = copy(c.weight.data)
+  @show σ
+  if σ == NNlib.relu
+  	println("Here")
+  	NNlib.NNPACK.convo(x, wt, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 1)
   else
-  	σ.(NNlib.NNPACK.conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 0, bias = c.bias))
+  	println("There")
+  	σ.(NNlib.NNPACK.convo(x, wt, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 0))
   end
 end

--- a/src/NNPACK.jl
+++ b/src/NNPACK.jl
@@ -1,4 +1,6 @@
+import NNlib.conv
 using NNlib: NNPACK
+using Flux: Tracker
 
 struct Conv{N,F,A,V}
   σ::F
@@ -9,17 +11,31 @@ struct Conv{N,F,A,V}
   dilation::NTuple{N,Int}
 end
 
+_conv(x, w, stride, pad, dilation, activation, bias) = NNlib.NNPACK.convo(x, w, bias, stride = stride, pad = pad, dilation = dilation, activation = activation)
+
+conv(x::TrackedArray{<:Real,N}, w::TrackedArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
+  Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
+conv(x::AbstractArray{<:Real,N}, w::TrackedArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
+  Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
+conv(x::TrackedArray{<:Real,N}, w::AbstractArray{<:Real,N}, bias; stride = 1, pad = 0, dilation = 1, activation = 0) where N =
+  Tracker.track(_conv, x, w, stride, pad, dilation, activation, bias)
+
 function (c::Conv)(x)
   # TODO: breaks gpu broadcast :(
   # ndims(x) == ndims(c.weight)-1 && return squeezebatch(c(reshape(x, size(x)..., 1)))
   σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
-  wt = copy(c.weight.data)
   # @show σ
   if σ == NNlib.relu
   	# println("Here")
-  	NNlib.NNPACK.convo(x, wt, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 1)
+  	conv(x, c.weight, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 1)
   else
   	println("There")
-  	σ.(NNlib.NNPACK.convo(x, wt, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 0))
+  	σ.(conv(x, c.weight, c.bias, stride = c.stride, pad = c.pad, dilation = c.dilation, activation = 0))
   end
+end
+
+
+function back(::typeof(_conv), Δ, x, w, stride, pad, dilation)
+  Tracker.@back(x, NNlib.NNPACK.∇conv_data(Δ, data(x), data(w); stride = stride, pad = pad, dilation = dilation))
+  Tracker.@back(w, NNlib.NNPACK.∇conv_filter(Δ, data(x), data(w); stride = stride, pad = pad, dilation = dilation))
 end

--- a/src/NNPACK.jl
+++ b/src/NNPACK.jl
@@ -59,6 +59,6 @@ function back(::typeof(_conv), Δ, x, w, stride, pad, dilation, extras...)
   # a = ∇conv_data(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1])
   println("here 4")
   # @show a
-  @back(x, NNlib.NNPACK.∇conv_data(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1]))
+  @back(x, NNlib.NNPACK.∇conv_data(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1], activation = extras[1]))
   @back(w, NNlib.NNPACK.∇conv_filter(Δ, data(x), data(w); stride = stride[1], pad = pad[1], dilation = dilation[1]))
 end

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -41,6 +41,10 @@ function (c::Conv)(x)
   # TODO: breaks gpu broadcast :(
   # ndims(x) == ndims(c.weight)-1 && return squeezebatch(c(reshape(x, size(x)..., 1)))
   σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
+  @show typeof(x)
+  @show typeof(c.weight)
+  @show typeof(conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation) .+ b)
+  @show typeof(σ.(conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation) .+ b))
   σ.(conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation) .+ b)
 end
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -32,7 +32,7 @@ Conv(w::AbstractArray{T,N}, b::AbstractVector{T}, σ = identity;
 
 Conv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity; init = initn,
      stride = 1, pad = 0, dilation = 1) where N =
-  Conv(param(init(k..., ch...)), param(zeros(ch[2])), σ,
+  Conv(param(init(k..., ch...)), param(zeros(Float32, ch[2])), σ,
        stride = stride, pad = pad, dilation = dilation)
 
 Flux.treelike(Conv)

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -41,10 +41,10 @@ function (c::Conv)(x)
   # TODO: breaks gpu broadcast :(
   # ndims(x) == ndims(c.weight)-1 && return squeezebatch(c(reshape(x, size(x)..., 1)))
   σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
-  @show typeof(x)
-  @show typeof(c.weight)
-  @show typeof(conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation) .+ b)
-  @show typeof(σ.(conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation) .+ b))
+  # @show typeof(x)
+  # @show typeof(c.weight)
+  # @show typeof(conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation) .+ b)
+  # @show typeof(σ.(conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation) .+ b))
   σ.(conv(x, c.weight, stride = c.stride, pad = c.pad, dilation = c.dilation) .+ b)
 end
 

--- a/src/tracker/Tracker.jl
+++ b/src/tracker/Tracker.jl
@@ -2,7 +2,7 @@ module Tracker
 
 import Base: ==
 
-export TrackedArray, TrackedVector, TrackedMatrix, param, back!
+export TrackedArray, TrackedVector, TrackedMatrix, param, back!, @back
 
 tracker(x) = nothing
 
@@ -52,8 +52,8 @@ include("scalar.jl")
 include("array.jl")
 include("numeric.jl")
 
-param(x::Number) = TrackedReal(float(x))
-param(xs::AbstractArray) = TrackedArray(float.(xs))
+param(x::Number) = TrackedReal(Cfloat(x))
+param(xs::AbstractArray) = TrackedArray(Cfloat.(xs))
 
 import NNlib.cudata
 import Adapt.adapt

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -63,7 +63,7 @@ Base.:(==)(x::TrackedArray, y::TrackedArray) = data(x) == data(y)
 Base.getindex(xs::TrackedArray, i...) = track(getindex, xs, i...)
 
 function back(::typeof(getindex), Δ, xs::TrackedArray, i...)
-  Δ′ = zeros(xs.data)
+  Δ′ = zeros(Float32, xs.data)
   Δ′[i...] = Δ
   @back(xs, Δ′)
 end

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -1,3 +1,10 @@
+using NNlib
+
+if NNlib.nnpack_available()
+  println("NNPACK found.")
+  include("../NNPACK.jl")
+end
+
 init_grad(x) = zero(x)
 zero_grad!(x) = zero(x)
 zero_grad!(x::AbstractArray) = (x .= 0)
@@ -21,7 +28,19 @@ function scan(x)
   return
 end
 
-back_(f, y, args...) = back(f, args...)
+function back_(f, y, args...)
+  # @show silentlyze(args)
+  println("\n")
+  @show f
+  @show length(args)
+  for i in args
+    @show typeof(i)
+    # @show i
+    # println()
+  end
+  println("\n")
+  back(f, args...)
+end
 back_(c::Call, y, Δ) = back_(c.func, y, Δ, c.args...)
 back_(::Call{Void}, y, Δ) = nothing
 

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -30,15 +30,15 @@ end
 
 function back_(f, y, args...)
   # @show silentlyze(args)
-  println("\n")
-  @show f
-  @show length(args)
-  for i in args
-    @show typeof(i)
-    # @show i
-    # println()
-  end
-  println("\n")
+  # println("\n")
+  # @show f
+  # @show length(args)
+  # for i in args
+  #   @show typeof(i)
+  #   # @show i
+  #   # println() 
+  # end
+  # println("\n")
   back(f, args...)
 end
 back_(c::Call, y, Δ) = back_(c.func, y, Δ, c.args...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 # Arrays
 
-initn(dims...) = randn(dims...)/100
-glorot_uniform(dims...) = (rand(dims...) - 0.5)*sqrt(24.0/(sum(dims)))
-glorot_normal(dims...) = (randn(dims...)*sqrt(2.0/sum(dims)))
+initn(dims...) = randn(Float32, dims...)/100
+glorot_uniform(dims...) = (rand(Float32, dims...) - 0.5f0)*sqrt(24.0f0/(sum(dims)))
+glorot_normal(dims...) = (randn(Float32, dims...)*sqrt(2.0/sum(dims)))
 
 unsqueeze(xs, dim) = reshape(xs, (size(xs)[1:dim-1]..., 1, size(xs)[dim:end]...))
 


### PR DESCRIPTION
This makes certain changes needed to bring about NNPACK support to Flux. For now, support has been provided to `conv`. Since NNPACK supports only `Float32`, datatypes have been changed at necessary places.

The PR on integration of NNPACK with NNlib.jl can be found here: https://github.com/FluxML/NNlib.jl/pull/56.