### PR TITLE
Preserve element type in stateless layers

### DIFF
--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -2,16 +2,21 @@ using NNlib: logsoftmax, logσ
 
 # Cost functions
 
-mse(ŷ, y) = sum((ŷ .- y).^2)/length(y)
+function mse(ŷ, y)
+  x = sum((ŷ .- y).^2)
+  return x/Tracker.tracked_eltype(x)(length(y))
+end
 
 function crossentropy(ŷ::AbstractVecOrMat, y::AbstractVecOrMat; weight = 1)
-  -sum(y .* log.(ŷ) .* weight) / size(y, 2)
+  x = -sum(y .* log.(ŷ) .* weight)
+  return x/Tracker.tracked_eltype(x)(size(y, 2))
 end
 
 @deprecate logloss(x, y) crossentropy(x, y)
 
 function logitcrossentropy(logŷ::AbstractVecOrMat, y::AbstractVecOrMat; weight = 1)
-  return -sum(y .* logsoftmax(logŷ) .* weight) / size(y, 2)
+  x = -sum(y .* logsoftmax(logŷ) .* weight)
+  return x/Tracker.tracked_eltype(x)(size(y, 2))
 end
 
 """

--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -494,3 +494,8 @@ if VERSION < v"1.1.0-DEV.548"
     end
   end
 end
+
+# Get the element type of an array or the element type of the inner array of a tracked array
+tracked_eltype(x) = eltype(x)
+tracked_eltype(x::TrackedArray) = eltype(data(x))
+tracked_eltype(x::TrackedReal{T}) where T = T


### PR DESCRIPTION
This should fix issues where Float32 weights and activations get suddenly switched to Float64 on the backwards pass.  MWE to show current problem:

```julia
using Flux

x = param(randn(Float32, 10, 10, 4, 4)
mp = MeanPool((10,10))
Flux.back!(Flux.mse(mp(x), mp(x)))
```

This currently errors out with:
```
ERROR: MethodError: no method matching ∇meanpool(::Array{Float64,4}, ::Array{Float32,4}, ::Array{Float32,4}, ::Tuple{Int64,Int64}; pad=(0, 0), stride=(10, 10))
```

This is because the backward pass of `mse()` is spuriously generating `Float64`'s.  I don't really understand why it is doing that, but this PR seems to fix it.