### PR TITLE
add inv/ldivide/rdivide + test

### DIFF
--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -1,6 +1,8 @@
 import Base: *
 
 import LinearAlgebra
+import LinearAlgebra: inv, \, /
+
 using Statistics
 using LinearAlgebra: Transpose, Adjoint, diagm, diag
 
@@ -204,6 +206,41 @@ end
 Base.kron(a::TrackedMatrix, b::TrackedMatrix)  = _kron(a, b)
 Base.kron(a::TrackedMatrix, b::AbstractMatrix) = _kron(a, b)
 Base.kron(a::AbstractMatrix, b::TrackedMatrix) = _kron(a, b)
+
+
+inv(A::TrackedArray) = Tracker.track(inv, A)
+@grad function inv(A)
+    return inv(Tracker.data(A)), function (Δ)
+        Ainv = inv(A)
+        ∇A = - Ainv' * Δ * Ainv'
+        return (∇A, )
+    end
+end
+
+#       (/) rdivide
+A::TrackedArray     / B::TrackedArray     = Tracker.track(/, A, B)
+A::AbstractVecOrMat / B::TrackedArray     = Tracker.track(/, A, B)
+A::TrackedArray     / B::AbstractVecOrMat = Tracker.track(/, A, B)
+@grad function (A / B)
+    return Tracker.data(A) / Tracker.data(B), function (Δ)
+        Binv = inv(B)
+        ∇B = - Binv' * A' * Δ * Binv'
+        return (Δ * Binv',  ∇B)
+    end
+end
+
+#       (\) ldivide  (left vec divide needs more work to resolve dispatch ambiguity)
+A::TrackedArray     \ B::TrackedArray     = Tracker.track(\, A, B)
+A::AbstractArray    \ B::TrackedArray     = Tracker.track(\, A, B)
+A::TrackedArray     \ B::AbstractVecOrMat = Tracker.track(\, A, B)
+@grad function (A \ B)
+    return Tracker.data(A) \ Tracker.data(B), function (Δ)
+        Ainv = inv(A)
+        ∇A = - Ainv' * Δ * B' * Ainv'
+        return (∇A,  Ainv' * Δ)
+    end
+end
+
 
 # Reductions
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -129,6 +129,11 @@ end
 
 @test gradtest(f-> Matrix(Diagonal(f)), rand(3))
 
+@test gradtest(W -> inv(log.(W * W)), (5,5))
+@test gradtest((A, B) -> A / B , (1,5), (5,5))
+@test gradtest((A, B) -> log.(A * A) / exp.(B * B), (5,5), (5,5))
+@test gradtest((A, B) -> log.(A * A) \ exp.(B * B), (5,5), (5,5))
+
 @testset "mean" begin
   @test gradtest(mean, rand(2, 3))
 


### PR DESCRIPTION
Added array functions:

* `inv`
* `\` (ldivide)
* `/` (rdivide)

I've added tests with a few extra nonlinearities thrown in as I've been caught out before calculating gradients which were correct only for *linear* input. A few things to be aware of:

* Not familiar with PRs, so apologies if I've done anything wrong.
* ldivide/rdivide are more numerically stable than their (mathematically) equivalent operations `inv(A)*B`, `A*inv(B)` (respectively), but for the time being, their *backward* pass is implemented using the inverses directly as I've found it significantly faster than multiple `lu` etc. solves using the `\`,`/` operators.
* My implementation currently requires the relevant arguments to be invertible even though `LinearAlgebra.\` and `LinearAlgebra./` do not (returning the least squares solution in this case). A work around is to require users to input the least squares projection (e.g. `inv(A'*A)*A'*B`) directly rather than using this MATLAB-style shortcut. Implementing the derivative of this is a little messy, and I think it's important for users to understand the overhead in what they're implicitly asking the AD engine to do.
* Thanks to Mike for help overloading the `/`,`\` operators.