### PR TITLE
Add dataloader

### DIFF
--- a/src/dataloader.jl
+++ b/src/dataloader.jl
@@ -1,0 +1,59 @@
+using Random:randperm!
+
+"""
+    DataLoader(dataset...; batchsize::Int=100, shuffle=true)
+
+DataLoader provides iterators over the dataset.
+
+```julia
+X = rand(10, 1000)
+Y = rand(1, 1000)
+
+m = Dense(10, 1)
+loss(x, y) = Flux.mse(m(x), y)
+opt = ADAM(params(m))
+
+trainloader = DataLoader(X, Y, batchsize=256, shuffle=true)
+
+Flux.train!(loss, trainloader, opt)
+```
+"""
+struct DataLoader
+  dataset::Tuple
+  batchsize::Int
+  shuffle::Bool
+  indices::Vector{Int}
+  n::Int
+end
+
+function DataLoader(dataset::NTuple{N,AbstractArray}; batchsize::Int=100, shuffle=false) where N
+  l = last.(size.(dataset))
+  n = first(l)
+  all(n .== l) || throw(DimensionMismatch("All data should have the same length."))
+  indices = collect(1:n)
+  shuffle && randperm!(indices)
+  DataLoader(dataset, batchsize, shuffle, indices, n)
+end
+
+DataLoader(dataset...; batchsize::Int=100, shuffle=false) =
+  DataLoader(dataset, batchsize=batchsize, shuffle=shuffle)
+
+function Base.iterate(it::DataLoader, start=1)
+  if start > it.n
+      it.shuffle && randperm!(it.indices)
+      return nothing
+  end
+  nextstart = min(start + it.batchsize, it.n + 1)
+  i = it.indices[start:nextstart-1]
+  element = Tuple(copy(selectdim(x, ndims(x), i)) for x in it.dataset)
+  return element, nextstart
+end
+
+Base.length(it::DataLoader) = it.n
+Base.eltype(it::DataLoader) = typeof(it.dataset)
+
+function Base.show(io::IO, it::DataLoader)
+  print(io, "DataLoader(dataset size = $(it.n)")
+  print(io, ", batchsize = $(it.batchsize), shuffle = $(it.shuffle)")
+  print(io, ")")
+end

--- a/src/dataloader.jl
+++ b/src/dataloader.jl
@@ -1,7 +1,7 @@
 using Random:randperm!
 
 """
-    DataLoader(dataset...; batchsize::Int=100, shuffle=true)
+    DataLoader(dataset::AbstractArray...; batchsize::Int, shuffle::Bool)
 
 DataLoader provides iterators over the dataset.
 
@@ -26,7 +26,7 @@ struct DataLoader
   n::Int
 end
 
-function DataLoader(dataset::NTuple{N,AbstractArray}; batchsize::Int=100, shuffle=false) where N
+function DataLoader(dataset::Tuple{AbstractArray, Vararg{AbstractArray}}; batchsize::Int, shuffle::Bool)
   l = last.(size.(dataset))
   n = first(l)
   all(n .== l) || throw(DimensionMismatch("All data should have the same length."))
@@ -35,7 +35,7 @@ function DataLoader(dataset::NTuple{N,AbstractArray}; batchsize::Int=100, shuffl
   DataLoader(dataset, batchsize, shuffle, indices, n)
 end
 
-DataLoader(dataset...; batchsize::Int=100, shuffle=false) =
+DataLoader(dataset::AbstractArray...; batchsize::Int, shuffle::Bool) =
   DataLoader(dataset, batchsize=batchsize, shuffle=shuffle)
 
 function Base.iterate(it::DataLoader, start=1)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -168,3 +168,6 @@ be used for aesthetic purposes, or by recovering Python users.
 macro jit(ex)
   esc(ex)
 end
+
+include("dataloader.jl")
+export DataLoader


### PR DESCRIPTION
Adding a PyTorch-like data loader that provides (random) iterators over the dataset.

The usage is quite simple:
```julia
X = rand(10, 1000)
Y = rand(1, 1000)
dataloader = DataLoader(X, Y, batchsize=256, shuffle=true)

for (x, y) in dataloader
    ...
end

# and work seamlessly with the train!()
Flux.train!(loss, trainloader, opt)
``` 