### PR TITLE
Fixed issue #542.

### DIFF
--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -1,7 +1,7 @@
 import Base: *
 
 import LinearAlgebra
-import LinearAlgebra: inv, det, \, /
+import LinearAlgebra: inv, det, logdet, logabsdet, \, /
 
 using Statistics
 using LinearAlgebra: Transpose, Adjoint, diagm, diag
@@ -126,6 +126,12 @@ Base.adjoint(xs::TrackedArray) = track(adjoint, xs)
 
 det(xs::TrackedArray) = track(det, xs)
 @grad det(xs) = det(data(xs)), Δ -> (Δ * det(xs) * transpose(inv(xs)),)
+
+logdet(xs::TrackedArray) = track(logdet, xs)
+@grad logdet(xs) = logdet(data(xs)), Δ -> (Δ * transpose(inv(xs)),)
+
+logabsdet(xs::TrackedArray) = track(logabsdet, xs)
+@grad logabsdet(xs) = logabsdet(data(xs)), Δ -> (Δ[1] * transpose(inv(xs)),)
 
 Base.repeat(xs::TrackedArray; kw...) = track(repeat, xs; kw...)
 

--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -125,7 +125,7 @@ Base.adjoint(xs::TrackedArray) = track(adjoint, xs)
 @grad adjoint(xs) = data(xs)', Δ -> (trim(xs, Δ'),)
 
 det(xs::TrackedArray) = track(det, xs)
-@grad det(xs) = det(data(xs)), Δ -> (Δ * transpose(adjoint(xs)),)
+@grad det(xs) = det(data(xs)), Δ -> (Δ * det(xs) * transpose(inv(xs)),)
 
 Base.repeat(xs::TrackedArray; kw...) = track(repeat, xs; kw...)
 

--- a/src/tracker/lib/array.jl
+++ b/src/tracker/lib/array.jl
@@ -1,7 +1,7 @@
 import Base: *
 
 import LinearAlgebra
-import LinearAlgebra: inv, \, /
+import LinearAlgebra: inv, det, \, /
 
 using Statistics
 using LinearAlgebra: Transpose, Adjoint, diagm, diag
@@ -123,6 +123,9 @@ Base.adjoint(xs::TrackedArray) = track(adjoint, xs)
 
 @grad transpose(xs) = transpose(data(xs)), Δ -> (trim(xs, transpose(Δ)),)
 @grad adjoint(xs) = data(xs)', Δ -> (trim(xs, Δ'),)
+
+det(xs::TrackedArray) = track(det, xs)
+@grad det(xs) = det(data(xs)), Δ -> (Δ * transpose(adjoint(xs)),)
 
 Base.repeat(xs::TrackedArray; kw...) = track(repeat, xs; kw...)
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -3,7 +3,7 @@ using Flux.Tracker, Test, NNlib
 using Flux.Tracker: TrackedReal, gradient, gradcheck, grad, checkpoint, forwarddiff
 using NNlib: conv, depthwiseconv
 using Printf: @sprintf
-using LinearAlgebra: diagm, dot, LowerTriangular, norm
+using LinearAlgebra: diagm, dot, LowerTriangular, norm, det, logdet, logabsdet
 using Statistics: mean, std
 using Random
 # using StatsBase
@@ -33,6 +33,10 @@ gradtest(f, dims...) = gradtest(f, rand.(Float64, dims)...)
 @test gradtest(Flux.crossentropy, rand(5,5), rand(5, 5))
 
 @test gradtest(x -> x', rand(5))
+
+@test gradtest(det, (4, 4))
+@test gradtest(logdet, (4, 4))
+@test gradtest((x) -> logabsdet(x)[1], (4, 4))
 
 @testset "indexing & slicing" begin
   gradtest(x->view(x, 1:2, 1:2), rand(4, 4))

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -35,7 +35,7 @@ gradtest(f, dims...) = gradtest(f, rand.(Float64, dims)...)
 @test gradtest(x -> x', rand(5))
 
 @test gradtest(det, (4, 4))
-@test gradtest(logdet, (4, 4))
+@test gradtest(logdet, map((x) -> x*x', (rand(4, 4),))[1])
 @test gradtest((x) -> logabsdet(x)[1], (4, 4))
 
 @testset "indexing & slicing" begin


### PR DESCRIPTION
Added tracking of LinearAlgebra.det and its grad method.

The gradient of the determinant is taken from
http://www.cs.cmu.edu/~zkolter/course/15-884/linalg-review.pdf (Section 4.5)

It is also mentioned that $det{A} A^{-T}$ can be used, this form is also written in 
Matrix Cookbook Sec. 2.1.2
https://www.ics.uci.edu/~welling/teaching/KernelsICS273B/MatrixCookBook.pdf

I don't know what variant is more appropriate.
