### PR TITLE
Support random numbers as constants

### DIFF
--- a/src/tracker/lib/real.jl
+++ b/src/tracker/lib/real.jl
@@ -55,14 +55,9 @@ Base.promote_rule(::Type{TrackedReal{S}},::Type{T}) where {S,T} =
 
 using Random
 
-Random.rand(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},rand(T))
-Random.rand(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},rand(rng,T))
-
-Random.randn(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randn(T))
-Random.randn(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randn(rng,T))
-
-Random.randexp(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randexp(T))
-Random.randexp(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randexp(rng,T))
+for f in :[rand, randn, randexp].args
+  @eval Random.$f(rng::AbstractRNG,::Type{TrackedReal{T}}) where {T} = param(rand(rng,T))
+end
 
 using DiffRules, SpecialFunctions, NaNMath
 

--- a/src/tracker/lib/real.jl
+++ b/src/tracker/lib/real.jl
@@ -55,8 +55,19 @@ Base.promote_rule(::Type{TrackedReal{S}},::Type{T}) where {S,T} =
 
 using Random
 
+Random.rand(x::Flux.Tracker.TrackedReal} = rand(typeof(x))
+Random.rand(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},rand(T))
+Random.rand(rng::AbstractRNG,x::Flux.Tracker.TrackedReal} = rand(rng,typeof(x))
 Random.rand(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},rand(rng,T))
+
+Random.randn(x::Flux.Tracker.TrackedReal} = randn(typeof(x))
+Random.randn(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randn(T))
+Random.randn(rng::AbstractRNG,x::Flux.Tracker.TrackedReal} = randn(rng,typeof(x))
 Random.randn(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randn(rng,T))
+
+Random.randexp(x::Flux.Tracker.TrackedReal} = randexp(typeof(x))
+Random.randexp(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randexp(T))
+Random.randexp(rng::AbstractRNG,x::Flux.Tracker.TrackedReal} = randexp(rng,typeof(x))
 Random.randexp(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randexp(rng,T))
 
 using DiffRules, SpecialFunctions, NaNMath

--- a/src/tracker/lib/real.jl
+++ b/src/tracker/lib/real.jl
@@ -53,6 +53,12 @@ Base.float(x::TrackedReal) = x
 Base.promote_rule(::Type{TrackedReal{S}},::Type{T}) where {S,T} =
   TrackedReal{promote_type(S,T)}
 
+using Random
+
+Random.rand(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},rand(rng,T))
+Random.randn(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randn(rng,T))
+Random.randexp(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randexp(rng,T))
+
 using DiffRules, SpecialFunctions, NaNMath
 
 for (M, f, arity) in DiffRules.diffrules()

--- a/src/tracker/lib/real.jl
+++ b/src/tracker/lib/real.jl
@@ -55,19 +55,13 @@ Base.promote_rule(::Type{TrackedReal{S}},::Type{T}) where {S,T} =
 
 using Random
 
-Random.rand(x::Flux.Tracker.TrackedReal} = rand(typeof(x))
 Random.rand(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},rand(T))
-Random.rand(rng::AbstractRNG,x::Flux.Tracker.TrackedReal} = rand(rng,typeof(x))
 Random.rand(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},rand(rng,T))
 
-Random.randn(x::Flux.Tracker.TrackedReal} = randn(typeof(x))
 Random.randn(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randn(T))
-Random.randn(rng::AbstractRNG,x::Flux.Tracker.TrackedReal} = randn(rng,typeof(x))
 Random.randn(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randn(rng,T))
 
-Random.randexp(x::Flux.Tracker.TrackedReal} = randexp(typeof(x))
 Random.randexp(::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randexp(T))
-Random.randexp(rng::AbstractRNG,x::Flux.Tracker.TrackedReal} = randexp(rng,typeof(x))
 Random.randexp(rng::AbstractRNG,::Type{Flux.Tracker.TrackedReal{T}}) where {T} = convert(Flux.Tracker.TrackedReal{T},randexp(rng,T))
 
 using DiffRules, SpecialFunctions, NaNMath


### PR DESCRIPTION
This adds support for rngs, specifically `rand`, `randn`, and `randexp`, by treating the generated random numbers as constants. The resulting derivative is the strong derivative, i.e. the derivative defined w.r.t. the chosen sequence of random numbers. For example, when looking at geometric Brownian motion (https://en.wikipedia.org/wiki/Geometric_Brownian_motion) and throwing this through the DiffEq SDE solvers, the values that are outputted are the derivatives w.r.t. the parameters of the strong solution of the SDE. This has a number of useful properties for optimization, since adding noise and optimizing the strong solutions has been shown to give robustness to data noise and thus acts as a form of regularization (https://www.sciencedirect.com/science/article/pii/S0025556414000510). Practically, this would let someone inject random numbers into a neural net and the calculated gradient would be the same as though that sequence of random forcings were hard coded into the net. 