### PR TITLE
indices was renamed to axes in Julia 0.7

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,7 +24,7 @@ julia> chunk(1:10, 3)
 """
 chunk(xs, n) = collect(Iterators.partition(xs, ceil(Int, length(xs)/n)))
 
-batchindex(xs, i) = (reverse(Base.tail(reverse(indices(xs))))..., i)
+batchindex(xs, i) = (reverse(Base.tail(reverse(axes(xs))))..., i)
 
 """
     frequencies(xs)


### PR DESCRIPTION
Some functions related to batches do not work on Julia 1.0 because the `indices` function has been renamed to `axes` (see https://github.com/JuliaLang/julia/pull/25057).

This is a minimal change so `batchindex` and `batchseq` can be used again in 1.0.