### PR TITLE
Make Chain immutable

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -2,6 +2,7 @@ module Flux
 
 # Zero Flux Given
 
+using Base: tail
 using MacroTools, Juno, Requires, Reexport, Statistics, Random
 using MacroTools: @forward
 


### PR DESCRIPTION
With this change the default chain object is type-inferrable, can be used on TPUs etc. It's slightly breaking though, since we removed `push!`.