### PR TITLE
Make crossentropy and binarycrossentropy numerically stable

### DIFF
--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -5,7 +5,7 @@ using NNlib: logsoftmax, logσ
 mse(ŷ, y) = sum((ŷ .- y).^2)/length(y)
 
 function crossentropy(ŷ::AbstractVecOrMat, y::AbstractVecOrMat;
-                      weight = 1, ϵ = eps(log(one(eltype(ŷ)))))
+                      weight = 1, ϵ = eps(one(log(one(eltype(ŷ))))))
     if typeof(ϵ) == eltype(ŷ)
         clamp!(ŷ, 0 + ϵ, 1 - ϵ)
     else
@@ -32,7 +32,7 @@ Return `-y*log(ŷ + ϵ) - (1-y)*log(1-ŷ + ϵ)`. The ϵ term provides numerica
     0.352317
     0.86167
 """
-function binarycrossentropy(ŷ, y; ϵ = eps(log(one(eltype(ŷ)))))
+function binarycrossentropy(ŷ, y; ϵ = eps(one(log(one(eltype(ŷ))))))
     ŷ= clamp(ŷ, 0 + ϵ, 1 - ϵ)
 
     -y*log(ŷ) - (1 - y)*log(1 - ŷ)

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -17,7 +17,7 @@ function logitcrossentropy(logŷ::AbstractVecOrMat, y::AbstractVecOrMat; weight
 end
 
 """
-    binarycrossentropy(ŷ, y; ϵ = eps(log(one(eltype(ŷ)))))
+    binarycrossentropy(ŷ, y; ϵ = eps(float(eltype(ŷ))))
 
 Return `-y*log(ŷ + ϵ) - (1-y)*log(1-ŷ + ϵ)`. The ϵ term provides numerical stability.
 

--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -376,8 +376,7 @@ unbroadcast(x::AbstractArray, Δ) =
     trim(x, sum(Δ, dims = ntuple(i -> size(x, i) == 1 ? i : ndims(Δ)+1, Val(ndims(Δ)))))
 
 unbroadcast(x::Number, Δ) = sum(Δ)
-unbroadcast(x::Base.RefValue{<:Function}, _) = nothing
-unbroadcast(x::Base.RefValue{<:Val}, _) = nothing
+unbroadcast(x::Base.RefValue, _) = nothing
 
 dual(x, p) = x
 dual(x::Real, p) = Dual(x, p)

--- a/test/layers/stateless.jl
+++ b/test/layers/stateless.jl
@@ -22,6 +22,7 @@ const ϵ = 1e-7
 
   @testset "crossentropy" begin
     @test crossentropy(ŷ, y) ≈ lossvalue
+    @test !isinf(crossentropy([1.0, 0.0], [0.0, 1.0]))
   end
 
   @testset "logitcrossentropy" begin


### PR DESCRIPTION
Follows the implementation in Keras

The slightly complicated way of getting the epsilon is so that yhat does not have to contain Float