### PR TITLE
TrackedArray interface matches standard usage with immutable arrays

### DIFF
--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -114,6 +114,16 @@ Base.:-(xs::TrackedArray) = track(-, xs)
 
 @grad -(xs) = -data(xs), Δ -> (-Δ,)
 
+function Base.:+(A::TrackedArray, J::LinearAlgebra.UniformScaling)
+  n = LinearAlgebra.checksquare(A)
+  A + J.λ * TrackedArray(Matrix(LinearAlgebra.I,n,n))
+end
+
+function Base.:-(J::LinearAlgebra.UniformScaling, A::TrackedArray)
+    n = LinearAlgebra.checksquare(A)
+    J.λ * TrackedArray(Matrix(LinearAlgebra.I,n,n)) - A
+end
+
 Base.transpose(xs::TrackedArray) = track(transpose, xs)
 Base.adjoint(xs::TrackedArray) = track(adjoint, xs)
 

--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -35,7 +35,7 @@ Base.eltype(x::Type{<:TrackedArray{T}}) where T <: Real = TrackedReal{T}
 
 Base.convert(::Type{T}, x::S) where {T<:TrackedArray,S<:T} = x
 
-Base.convert(::Type{<:TrackedArray}, x::TrackedArray) =
+Base.convert(::Type{T}, x::TrackedArray) where T<:TrackedArray =
   error("Not implemented: convert $(typeof(x)) to $T")
 
 Base.convert(::Type{<:TrackedArray{T,N,A}}, x::AbstractArray) where {T,N,A} =

--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -6,7 +6,7 @@ import LinearAlgebra: inv, \, /
 using Statistics
 using LinearAlgebra: Transpose, Adjoint, diagm, diag
 
-struct TrackedArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
+struct TrackedArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{TrackedReal{T},N}
   tracker::Tracked{A}
   data::A
   grad::A

--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -79,6 +79,8 @@ Base.similar(x::TrackedArray, dims::Union{AbstractUnitRange,Integer}...) =
 
 Base.similar(x::TrackedArray, T::Type) = similar(data(x), T)
 
+Base.zero(x::Flux.Tracker.TrackedArray) = 0*x
+
 for op in [:(==), :≈]
     @eval Base.$op(x::TrackedArray, y::AbstractArray) = Base.$op(data(x), y)
     @eval Base.$op(x::AbstractArray, y::TrackedArray) = Base.$op(x, data(y))

--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -79,7 +79,7 @@ Base.similar(x::TrackedArray, dims::Union{AbstractUnitRange,Integer}...) =
 
 Base.similar(x::TrackedArray, T::Type) = similar(data(x), T)
 
-Base.zero(x::Flux.Tracker.TrackedArray) = 0*x
+Base.zero(x::TrackedArray) = 0*x
 
 for op in [:(==), :≈]
     @eval Base.$op(x::TrackedArray, y::AbstractArray) = Base.$op(data(x), y)


### PR DESCRIPTION
Changes which were made:

- `zero` keeps type like StaticArrays
- UniformScaling overloads work around the generic `setindex!`
- `eltype(x) == typeof(x[i])` for TrackedArrays
- Fixed a random error message that failed because T wasn't defined

Together, this makes TrackedArrays work in many generic codes, including the DiffEq non-stiff and stiff integrators.