### PR TITLE
Add a update!(params, opt, losses) suitable for writing own training loops

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -35,7 +35,7 @@ it is often cleaner to just write your own training loop, using `update!` as abo
 
 A more complicated example:
 ```julia
-# Inputs: model, train_data, dev_data, opt 
+# Inputs: model, xs, ys, opt 
 ps = params(model)
 num_obs = length(xs)
 

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -21,8 +21,8 @@ For example, a simple training loop:
 ps = params(model)
 for (x,y_true) in zip(xs, ys)
     y_pred = model(x)
-    losses = (y_pred - y_pred).^2
-    update!(ps, opt, losses)
+    loss = (y_pred - y_true)^2
+    update!(ps, opt, loss)
 end
 ```
 
@@ -32,6 +32,23 @@ For example if your loss function changes depending on the iteration, or some ex
 or you want to use a complicated early stopping rule.
 While all things can be done via surficiently complicated closures in the [train!](@ref) callbacks and loss functions,
 it is often cleaner to just write your own training loop, using `update!` as above.
+
+A more complicated example:
+```julia
+# Inputs: model, train_data, dev_data, opt 
+ps = params(model)
+num_obs = length(xs)
+
+for (ii, (x, y_true)) in enumerate(zip(xs, ys))
+    y_pred = model(x)
+    loss = (y_pred - y_true)^2
+    loss *= exp10(10*ii/num_obs)  # Weight losses proportionate to how recently 
+    update!(ps, opt, loss)
+    
+    @info "traing step done" ii loss
+end
+```
+
 """
 function update!(parameters::Params, opt, losses)
     @interrupts back!(losses)


### PR DESCRIPTION
re the discussion @staticfloat  and I were having on slack:
Shortedned:


> 
> ## Lyndon White
> What is the pattern in Flux to use when
> I already have a TrackedVector of `loss`es,
> and I just want to use those to update my model.
> Do I use `train!` with dummy arguments? (edited) 
> 
> I think I am happiest handling my early stopping and batching and loss calculation all myself in a loop.
> Feeding `train!`  an interator and a callback, and loss-function feels a bit too constraining, like i have to shoe horn my problem into that form. (edited) 
> 
> ## Elliot Saba   [Today at 10:57 AM]
> I would just not use `train!()` at all in that case.  Just call `Flux.back!()` with your losses directly, and then do the optimizer step.


I feel like pushing advanced users to write their own loops is a good thing.
and giving them a simple `update!(params, opt, losses)`,
to call from their loop, is giving them the tools for the job,
