### PR TITLE
Fix issues #354, #174, #301, #323, add Unittest for basic.jl, ignore .DS_Store and Project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/site/
 docs/flux.css
 deps
 Manifest.toml
+Project.toml
+.DS_Store

--- a/docs/src/models/regularisation.md
+++ b/docs/src/models/regularisation.md
@@ -1,13 +1,15 @@
 # Regularisation
 
 Applying regularisation to model parameters is straightforward. We just need to
-apply an appropriate regulariser, such as `vecnorm`, to each model parameter and
+apply an appropriate regulariser, such as Lp-norm, to each model parameter and
 add the result to the overall loss.
 
 For example, say we have a simple regression.
 
 ```julia
+using Flux
 using Flux: crossentropy
+using LinearAlgebra: norm
 m = Dense(10, 5)
 loss(x, y) = crossentropy(softmax(m(x)), y)
 ```
@@ -15,12 +17,12 @@ loss(x, y) = crossentropy(softmax(m(x)), y)
 We can regularise this by taking the (L2) norm of the parameters, `m.W` and `m.b`.
 
 ```julia
-penalty() = vecnorm(m.W) + vecnorm(m.b)
+penalty() = norm(m.W) + norm(m.b) # default: L2-norm
 loss(x, y) = crossentropy(softmax(m(x)), y) + penalty()
 ```
 
 When working with layers, Flux provides the `params` function to grab all
-parameters at once. We can easily penalise everything with `sum(vecnorm, params)`.
+parameters at once. We can easily penalise everything with `sum(norm, params(m))`, which is equivalent to `sum(map(norm,params(m)))`.
 
 ```julia
 julia> params(m)
@@ -28,7 +30,7 @@ julia> params(m)
  param([0.355408 0.533092; … 0.430459 0.171498])
  param([0.0, 0.0, 0.0, 0.0, 0.0])
 
-julia> sum(vecnorm, params(m))
+julia> sum(norm, params(m))
 26.01749952921026 (tracked)
 ```
 
@@ -40,23 +42,23 @@ m = Chain(
   Dense(128, 32, relu),
   Dense(32, 10), softmax)
 
-loss(x, y) = crossentropy(m(x), y) + sum(vecnorm, params(m))
+loss(x, y) = crossentropy(m(x), y) + sum(norm, params(m))
 
 loss(rand(28^2), rand(10))
 ```
 
-One can also easily add per-layer regularisation via the `activations` function:
+One can also easily add per-layer regularisation :
 
 ```julia
 julia> c = Chain(Dense(10,5,σ),Dense(5,2),softmax)
 Chain(Dense(10, 5, NNlib.σ), Dense(5, 2), NNlib.softmax)
 
-julia> activations(c, rand(10))
+julia> Flux.activations(c, rand(10))
 3-element Array{Any,1}:
  param([0.71068, 0.831145, 0.751219, 0.227116, 0.553074])
  param([0.0330606, -0.456104])
  param([0.61991, 0.38009])
 
-julia> sum(vecnorm, ans)
+julia> sum(norm, ans)
 2.639678767773633 (tracked)
 ```

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -1,4 +1,4 @@
-import Base: *, ==
+import Base: *, ==, ≈
 
 import LinearAlgebra
 using Statistics
@@ -63,6 +63,10 @@ Base.similar(x::TrackedArray, T::Type) = similar(data(x), T)
 x::TrackedArray == y = data(x) == y
 y == x::TrackedArray = y == data(x)
 x::TrackedArray == y::TrackedArray = data(x) == data(y)
+
+x::TrackedArray ≈ y = data(x) ≈ y
+y ≈ x::TrackedArray = y ≈ data(x)
+x::TrackedArray ≈ y::TrackedArray = data(x) ≈ data(y)
 
 # Array Stdlib
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -1,0 +1,42 @@
+using Test
+using Flux: activations
+
+
+@testset "basic" begin
+    @testset "Chain" begin
+        @test_nowarn Chain(Dense(10, 5, σ),Dense(5, 2), softmax)
+        @test_nowarn Chain(Dense(10, 5, σ),Dense(5, 2), softmax)(randn(10))
+    end
+
+    @testset "Dense" begin
+        @test  length(Dense(10, 5)(randn(10))) == 5
+        @test_throws DimensionMismatch Dense(10, 5)(randn(1))
+        Random.seed!(0)
+        @test all(Dense(10, 1)(randn(10)).data .≈ 1.1774348382231168)
+        Random.seed!(0)
+        @test all(Dense(10, 2)(randn(10)).data .≈ [  -0.3624741476779616
+            -0.46724765394534323])
+
+        @test_throws DimensionMismatch Dense(10, 5)(1)
+    end
+
+    @testset "Diagonal" begin
+        @test length(Flux.Diagonal(10)(randn(10))) == 10
+        @test length(Flux.Diagonal(10)(1)) == 10
+        @test length(Flux.Diagonal(10)(randn(1))) == 10
+        @test_throws DimensionMismatch Flux.Diagonal(10)(randn(2))
+        Random.seed!(0)
+        @test all(Flux.Diagonal(2)(randn(2)).data .≈ [ 0.6791074260357777,
+            0.8284134829000359])
+    end
+
+    @testset "activations" begin
+        c = Chain(Dense(10, 5, σ),Dense(5, 2), softmax)
+        # Single layer activation
+        @test length(activations(c[1], randn(10))) == 1
+        @test isa(activations(c[1], randn(10)), Array{Any,1})
+        # Chain activation
+        @test length(activations(c, randn(10))) == 3
+        @test isa(activations(c, randn(10)), Array{Any,1})
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ include("utils.jl")
 include("tracker.jl")
 include("layers/normalisation.jl")
 include("layers/stateless.jl")
+include("layers/basic.jl")
 include("optimise.jl")
 include("data.jl")
 


### PR DESCRIPTION
## Bug fix #354
1. change the denifition of struct `Dense` to make it less general
2. add a `(a::Dense)(x::Number) = a([x])` to prevent broadcasting of scalar value

## Bug fixed: #174
Rewrite the `Flux.activations` function such that the last code sample in [Regularisation](https://github.com/FluxML/Flux.jl/blob/d6a75e1289488945ade1cfa8867717fe1ed19557/docs/src/models/regularisation.md) works as expected

## fix Issue #301
rewrite the tutorial code sample in regularisation.md where `vecnorm` raise MethodError, as is in [Issue #301](https://github.com/FluxML/Flux.jl/issues/301)

## fix Issue #323
Support ≈ for TrackedArray

## add Unittest for basic.jl

## add .DS_Store, Project.toml to .gitignore