### PR TITLE
Make eltype of TrackedArray a TrackedReal{T}

### DIFF
--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -6,7 +6,7 @@ import LinearAlgebra: inv, \, /
 using Statistics
 using LinearAlgebra: Transpose, Adjoint, diagm, diag
 
-struct TrackedArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
+struct TrackedArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{TrackedReal{T},N}
   tracker::Tracked{A}
   data::A
   grad::A


### PR DESCRIPTION
It breaks some array interface assumptions to have indexing return a value that doesn't match the prescribed `eltype` of the array. This changes it so that way the `eltype` of a TrackedArray is the same as the type of the elements that come out.