### PR TITLE
Use promotion in binary derivatives to avoid issues with irrationals

### DIFF
--- a/src/tracker/array.jl
+++ b/src/tracker/array.jl
@@ -223,7 +223,7 @@ end
 A::TrackedArray     / B::TrackedArray     = Tracker.track(/, A, B)
 A::AbstractVecOrMat / B::TrackedArray     = Tracker.track(/, A, B)
 A::TrackedArray     / B::AbstractVecOrMat = Tracker.track(/, A, B)
-@grad function (A / B)
+@grad function (A::AbstractVecOrMat / B::AbstractVecOrMat)
     return Tracker.data(A) / Tracker.data(B), function (Δ)
         Binv = inv(B)
         ∇B = - Binv' * A' * Δ * Binv'
@@ -235,7 +235,7 @@ end
 A::TrackedArray     \ B::TrackedArray     = Tracker.track(\, A, B)
 A::AbstractArray    \ B::TrackedArray     = Tracker.track(\, A, B)
 A::TrackedArray     \ B::AbstractVecOrMat = Tracker.track(\, A, B)
-@grad function (A \ B)
+@grad function (A::AbstractVecOrMat \ B::AbstractVecOrMat)
     return Tracker.data(A) \ Tracker.data(B), function (Δ)
         Ainv = inv(A)
         ∇A = - Ainv' * Δ * B' * Ainv'

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -284,4 +284,11 @@ end
   @test count == 3
 end
 
+@testset "promotion of irrationals" begin
+  @test Tracker.gradient(t -> π + t, 1.0f0) === (1.0f0,)
+  @test Tracker.gradient(t -> t + π, 1.0f0) === (1.0f0,)
+  @test Tracker.data.(Tracker.gradient(t -> π * t, 1.0f0)) === (Float32(π),)
+  @test Tracker.data.(Tracker.gradient(t -> t * π, 1.0f0)) === (Float32(π),)
+end
+
 end #testset


### PR DESCRIPTION
Man, autodiff code is convoluted. All the closures. Besides the issue with size `zero` of irrationals there was also another promotion issue where the irrational caused promotion to `Float64` even when the input is `Float32.
```julia
julia> Tracker.derivative(t -> π*t, Float32(1.0))
3.141592653589793
```
This should be fixed with this PR together with the `zero` issue.