### PR TITLE
Improving BatchNorm

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -133,7 +133,7 @@ function (BN::BatchNorm)(x)
     # update moving mean/std
     mtm = data(convert(T, BN.momentum))
     BN.μ = (1 - mtm) .* BN.μ .+ mtm .* reshape(data(μ), :)
-    BN.σ² = (1 - mtm) .* BN.σ² .+ mtm .* reshape(data(σ²), :) .* m ./ (m - 1)
+    BN.σ² = (1 - mtm) .* BN.σ² .+ (mtm * m / (m - 1)) .* reshape(data(σ²), :)
   end
 
   let λ = BN.λ

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -113,34 +113,32 @@ BatchNorm(chs::Integer, λ = identity;
 function (BN::BatchNorm)(x)
   size(x, ndims(x)-1) == length(BN.β) ||
     error("BatchNorm expected $(length(BN.β)) channels, got $(size(x, ndims(x)-1))")
-  γ, β = BN.γ, BN.β
   dims = length(size(x))
   channels = size(x, dims-1)
   affine_shape = ones(Int, dims)
   affine_shape[end-1] = channels
   m = prod(size(x)[1:end-2]) * size(x)[end]
-
+  γ = reshape(BN.γ, affine_shape...)
+  β = reshape(BN.β, affine_shape...)
   if !BN.active
     μ = reshape(BN.μ, affine_shape...)
     σ² = reshape(BN.σ², affine_shape...)
+    ϵ = BN.ϵ
   else
     T = eltype(x)
-
-    ϵ = data(convert(T, BN.ϵ))
     axes = [1:dims-2; dims] # axes to reduce along (all but channels axis)
     μ = mean(x, dims = axes)
     σ² = sum((x .- μ) .^ 2, dims = axes) ./ m
-
+    ϵ = data(convert(T, BN.ϵ))
     # update moving mean/std
     mtm = data(convert(T, BN.momentum))
     BN.μ = (1 - mtm) .* BN.μ .+ mtm .* reshape(data(μ), :)
-    BN.σ² = ((1 - mtm) .* BN.σ² .+ mtm .* reshape(data(σ²), :) .* m ./ (m - 1))
+    BN.σ² = (1 - mtm) .* BN.σ² .+ mtm .* reshape(data(σ²), :) .* m ./ (m - 1)
   end
 
   let λ = BN.λ
-    temp = reshape(γ, affine_shape...) .* ((x .- μ) ./ sqrt.(σ² .+ BN.ϵ)) 
-    # This is intentionally not fused because of an extreme slowdown doing so
-    λ.(temp .+ reshape(β, affine_shape...))
+    x̂ = (x .- μ) ./ sqrt.(σ² .+ ϵ)
+    λ.(γ .* x̂ .+ β)
   end
 end
 


### PR DESCRIPTION
Fixes 2 issues
1. ϵ is declared but never used.
2. Makes BatchNorm notation similar to that of the original paper with similar performance.

### Ubuntu 18.04 GPU K-80

Test
```julia
bn = gpu(BatchNorm(32))
testimg = gpu(randn(Float32, 416, 416, 32, 1))
@time gpu(bn(testimg))
@time gpu(bn(testimg))
```

Old Code
```julia
3.327136 seconds (3.25 M allocations: 167.726 MiB, 1.83% gc time)
0.001245 seconds (155 allocations: 5.391 KiB)
```

New Code
```julia
3.542283 seconds (3.46 M allocations: 178.192 MiB, 2.74% gc time)
0.001185 seconds (149 allocations: 5.281 KiB)
```

### OSX CPU

Test
```julia
using Flux
bn = BatchNorm(32)
testimg = randn(Float32, 416, 416, 32, 1)
@time bn(testimg)
@time bn(testimg)
```

Old Code
```julia
14.939357 seconds (225.12 M allocations: 3.799 GiB, 2.11% gc time)
12.857950 seconds (215.97 M allocations: 3.342 GiB, 1.32% gc time)
```
New Code
```julia
2.701686 seconds (8.37 M allocations: 487.830 MiB, 9.61% gc time)
0.077704 seconds (135 allocations: 63.381 MiB, 24.40% gc time)
```
