### PR TITLE
Gradients for prod(x; dims) and cumprod(x), which take keywords & allow for zero entries

### DIFF
--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -16,10 +16,35 @@ gradtest(f, dims...) = gradtest(f, rand.(dims)...)
 @test gradtest((w, x) -> w*x', randn(5,5), randn(5,5))
 
 @test gradtest(x -> sum(x, (2, 3)), (3,4,5))
-@test gradtest(x -> prod(x, (2, 3)), (3,4,5))
-@test gradtest(x -> prod(x, 2), (3,4,5))
+  
+@test gradtest(x -> prod(x, dims=(2, 3)), (3,4,5))
+@test gradtest(x -> prod(x, dims=1), (3,4,5))
+@test gradtest(x -> prod(x, dims=1), (3,))
 @test gradtest(x -> prod(x), (3,4,5))
+@test gradtest(x -> prod(x), (3,))
 
+rz(dims...) = begin x = rand(dims...); x[2]=0; x end
+@test gradtest(x -> prod(x, dims=(2, 3)), rz(3,4,5))
+@test gradtest(x -> prod(x, dims=1), rz(3,4,5))
+@test gradtest(x -> prod(x, dims=1), rz(3,))
+@test gradtest(x -> prod(x), rz(3,4,5))
+@test gradtest(x -> prod(x), rz(3,))
+
+@test gradtest(x -> prod(x, dims=2), rz(3,4)') ## Adjoint tests fall-back methods
+@test gradtest(x -> prod(x, dims=2), rz(3,)')
+@test gradtest(x -> prod(x), rz(3,4)')
+@test gradtest(x -> prod(x), rz(3,)')
+
+@test gradtest(x -> cumprod(x, dims=2), (3,4,5))
+@test gradtest(x -> cumprod(x, dims=1), (3,)) 
+@test gradtest(x -> cumprod(x), (3,))
+
+@test gradtest(x -> cumprod(x, dims=2), rz(3,4,5))
+@test gradtest(x -> cumprod(x, dims=1), rz(3,)) 
+@test gradtest(x -> cumprod(x), rz(3,))
+
+  
+  
 @test gradtest(x -> softmax(x).*(1:3), 3)
 @test gradtest(x -> softmax(x).*(1:3), (3,5))
 @test gradtest(x -> logsoftmax(x).*(1:3), 3)

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -17,6 +17,7 @@ gradtest(f, dims...) = gradtest(f, rand.(dims)...)
 
 @test gradtest(x -> sum(x, (2, 3)), (3,4,5))
 @test gradtest(x -> prod(x, (2, 3)), (3,4,5))
+@test gradtest(x -> prod(x, 2), (3,4,5))
 @test gradtest(x -> prod(x), (3,4,5))
 
 @test gradtest(x -> softmax(x).*(1:3), 3)


### PR DESCRIPTION
In the tagged version 0.5.3, there is a clever function for gradient of `prod(x)` allowing for it to have zero entries. This PR adds a similar function for `prod(x,dim)`, fixing the following problem: 
```
Flux.Tracker.gradcheck(prod, [1.2, 2.3, 0.0, 4.5]) ## true
Flux.Tracker.gradcheck(z -> sum(prod(z,1)), [1.2, 2.3, 0.0, 4.5]) ## false
```
On master branch, this neat function was (by mistake?) applied to `prod(z,dim)` instead, reversing false <--> true in the above. 

I don't fully understand what `(nobacksies(:sum,` is doing so I left it alone. 

I also left a naiive fallback function for `prod(x, dims)` with several `dims=(2,3)` etc. to pass tests. Perhaps I should add tests with zeros. 

However these functions are much slower than the naiive gradient --- 1000 times slower for me on Julia 0.6.3, although only 40 times slower on 0.7:
```
∇prod(x) = prod(x) ./ x

∇prod0(x::Vector) = .*(circshift.([x], 1:length(x)-1)...)

∇prod0(x::Array, dim::Int) =.*(circshift.([x], tuple.(Iterators.repeated(0,dim-1)...,1:size(x,dim)-1))...)

using BenchmarkTools
rr = rand(5)

@btime ∇prod($rr) 
@btime ∇prod0($rr)
@btime ∇prod0($rr,1)
```
For `prod(x)` at least, it would be easy to add an if statement that only runs the slow version `prod(x)==0`. For `prod(x,dim)` this starts to sound messy. 