### PR TITLE
Add missing eps overload for TrackedReal

### DIFF
--- a/src/tracker/lib/real.jl
+++ b/src/tracker/lib/real.jl
@@ -39,6 +39,7 @@ for op in [:(==), :≈, :<]
 end
 
 Base.eps(x::TrackedReal) = eps(data(x))
+Base.eps(::Type{TrackedReal{T}}) where T = eps(T)
 
 for f in :[isinf, isnan, isfinite].args
   @eval Base.$f(x::TrackedReal) = Base.$f(data(x))


### PR DESCRIPTION
`eps` can be called on the number type as well, and this is missing from the TrackedReal overloads.