### PR TITLE
Match paper for Adam implementation and make epsilon use more consistent

### DIFF
--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -149,7 +149,7 @@ function update!(o::ADAGrad, x, Δ)
   η = o.eta
   acc = get!(o.acc, x, fill(ϵ, size(x)))::typeof(x)
   @. acc += Δ^2
-  @. Δ *= η / √(acc + ϵ)
+  @. Δ *= η / (√acc + ϵ)
 end
 
 """
@@ -169,7 +169,7 @@ function update!(o::ADADelta, x, Δ)
   ρ = o.rho
   acc, Δacc = get!(o.state, x, (zero(x), zero(x)))
   @. acc = ρ * acc + (1 - ρ) * Δ^2
-  @. Δ *= √(Δacc + ϵ) / √(acc + ϵ)
+  @. Δ *= √Δacc/ (√acc + ϵ)
   @. Δacc = ρ * Δacc + (1 - ρ) * Δ^2
   return Δ
 end
@@ -194,7 +194,7 @@ function update!(o::AMSGrad, x, Δ)
   @. mt = β[1] * mt + (1 - β[1]) * Δ
   @. vt = β[2] * vt + (1 - β[2]) * Δ ^ 2
   @. v̂t = max.(v̂t, vt)
-  @. Δ = η * mt / √v̂t
+  @. Δ = η * mt / (√v̂t + ϵ)
 end
 
 """
@@ -217,7 +217,7 @@ function update!(o::NADAM, x, Δ)
   mt, vt = get!(o.state, x, (zero(x), zero(x)))
   @. mt = β[1] * mt + (1 - β[1]) * Δ
   @. vt = β[2] * vt + (1 - β[2]) * Δ^2
-  @. Δ = (β[1] * mt / (1 - β[1] * β1p) + (1 - β[1]) * Δ / (1 - β1p)) / √(vt * β[2] / (1 - β2p) + ϵ) * η
+  @. Δ = (β[1] * mt / (1 - β[1] * β1p) + (1 - β[1]) * Δ / (1 - β1p)) / (√(vt * β[2] / (1 - β2p)) + ϵ) * η
   o.state[x] = (mt, vt, (β1p * β[1], β2p * β[2]))
   return Δ
 end


### PR DESCRIPTION
@CarloLucibello @tejank10 according to the papers, I think the epsilons are supposed to be outside the square roots in adam ~and nadam~, was there a reason you wanted to add the epsilon inside the sqrt in https://github.com/FluxML/Flux.jl/pull/224? Maybe to avoid sqrts of subnormal floating point values?

Adam: https://arxiv.org/abs/1412.6980v9
<img width="590" alt="adam_update" src="https://user-images.githubusercontent.com/854183/47264800-1d9e5c00-d569-11e8-8496-72528b7523a3.png">

~Nadam~ADAMW: https://arxiv.org/abs/1711.05101
<img width="357" alt="adamw_update" src="https://user-images.githubusercontent.com/854183/47264805-2e4ed200-d569-11e8-8cb5-bc8882af12b6.png">

Not sure how much of an issue this is in practice, but it does change the values if `vt` is small. Also with the epsilon inside the sqrt it's similar to using a default of 1e-4.

I think we should probably match the paper for Adam ~/Nadam~. It seems unlikely the moving averages of the variance of the gradients are going to be subnormal, but not 0, very often, but maybe there's something else I'm missing.

As a data point, from a brief squiz at the pytorch code [here](https://pytorch.org/docs/stable/_modules/torch/optim/adam.html) they keep epsilon outside the sqrt: `denom = exp_avg_sq.sqrt().add_(group['eps'])`

If we don't want this then it still might be a good idea to change the default epsilon to 1e-16.

I'm not 100% about rmsprop, adagrad and adadelta, but making them the same seems sensible so that the default value of epsilon for each of them is consistent.

edited: was looking at ADAMW not NADAM 🥇 these [two](https://openreview.net/forum?id=OM0jvwB8jIp57ZJjtNEZ) [versions](http://cs229.stanford.edu/proj2015/054_report.pdf) of the Nadam paper have the epsilons inside and outside the sqrt respectively, so ¯\_(ツ)_/¯