### PR TITLE
Supply useful arguments to the Flux.train! callback function `cb`.

### DIFF
--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -1,15 +1,16 @@
 # Training
 
-To actually train a model we need three things:
+To actually train a model we need four things:
 
 * A *objective function*, that evaluates how well a model is doing given some input data.
+* A collection of parameters that define the behavior of the model.
 * A collection of data points that will be provided to the objective function.
 * An [optimiser](optimisers.md) that will update the model parameters appropriately.
 
 With these we can call `Flux.train!`:
 
 ```julia
-Flux.train!(objective, data, opt)
+Flux.train!(objective, params, data, opt)
 ```
 
 There are plenty of examples in the [model zoo](https://github.com/FluxML/model-zoo).
@@ -26,7 +27,7 @@ m = Chain(
 loss(x, y) = Flux.mse(m(x), y)
 
 # later
-Flux.train!(loss, data, opt)
+Flux.train!(loss, Flux.params(m), data, opt)
 ```
 
 The objective will almost always be defined in terms of some *cost function* that measures the distance of the prediction `m(x)` from the target `y`. Flux has several of these built in, like `mse` for mean squared error or `crossentropy` for cross entropy loss, but you can calculate it however you want.
@@ -78,7 +79,7 @@ julia> @epochs 2 Flux.train!(...)
 `train!` takes an additional argument, `cb`, that's used for callbacks so that you can observe the training process. For example:
 
 ```julia
-train!(objective, data, opt, cb = () -> println("training"))
+train!(loss, params, data, opt, cb = () -> println("training"))
 ```
 
 Callbacks are called for every batch of training data. You can slow this down using `Flux.throttle(f, timeout)` which prevents `f` from being called more than once every `timeout` seconds.
@@ -89,6 +90,6 @@ A more typical callback might look like this:
 test_x, test_y = # ... create single batch of test data ...
 evalcb() = @show(loss(test_x, test_y))
 
-Flux.train!(objective, data, opt,
+Flux.train!(objective, params, data, opt,
             cb = throttle(evalcb, 5))
 ```

--- a/src/optimise/Optimise.jl
+++ b/src/optimise/Optimise.jl
@@ -3,7 +3,8 @@ module Optimise
 export train!,
 	SGD, Descent, ADAM, Momentum, Nesterov, RMSProp,
 	ADAGrad, AdaMax, ADADelta, AMSGrad, NADAM, ADAMW,
-	InvDecay, ExpDecay, WeightDecay, stop, Optimiser
+	InvDecay, ExpDecay, WeightDecay, stop, Optimiser,
+	CallbackInfo
 
 include("optimisers.jl")
 include("train.jl")

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -45,7 +45,7 @@ function stop()
 end
 
 """
-    train!(model, loss, data, opt)
+    train!(loss, params, data, opt)
 
 For each datapoint `d` in `data` computes the gradient of `loss(d...)` through
 backpropagation and calls the optimizer `opt`.
@@ -54,7 +54,7 @@ Takes a callback as keyword argument `cb`. For example, this will print "trainin
 every 10 seconds:
 
 ```julia
-Flux.train!(model, loss, data, opt,
+Flux.train!(loss, params, data, opt,
             cb = throttle(() -> println("training"), 10))
 ```
 

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -48,7 +48,7 @@ end
               (),
               Iterators.repeated((), 100),
               Descent(),
-              cb = Flux.throttle(() -> (i > 3 && Flux.stop()), 1))
+              cb = Flux.throttle((_) -> (i > 3 && Flux.stop()), 1))
 
   @test 3 < i < 50
 


### PR DESCRIPTION
First shot at this.

The first commit is not directly related, but rather does some cleanups of the Flux.train! docs to reflect the new parameters.

The second commit adds callback info. I'm not too happy with the CallbackInfo struct's fieldnames. Also, maybe we should return `data(loss)` instead of  `loss`, since directly returning loss carries the risk that someone inadvertently messes with the parameters?

I tested this with the `xor1.jl` example in the modle-zoo, where I adapted the `evalcb` function:

```julia
evalcb = (info) -> begin
    dump(info)
    @show batch_loss(val)
end
```

Fixes #489.