### PR TITLE
Adapt to the new CUDAdrv.CuPtr pointer type.

### DIFF
--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -5,14 +5,14 @@ import ..CuArrays.CUDAdrv: CuPtr, CU_NULL
 using Pkg.TOML
 
 function version_check()
-  minor_version = 9
+  major_version = 1
   project = joinpath(dirname(pathof(CuArrays)), "../Project.toml")
   project = TOML.parse(String(read(project)))
   version = VersionNumber(get(project, "version", "0.0.0"))
-  if !(version.major == 0 && version.minor == minor_version)
+  if version.major != major_version
     @warn """
-    Flux is only supported with CuArrays v0.$minor_version.
-    Try running `] pin CuArrays@0.$minor_version`.
+    Flux is only supported with CuArrays v$major_version.x.
+    Try running `] pin CuArrays@$major_version`.
     """
   end
 end

--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -1,7 +1,7 @@
 module CUDA
 
-import CUDAdrv: CuPtr, CU_NULL
 using ..CuArrays
+import CuArrays.CUDAdrv: CuPtr, CU_NULL
 using Pkg.TOML
 
 function version_check()

--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -1,7 +1,7 @@
 module CUDA
 
 using ..CuArrays
-import CuArrays.CUDAdrv: CuPtr, CU_NULL
+import ..CuArrays.CUDAdrv: CuPtr, CU_NULL
 using Pkg.TOML
 
 function version_check()

--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -1,5 +1,6 @@
 module CUDA
 
+import CUDAdrv: CuPtr, CU_NULL
 using ..CuArrays
 using Pkg.TOML
 

--- a/src/cuda/curnn.jl
+++ b/src/cuda/curnn.jl
@@ -101,18 +101,18 @@ function cudnnRNNForward(rnn::RNNDesc{T}, seqlen, xd, x, hd, h, cd, c, wd, w, yd
   if reserve == nothing
     @check ccall((:cudnnRNNForwardInference, libcudnn), cudnnStatus_t,
                  (Ptr{Nothing}, Ptr{Nothing}, Cint,
-                  Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T},
-                  Ptr{Nothing}, Ptr{T}, Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T},
-                  Ptr{Nothing}, Ptr{T},
-                  Ptr{Nothing}, Csize_t),
+                  Ptr{Ptr{Nothing}}, CuPtr{T}, Ptr{Nothing}, CuPtr{T}, Ptr{Nothing}, CuPtr{T},
+                  Ptr{Nothing}, CuPtr{T}, Ptr{Ptr{Nothing}}, CuPtr{T}, Ptr{Nothing}, CuPtr{T},
+                  Ptr{Nothing}, CuPtr{T},
+                  CuPtr{Nothing}, Csize_t),
                  handle(), rnn, seqlen,
                  xd, x, hd, h, cd, c, wd, w, yd, y, hod, ho, cod, co,
                  workspace, length(workspace))
   else
     @check ccall((:cudnnRNNForwardTraining, libcudnn), cudnnStatus_t,
                  (Ptr{Nothing}, Ptr{Nothing}, Cint,
-                  Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T},
-                  Ptr{Nothing}, Csize_t, Ptr{Nothing}, Csize_t),
+                  Ptr{Ptr{Nothing}}, CuPtr{T}, Ptr{Nothing}, CuPtr{T}, Ptr{Nothing}, CuPtr{T}, Ptr{Nothing}, CuPtr{T}, Ptr{Ptr{Nothing}}, CuPtr{T}, Ptr{Nothing}, CuPtr{T}, Ptr{Nothing}, CuPtr{T},
+                  CuPtr{Nothing}, Csize_t, CuPtr{Nothing}, Csize_t),
                  handle(), rnn, seqlen,
                  xd, x, hd, h, cd, c, wd, w, yd, y, hod, ho, cod, co,
                  workspace, length(workspace), reserve, length(reserve))
@@ -121,7 +121,7 @@ end
 
 xDesc(x) = [TensorDesc(eltype(x), (1, size(x, 1), size(x, 2)))]
 
-hDesc(h::Nothing) = C_NULL, C_NULL
+hDesc(h::Nothing) = C_NULL, CU_NULL
 hDesc(x::Integer) = (@assert x == 0; hDesc(nothing))
 function hDesc(h::CuArray)
   TensorDesc(eltype(h), (size(h, 1), size(h, 2), 1)), h
@@ -169,10 +169,10 @@ function cudnnRNNBackwardData(rnn::RNNDesc{T}, seqlen, yd, y, dyd, dy, dhod, dho
                               wd, w, hd, h, cd, c, dxd, dx, dhd, dh, dcd, dc, ws, rs) where T
   @check ccall((:cudnnRNNBackwardData,libcudnn),cudnnStatus_t,
                (Ptr{Nothing}, Ptr{Nothing}, Cint,
-                Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T},
-                Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing},
-                Ptr{T}, Ptr{Ptr{Nothing}}, Ptr{T}, Ptr{Nothing}, Ptr{T}, Ptr{Nothing}, Ptr{T},
-                Ptr{Nothing}, Csize_t, Ptr{Nothing}, Csize_t),
+                Ptr{Ptr{Nothing}}, CuPtr{T}, Ptr{Ptr{Nothing}}, CuPtr{T}, Ptr{Nothing}, CuPtr{T},
+                Ptr{Nothing}, CuPtr{T}, Ptr{Nothing}, CuPtr{T}, Ptr{Nothing}, CuPtr{T}, Ptr{Nothing},
+                CuPtr{T}, Ptr{Ptr{Nothing}}, CuPtr{T}, Ptr{Nothing}, CuPtr{T}, Ptr{Nothing}, CuPtr{T},
+                CuPtr{Nothing}, Csize_t, CuPtr{Nothing}, Csize_t),
                handle(), rnn, seqlen, yd, y, dyd, dy, dhod, dho, dcod, dco,
                wd, w, hd, h, cd, c, dxd, dx, dhd, dh, dcd, dc, ws, length(ws), rs, length(rs))
 end
@@ -199,12 +199,12 @@ function cudnnRNNBackwardWeights(rnn::RNNDesc{T}, seqlen, xd, x, hd, h, yd, y, d
                                  workspace, reserve) where T
   @check ccall((:cudnnRNNBackwardWeights,libcudnn), cudnnStatus_t,
                (Ptr{Nothing}, Ptr{Nothing}, Cint,  # handle, rnnDesc, seqLength
-                Ptr{Ptr{Nothing}}, Ptr{T}, #x
-                Ptr{Nothing}, Ptr{T}, #hx
-                Ptr{Ptr{Nothing}}, Ptr{T}, #y
-                Ptr{Nothing}, Csize_t, #ws
-                Ptr{Nothing}, Ptr{T}, #dw
-                Ptr{Nothing}, Csize_t), #rs
+                Ptr{Ptr{Nothing}}, CuPtr{T}, #x
+                Ptr{Nothing}, CuPtr{T}, #hx
+                Ptr{Ptr{Nothing}}, CuPtr{T}, #y
+                CuPtr{Nothing}, Csize_t, #ws
+                Ptr{Nothing}, CuPtr{T}, #dw
+                CuPtr{Nothing}, Csize_t), #rs
                handle(), rnn, seqlen, xd, x, hd, h, yd, y,
                workspace, length(workspace), dwd, dw, reserve, length(reserve))
 end


### PR DESCRIPTION
FWIW, this would have been easier with some type aliases in the `ccall` signatures (from CuArrays.jl, `cudnnTensorDescriptor_t`, `Ptr{cudnnTensorFormat_t}`, etc).

There also seems to have sneaked in a `allowscalar` violation, but I don't have the time to hunt that down right now.

The dep on `CUDAdrv` would also need the Requires-style handling like CuArrays, so it might be easier to move those wrappers to CuArrays not to have to do that.

Ref https://github.com/JuliaGPU/CUDAdrv.jl/pull/125