### PR TITLE
Configurable dtypes for all layers and initializers

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -71,8 +71,8 @@ end
 Dense(W, b) = Dense(W, b, identity)
 
 function Dense(in::Integer, out::Integer, σ = identity;
-               initW = glorot_uniform, initb = zeros)
-  return Dense(param(initW(out, in)), param(initb(out)), σ)
+               initW = glorot_uniform, initb = zeros, dtype = FloatX)
+  return Dense(param(initW(dtype, out, in)), param(initb(dtype, out)), σ)
 end
 
 @treelike Dense
@@ -103,8 +103,8 @@ struct Diagonal{T}
   β::T
 end
 
-Diagonal(in::Integer; initα = ones, initβ = zeros) =
-  Diagonal(param(initα(in)), param(initβ(in)))
+Diagonal(in::Integer; initα = ones, initβ = zeros, dtype = FloatX) =
+  Diagonal(param(initα(dtype, in)), param(initβ(dtype, in)))
 
 @treelike Diagonal
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -31,8 +31,9 @@ Conv(w::AbstractArray{T,N}, b::AbstractVector{T}, σ = identity;
   Conv(σ, w, b, expand.(sub2(Val(N)), (stride, pad, dilation))...)
 
 Conv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;
-     init = glorot_uniform,  stride = 1, pad = 0, dilation = 1) where N =
-  Conv(param(init(k..., ch...)), param(zeros(ch[2])), σ,
+     init = glorot_uniform,  stride = 1, pad = 0, dilation = 1,
+     dtype = FloatX) where N =
+  Conv(param(init(dtype, k..., ch...)), param(zeros(dtype, ch[2])), σ,
        stride = stride, pad = pad, dilation = dilation)
 
 @treelike Conv
@@ -84,15 +85,17 @@ DepthwiseConv(w::AbstractArray{T,N}, b::AbstractVector{T}, σ = identity;
   DepthwiseConv(σ, w, b, expand.(sub2(Val(N)), (stride, pad))...)
 
 DepthwiseConv(k::NTuple{N,Integer}, ch::Integer, σ = identity; init = initn,
-     stride = 1, pad = 0) where N =
-  DepthwiseConv(param(init(k..., 1, ch)), param(zeros(ch)), σ,
+     stride = 1, pad = 0, dtype = FloatX) where N =
+  DepthwiseConv(param(init(dtype, k..., 1, ch)), param(zeros(dtype, ch)), σ,
        stride = stride, pad = pad)
 
 DepthwiseConv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity; init = initn,
      stride::NTuple{N,Integer} = map(_->1,k),
-     pad::NTuple{N,Integer} = map(_->0,k)) where N =
-  DepthwiseConv(param(init(k..., ch[2], ch[1])), param(zeros(ch[2]*ch[1])), σ,
-       stride = stride, pad = pad)
+     pad::NTuple{N,Integer} = map(_->0,k),
+     dtype = FloatX) where N =
+   DepthwiseConv(param(init(dtype, k..., ch[2], ch[1])),
+                 param(zeros(dtype, ch[2]*ch[1])), σ,
+                 stride = stride, pad = pad)
 
 @treelike DepthwiseConv
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -82,9 +82,9 @@ mutable struct RNNCell{F,A,V}
 end
 
 RNNCell(in::Integer, out::Integer, σ = tanh;
-        init = glorot_uniform) =
-  RNNCell(σ, param(init(out, in)), param(init(out, out)),
-          param(zeros(out)), param(init(out)))
+        init = glorot_uniform, dtype = FloatX) =
+  RNNCell(σ, param(init(dtype, out, in)), param(init(dtype, out, out)),
+          param(zeros(dtype, out)), param(init(dtype, out)))
 
 function (m::RNNCell)(h, x)
   σ, Wi, Wh, b = m.σ, m.Wi, m.Wh, m.b
@@ -121,9 +121,10 @@ mutable struct LSTMCell{A,V}
 end
 
 function LSTMCell(in::Integer, out::Integer;
-                  init = glorot_uniform)
-  cell = LSTMCell(param(init(out*4, in)), param(init(out*4, out)), param(zeros(out*4)),
-                  param(init(out)), param(init(out)))
+                  init = glorot_uniform, dtype = FloatX)
+  cell = LSTMCell(param(init(dtype, out*4, in)), param(init(dtype, out*4, out)),
+                  param(zeros(dtype, out*4)), param(init(dtype, out)),
+                  param(init(dtype, out)))
   cell.b.data[gate(out, 2)] .= 1
   return cell
 end
@@ -167,9 +168,9 @@ mutable struct GRUCell{A,V}
   h::V
 end
 
-GRUCell(in, out; init = glorot_uniform) =
-  GRUCell(param(init(out*3, in)), param(init(out*3, out)),
-          param(zeros(out*3)), param(init(out)))
+GRUCell(in, out; init = glorot_uniform, dtype = FloatX) =
+  GRUCell(param(init(dtype, out*3, in)), param(init(dtype, out*3, out)),
+          param(zeros(dtype, out*3)), param(init(dtype, out)))
 
 function (m::GRUCell)(h, x)
   b, o = m.b, size(h, 1)

--- a/src/tracker/lib/real.jl
+++ b/src/tracker/lib/real.jl
@@ -7,6 +7,7 @@ TrackedReal(x::Real) = TrackedReal(x, Tracked{typeof(x)}(Call(), zero(x)))
 
 data(x::TrackedReal) = x.data
 tracker(x::TrackedReal) = x.tracker
+Base.eltype(::Type{TrackedReal{T}}) where T = T
 
 track(f::Call, x::Real) = TrackedReal(x, Tracked{typeof(x)}(f, zero(x)))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,12 +1,19 @@
+# Float precision config
+# TODO: provide an option to configure at import time
+FloatX = Float32
+
 # Arrays
-glorot_uniform(dims...) = (rand(Float32, dims...) .- 0.5f0) .* sqrt(24.0f0/sum(dims))
-glorot_normal(dims...) = randn(Float32, dims...) .* sqrt(2.0f0/sum(dims))
+glorot_uniform(dtype::DataType, dims...) = (rand(dtype, dims...) .- 0.5f0) .* sqrt(24.0f0/sum(dims))
+glorot_normal(dtype::DataType, dims...) = randn(dtype, dims...) .* sqrt(2.0f0/sum(dims))
+
+glorot_uniform(dims...) = glorot_uniform(FloatX, dims...)
+glorot_normal(dims...) = glorot_normal(FloatX, dims...)
 
 ones(T::Type, dims...) = Base.ones(T, dims...)
 zeros(T::Type, dims...) = Base.zeros(T, dims...)
 
-ones(dims...) = Base.ones(Float32, dims...)
-zeros(dims...) = Base.zeros(Float32, dims...)
+ones(dims...) = Base.ones(FloatX, dims...)
+zeros(dims...) = Base.zeros(FloatX, dims...)
 
 unsqueeze(xs, dim) = reshape(xs, (size(xs)[1:dim-1]..., 1, size(xs)[dim:end]...))
 

--- a/test/dtype_test_utils.jl
+++ b/test/dtype_test_utils.jl
@@ -1,0 +1,15 @@
+all_dtype_equal(params, T) = all(eltype(eltype(p)) == T for p in params)
+
+"""
+    test_layer_dtype(treelike_factory)
+
+Takes a method that takes in `nothing`, `Float32`, or `Float64` and returns a
+treelike type, such as Dense.
+Ensures that the treelike's params are of the desired type.
+"""
+function test_layer_dtype(treelike_factory)
+  @test all_dtype_equal(params(treelike_factory(nothing)), Flux.FloatX)
+  for T in [Float32, Float64]
+    @test all_dtype_equal(params(treelike_factory(T)), T)
+  end
+end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -13,11 +13,12 @@ using Test, Random
         @test_throws MethodError Dense(10, 5)(1) # avoid broadcasting
         @test_throws MethodError Dense(10, 5).(randn(10)) # avoid broadcasting
 
+        test_dtype_works(T -> (T == nothing) ? Dense(10, 1) : Dense(10, 1, dtype = T))
+
         @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(1, 1)
         @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
         @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
         @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
-
     end
 
     @testset "Diagonal" begin
@@ -25,6 +26,8 @@ using Test, Random
         @test length(Flux.Diagonal(10)(1)) == 10
         @test length(Flux.Diagonal(10)(randn(1))) == 10
         @test_throws DimensionMismatch Flux.Diagonal(10)(randn(2))
+
+        test_dtype_works(T -> (T == nothing) ? Flux.Diagonal(10) : Flux.Diagonal(10, dtype = T))
 
         @test Flux.Diagonal(2)([1 2]) == [1 2; 1 2]
         @test Flux.Diagonal(2)([1,2]) == [1,2]

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -13,7 +13,7 @@ using Test, Random
         @test_throws MethodError Dense(10, 5)(1) # avoid broadcasting
         @test_throws MethodError Dense(10, 5).(randn(10)) # avoid broadcasting
 
-        test_dtype_works(T -> (T == nothing) ? Dense(10, 1) : Dense(10, 1, dtype = T))
+        test_layer_dtype(T -> (T == nothing) ? Dense(10, 1) : Dense(10, 1, dtype = T))
 
         @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(1, 1)
         @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
@@ -27,7 +27,7 @@ using Test, Random
         @test length(Flux.Diagonal(10)(randn(1))) == 10
         @test_throws DimensionMismatch Flux.Diagonal(10)(randn(2))
 
-        test_dtype_works(T -> (T == nothing) ? Flux.Diagonal(10) : Flux.Diagonal(10, dtype = T))
+        test_layer_dtype(T -> (T == nothing) ? Flux.Diagonal(10) : Flux.Diagonal(10, dtype = T))
 
         @test Flux.Diagonal(2)([1 2]) == [1 2; 1 2]
         @test Flux.Diagonal(2)([1,2]) == [1,2]

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -10,7 +10,7 @@ using Flux: maxpool, meanpool
 end
 
 @testset "CNN" begin
-  r = zeros(Float32, 28, 28, 1, 5)
+  r = zeros(Flux.FloatX, 28, 28, 1, 5)
   m = Chain(
     Conv((2, 2), 1=>16, relu),
     MaxPool((2,2)),
@@ -20,4 +20,6 @@ end
     Dense(288, 10), softmax)
 
   @test size(m(r)) == (10, 5)
+  @test all_dtype_equal(params(m), Flux.FloatX)
+  @test eltype(eltype(m(r))) == Flux.FloatX
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,8 @@ Random.seed!(0)
 # So we can use the system CuArrays
 insert!(LOAD_PATH, 2, "@v#.#")
 
+include("dtype_test_utils.jl")
+
 @testset "Flux" begin
 
 @info "Testing Basics"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -78,6 +78,20 @@ end
     @test std(v) > 0.9*sqrt(2/(n_in + n_out))
     @test std(v) < 1.1*sqrt(2/(n_in + n_out))
   end
+
+  # dtype tests
+  @testset "dtype" begin
+    n_in, n_out = 100, 100
+    for init in [glorot_uniform, glorot_normal]
+      for T in [nothing, Float32, Float64]
+        if T == nothing
+          @test eltype(init(n_in, n_out)) == Flux.FloatX
+        else
+          @test eltype(init(T, n_in, n_out)) == T
+        end
+      end
+    end
+  end
 end
 
 @testset "Params" begin


### PR DESCRIPTION
Hi
I thought Flux could benefit from easier configuration of dtypes, so I tried implementing something myself. 
I based the `FloatX` default dtype variable off of Theano: http://deeplearning.net/software/theano/library/config.html . 

Things I'm looking for feedback on:
* Currently there's no good way to set `FloatX`. Should we make `FloatX` configurable by environment variable or from a config variable? Is there a good way the user could set `FloatX` before all of the functions with optional argument `dtype=FloatX` get interpreted?
* This will break any user's initializers that do not have a `(::Type, size...)` method. Is that OK at this point?
* This is some of the first Julia code I've written, so interested in anywhere I violated best practice / code hygiene / etc.

Changes:
* All layers and initializers now optionally take a dtype argument.
* There is a new variable Flux.FloatX that defines the default
  floating point type (currently Float32).
* defined eltype(TrackedReal{T}) = T