### PR TITLE
Destroy AD graph when doing in-place gradients

### DIFF
--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -26,8 +26,8 @@ function back_(c::Call, Δ, once)
   foreach((x, d) -> back(x, d, once), c.args, data.(Δs))
 end
 
-back_(::Call{Nothing}, _, _) = nothing
-back_(::Call{Missing}, _, _) = error("`back!` was already used")
+back_(::Call{Nothing}, Δ, once) = nothing
+back_(::Call{Missing}, Δ, once) = error("`back!` was already used")
 
 accum!(x, Δ) = x .+ Δ
 accum!(x::AbstractArray, Δ) = (x .+= Δ)
@@ -49,7 +49,7 @@ function back(x::Tracked, Δ, once)
   return
 end
 
-back(::Nothing, _, _) = return
+back(::Nothing, Δ, once) = return
 
 # Interface methods
 
@@ -94,11 +94,11 @@ Grads() = Grads(IdDict())
 Grads(ps::Params) = Grads(IdDict(tracker(p) => init_grad(data(p)) for p in ps))
 
 Base.getindex(g::Grads, x::Tracked) = g.grads[x]
+
 function Base.getindex(g::Grads, x)
   istracked(x) || error("Object not tracked: $x")
   g[tracker(x)]
 end
-
 
 accum!(g::Grads, x, Δ) = g[x] = haskey(g, x) ? g[x] .+ Δ : Δ
 

--- a/src/tracker/scalar.jl
+++ b/src/tracker/scalar.jl
@@ -10,10 +10,10 @@ tracker(x::TrackedReal) = x.tracker
 
 track(f::Call, x::Real) = TrackedReal(x, Tracked{typeof(x)}(f, zero(x)))
 
-function back!(x::TrackedReal)
+function back!(x::TrackedReal; once = true)
     isinf(x) && error("Loss is Inf")
     isnan(x) && error("Loss is NaN")
-    return back!(x, 1)
+    return back!(x, 1, once = once)
 end
 
 function Base.show(io::IO, x::TrackedReal)
@@ -123,8 +123,8 @@ function scan(c::Call{typeof(collect)})
   foreach(scan, c.args[1])
 end
 
-function back_(c::Call{typeof(collect)}, Δ)
-  foreach(back, c.args[1], data(Δ))
+function back_(c::Call{typeof(collect)}, Δ, once)
+  foreach((x, d) -> back(x, d, once), c.args[1], data(Δ))
 end
 
 function back_(g::Grads, c::Call{typeof(collect)}, Δ)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -147,9 +147,9 @@ function jacobian(m,x)
     n  = length(x)
     J  = Matrix{eltype(x)}(undef,n,k)
     for i = 1:k
-        Flux.back!(y[i]) # Populate gradient accumulator
+        Flux.back!(y[i], once = false) # Populate gradient accumulator
         J[:,i] = xp.grad
-        xp.grad .*= 0 # Reset gradient accumulator
+        xp.grad .= 0 # Reset gradient accumulator
     end
     J'
 end

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -232,10 +232,10 @@ end
 @testset "Intermediates" begin
   x = param([1])
   l = sum((x .+ x).^2)
-  Flux.back!(l)
+  Flux.back!(l, once = false)
   @test x.grad == [8]
   x.grad .= 0
-  Flux.back!(l)
+  Flux.back!(l, once = false)
   @test x.grad == [8]
 end
 


### PR DESCRIPTION
This is technically breaking if you call `back!` more than once on the same tracked output, but it's pretty easy to fix.

Dismantling the graph as we go along allows memory to be reclaimed as we do the backwards pass, which is likely to be useful especially for larger convnets and such. @avik-pal would be great if you could check for an improvement with this branch.