### PR TITLE
Handle back! and isleaf sensibly

### DIFF
--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -1,3 +1,5 @@
+
+
 init_grad(x) = zero(x)
 zero_grad!(x) = zero(x)
 zero_grad!(x::AbstractArray) = (x .= 0)
@@ -26,8 +28,8 @@ function back_(c::Call, Δ, once)
   foreach((x, d) -> back(x, d, once), c.args, data.(Δs))
 end
 
-back_(::Call{Nothing}, Δ, once) = nothing
-back_(::Call{Missing}, Δ, once) = error("`back!` was already used")
+back_(::Call{NoComputation}, Δ, once) = nothing
+back_(::Call{FreedComputation}, Δ, once) = error("`back!` was already used")
 
 accum!(x, Δ) = x .+ Δ
 accum!(x::AbstractArray, Δ) = (x .+= Δ)

--- a/src/tracker/back.jl
+++ b/src/tracker/back.jl
@@ -1,5 +1,3 @@
-
-
 init_grad(x) = zero(x)
 zero_grad!(x) = zero(x)
 zero_grad!(x::AbstractArray) = (x .= 0)

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -329,6 +329,15 @@ end
   @test gs[W] == dW
 end
 
+@testset "Params after back!" begin
+  w = param(1)
+  model(z) = w*z
+  params_before = params(model)
+  Flux.back!(model, 1.0; once=true)
+  @test params(model) == params_before()
+end
+
+
 @testset "Forward" begin
   @test @inferred(Tracker.forward_jacobian(x -> [sum(x)], rand(5,5), Val(12)))[2] ==
     reshape(ones(25), :, 1)


### PR DESCRIPTION
calling `back!` should not change if something `isleaf` or not.
and it should not  cause checking such to give missing related errors.

This solves https://discourse.julialang.org/t/typeerror-non-boolean-missing-used-in-boolean-context-when-collecting-parameters/20593

Wether or not this is a wise thing that a user should do or not,
the behavour with this PR is more sensible.

