### PR TITLE
Correct CuArrays requirements.

### DIFF
--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -4,7 +4,7 @@ Support for array operations on other hardware backends, like GPUs, is provided 
 
 For example, we can use `CuArrays` (with the `cu` converter) to run our [basic example](models/basics.md) on an NVIDIA GPU.
 
-(Note that you need to build Julia 0.6 from source and have CUDA available to use CuArrays – please see the [CUDAnative.jl](https://github.com/JuliaGPU/CUDAnative.jl) instructions for more details.)
+(Note that you need to have CUDA available to use CuArrays – please see the [CuArrays.jl (https://github.com/JuliaGPU/CuArrays.jl) instructions for more details.)
 
 ```julia
 using CuArrays


### PR DESCRIPTION
According to the CuArrays README, "CuArrays should work out-of-the-box on Julia 1.0."
Correct the outdated Julia 0.6 requirement. Also, update the instructions link to point to the
CuArrays.jl README, which has setup instructions (CUDAnative.jl's README doesn't).