### PR TITLE
Add Parallel layer

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -6,7 +6,7 @@ using Base: tail
 using MacroTools, Juno, Requires, Reexport, Statistics, Random
 using MacroTools: @forward
 
-export Chain, Dense, RNN, LSTM, GRU, Conv, ConvTranspose, MaxPool, MeanPool,
+export Chain, Dense, RNN, LSTM, GRU, Parallel, Bi, BiLSTM, PLSTM, BiPLSTM, Conv, ConvTranspose, MaxPool, MeanPool,
        DepthwiseConv, Dropout, LayerNorm, BatchNorm,
        params, mapleaves, cpu, gpu, f32, f64
 
@@ -32,6 +32,7 @@ include("layers/stateless.jl")
 include("layers/basic.jl")
 include("layers/conv.jl")
 include("layers/recurrent.jl")
+include("layers/parallel.jl")
 include("layers/normalise.jl")
 
 include("data/Data.jl")

--- a/src/layers/parallel.jl
+++ b/src/layers/parallel.jl
@@ -51,6 +51,8 @@ function Parallel(
 end
 
 function (p::Parallel)(xs)
+    # NOTE: The implementation is acutally sequential and not parallel. How to parallelize for cpu() and gpu()?
+    #       `Base.pmap` does not exist anymore and `Threads.@threads` does not seem to be a good idea neither.
 
     # double reverse - see: recurrent.jl#flip(f, xs)
     # y = map^-1(f(map(x)))
@@ -59,7 +61,7 @@ function (p::Parallel)(xs)
     # implicit mapping
     # Z = map(l -> apply(l), eachindex(p.layers))
 
-    # explicit mapping - define type and size of Z
+    # explicit mapping - define type and size of Z    
     first = apply(1)
     Z = Vector{typeof(first)}(UndefInitializer(), length(p.layers))
     for l in eachindex(p.layers)

--- a/src/layers/parallel.jl
+++ b/src/layers/parallel.jl
@@ -145,25 +145,9 @@ function Bi(layer::Recur, reduce::Function = concat)
 end
 
 function BiLSTM(in::Int, out::Int; reduce::Function = concat)
-    if reduce == concat
-        if out % 2 == 0
-            Bi(LSTM(in, convert(Int64, out/2)), reduce)
-        else
-            throw(DimensionMismatch("The reduce function `concat` requires `out` to be a multiple of two."))
-        end
-    else
-        Bi(LSTM(in, out), reduce)
-    end
+    Bi(LSTM(in, out), reduce)
 end
 
 function BiPLSTM(in::Int, out::Int; reduce::Function = concat)    
-    if reduce == concat
-        if out % 2 == 0
-            Bi(PLSTM(in, convert(Int64, out/2)), reduce)
-        else
-            throw(DimensionMismatch("`out` must be a multiple of two for `concat` as reduce function."))
-        end
-    else
-        Bi(PLSTM(in, out), reduce)
-    end
+    Bi(PLSTM(in, out), reduce)
 end

--- a/src/layers/parallel.jl
+++ b/src/layers/parallel.jl
@@ -138,7 +138,7 @@ end
 # see:
 #  "SPEECH RECOGNITION WITH DEEP RECURRENT NEURAL NETWORKS" https://arxiv.org/pdf/1303.5778.pdf
 #  "Bidirectional LSTM-CRF Models for Sequence Tagging" https://arxiv.org/pdf/1508.01991.pdf
-
+#  Bidirectional layer of Keras: https://github.com/keras-team/keras/blob/05d713504852b490afcf2607aea1ce923e93ecfe/keras/layers/wrappers.py#L333
 function Bi(layer::Recur, reduce::Function = concat)
     map = Dict{Int64,Function}(2 => reverse)
     Parallel([layer, deepcopy(layer)], map=map, reduce=reduce)
@@ -159,7 +159,7 @@ end
 function BiPLSTM(in::Int, out::Int; reduce::Function = concat)    
     if reduce == concat
         if out % 2 == 0
-            Bi(PLSTM(in,convert(Int64, out / 2)), reduce)
+            Bi(PLSTM(in, convert(Int64, out/2)), reduce)
         else
             throw(DimensionMismatch("`out` must be a multiple of two for `concat` as reduce function."))
         end

--- a/src/layers/parallel.jl
+++ b/src/layers/parallel.jl
@@ -1,0 +1,167 @@
+import Flux: Recur, _truncate, prefor, glorot_uniform, gate
+
+function identities(n::Int64)
+    fill(identity, n)
+end
+
+# reduce/merge modes in keras: 'sum', 'mul', 'concat', 'ave', None
+# see https://github.com/keras-team/keras/blob/master/keras/layers/wrappers.py#L333
+
+function concat(xs)
+    # TODO: should this be always `vcat` or sometimes `hcat` or something more general with `cat` and `dims`?
+    vcat(xs...)
+end
+
+function mul(xs)
+    D = xs[1]
+    for i in 2:length(xs)
+        D = D .* xs[i]
+    end
+    D
+end
+
+function mean(xs)
+    D = sum(xs) ./ length(xs)
+    D
+end
+
+
+mutable struct Parallel{L<:Recur}
+    layers::Vector{L}
+    map::Vector{Function}
+    # TODO: explicit inverse mappings?
+    reduce::Function
+end
+
+Parallel(layers::Vector{Recur}) = Parallel(layers, identities(length(layers)), concat)
+
+function Parallel(
+    layers::Vector{L};
+    map::Dict{Int64,Function} = Dict{Int64,Function}(),
+    reduce::Function = concat) where L<:Recur
+
+    # TODO: throw error for min length for layers - 1 or 2?
+
+    mappings::Vector{Function} = identities(length(layers))
+    for (k,v) in map
+        mappings[k] = v
+    end
+
+    return Parallel(layers, mappings, reduce)
+end
+
+function (p::Parallel)(xs)
+
+    # double reverse - see: recurrent.jl#flip(f, xs)
+    # y = map^-1(f(map(x)))
+    apply(l) = p.map[l](p.layers[l](p.map[l](xs)))
+    
+    # implicit mapping
+    # Z = map(l -> apply(l), eachindex(p.layers))
+
+    # explicit mapping - define type and size of Z
+    first = apply(1)
+    Z = Vector{typeof(first)}(UndefInitializer(), length(p.layers))
+    for l in eachindex(p.layers)
+        if l == 1
+            Z[l] = first
+        else
+            Z[l] = apply(l)
+        end
+    end
+
+    p.reduce(Z)
+end
+
+@treelike Parallel layers, map, reduce
+
+Base.show(io::IO, m::Parallel) = print(io, "Parallel(", m.layers, ", ", m.map, ", ", m.reduce, ")")
+
+function _truncate_parallel(x)
+    if x isa Recur
+        x.state = _truncate(x.state)
+    elseif x isa Parallel
+        for layer in x.layers
+            _truncate_parallel(layer)
+        end
+    end
+end
+
+function truncate_parallel!(m)
+    prefor(_truncate_parallel, m)
+end
+
+function _reset_parallel(x)
+    if x isa Recur
+        x.state = x.init
+    elseif x isa Parallel
+        for recur in x.layers
+            _reset_parallel(recur)
+        end
+    end
+end
+
+function reset_parallel!(m)
+    prefor(_reset_parallel, m)
+end
+
+function Base.reverse(M::Flux.OneHotMatrix{Array{Flux.OneHotVector,1}})
+    Flux.OneHotMatrix(M.height, reverse(M.data))
+    # M.data = reverse(M.data)
+    # M
+end
+
+function Base.reverse(v::Flux.OneHotVector)
+    v
+end
+
+function Base.reverse(ta::TrackedArray)
+    if length(size(ta.data)) == 2
+        # TODO: does this need to be param() or params() or how to propagate the tracking?
+        # reverse(ta.data, dims=2)
+        params(reverse(ta.data, dims=2))
+    else
+        ta
+    end
+end
+
+function Base.reverse(b::Bool)
+    b
+end
+
+function Base.reverse(x::Number)
+    x
+end
+
+# see:
+#  "SPEECH RECOGNITION WITH DEEP RECURRENT NEURAL NETWORKS" https://arxiv.org/pdf/1303.5778.pdf
+#  "Bidirectional LSTM-CRF Models for Sequence Tagging" https://arxiv.org/pdf/1508.01991.pdf
+
+function Bi(layer::Recur, reduce::Function = concat)
+    map = Dict{Int64,Function}(2 => reverse)
+    Parallel([layer, deepcopy(layer)], map=map, reduce=reduce)
+end
+
+function BiLSTM(in::Int, out::Int; reduce::Function = concat)
+    if reduce == concat
+        if out % 2 == 0
+            Bi(LSTM(in, convert(Int64, out/2)), reduce)
+        else
+            throw(DimensionMismatch("The reduce function `concat` requires `out` to be a multiple of two."))
+        end
+    else
+        Bi(LSTM(in, out), reduce)
+    end
+end
+
+function BiPLSTM(in::Int, out::Int; reduce::Function = concat)    
+    if reduce == concat
+        if out % 2 == 0
+            Bi(PLSTM(in,convert(Int64, out / 2)), reduce)
+        else
+            throw(DimensionMismatch("`out` must be a multiple of two for `concat` as reduce function."))
+        end
+    else
+        Bi(PLSTM(in, out), reduce)
+    end
+end

--- a/src/layers/parallel.jl
+++ b/src/layers/parallel.jl
@@ -8,7 +8,17 @@ end
 # see https://github.com/keras-team/keras/blob/master/keras/layers/wrappers.py#L333
 
 function concat(xs)
-    vcat(xs...)
+    # implicit concatenation
+    return vcat(xs...)
+
+    # explcit concatenation
+    # n = length(xs)
+    # m = length(xs[1])
+    # concated = Array{eltype(xs[1].data)}(UndefInitializer(), n * m)
+    # for i in 1:n
+    #     concated[(i-1)*m+1:i*m] = xs[i].data
+    # end
+    # return param(concated)
 end
 
 function mul(xs)
@@ -19,34 +29,33 @@ function mul(xs)
     D
 end
 
-function mean(xs)
-    D = sum(xs) ./ length(xs)
-    D
-end
+# function mean(xs)
+#     D = sum(xs) ./ length(xs)
+#     D
+# end
 
 
-mutable struct Parallel  #{M<:Recur}
+mutable struct Parallel
     layers::Vector
     map::Vector{Function}
     inv::Vector{Function}
     reduce::Function
 end
 
-function Parallel(layers::Vector)
-    Parallel(layers, identities(length(layers)), identities(length(layers)), concat)
-end
 
 function Parallel(
     layers::Vector;
     map::Dict{Int64,Function} = Dict{Int64,Function}(),
-    reduce::Function = concat) # where M<:Recur
-
-    # TODO: throw error for min length for layers - 1 or 2?
+    inv::Dict{Int64,Function} = Dict{Int64,Function}(),
+    reduce::Function = concat)
 
     mappings::Vector{Function} = identities(length(layers))
-    inverses::Vector{Function} = copy(mappings)
     for (k,v) in map
         mappings[k] = v
+    end
+
+    inverses::Vector{Function} = identities(length(layers))
+    for (k,v) in inv
         inverses[k] = v
     end
 
@@ -58,23 +67,23 @@ function (p::Parallel)(xs)
     #       How to parallelize for cpu() and gpu() ia an open question to me, as `Base.pmap` does not exist anymore and 
     #       `Threads.@threads` does not seem to be a good idea neither.
 
-    # double reverse, analog to `Flux.flip` but without broadcast; see: recurrent.jl#flip(f, xs)
+    # double reverse; analog to `Flux.flip`, but without broadcast; see: recurrent.jl#flip(f, xs)
     # y = map^-1(f(map(x))) or map(x) |> f |> map^-1
     apply(l) = p.inv[l](p.layers[l](p.map[l](xs)))
     
     # implicit mapping
-    # Z = map(l -> apply(l), eachindex(p.layers))
+    Z = map(l -> apply(l), eachindex(p.layers))
 
     # explicit mapping - define type and size of Z    
-    first = apply(1)
-    Z = Vector{typeof(first)}(UndefInitializer(), length(p.layers))
-    for l in eachindex(p.layers)
-        if l == 1
-            Z[l] = first
-        else
-            Z[l] = apply(l)
-        end
-    end
+    # first = apply(1)
+    # Z = Vector{typeof(first)}(UndefInitializer(), length(p.layers))
+    # for l in eachindex(p.layers)
+    #     if l == 1
+    #         Z[l] = first
+    #     else
+    #         Z[l] = apply(l)
+    #     end
+    # end
 
     p.reduce(Z)
 end
@@ -84,78 +93,117 @@ end
 Flux.children(p::Parallel) = p.layers
 Flux.mapchildren(f, p::Parallel) = Parallel(f.(p.layers), p.map, p.inv, p.reduce)
 
-Base.show(io::IO, m::Parallel) = print(io, "Parallel(", m.layers, ", ", m.map, ", ", m.inv, ", ", m.reduce, ")")
-
-function _truncate_parallel(x)
-    if x isa Recur
-        x.state = _truncate(x.state)
-    elseif x isa Parallel
-        for layer in x.layers
-            _truncate_parallel(layer)
-        end
-    end
+function Base.show(io::IO, m::Parallel)
+    print(io, "Parallel(\n")
+    print(io, "  layers = ", m.layers, ",\n")
+    print(io, "     map = ", m.map, ",\n")
+    print(io, "     inv = ", m.inv, ",\n")
+    print(io, "  reduce = ", m.reduce, "\n")
+    print(io, ")")
 end
 
-function truncate_parallel!(m)
-    prefor(_truncate_parallel, m)
-end
 
-function _reset_parallel(x)
-    if x isa Recur
-        x.state = x.init
-    elseif x isa Parallel
-        for recur in x.layers
-            _reset_parallel(recur)
-        end
-    end
-end
-
-function reset_parallel!(m)
-    prefor(_reset_parallel, m)
-end
-
-function Base.reverse(M::Flux.OneHotMatrix{Array{Flux.OneHotVector,1}})
-    # Flux.OneHotMatrix(M.height, reverse(M.data))
-    # M.data = reverse(M.data)
+"""
     reverse(M)
+    
+Reverse the input vector for each batch.
+
+# Examples
+```julia-repl
+julia> M = onehotbatch([:a, :a, :b, :b], [:a, :b, :c])
+3×4 Flux.OneHotMatrix{Array{Flux.OneHotVector,1}}:
+  true   true  false  false
+ false  false   true   true
+ false  false  false  false
+
+julia> reverse(M)
+3×4 Flux.OneHotMatrix{Array{Flux.OneHotVector,1}}:
+ false  false   true   true
+  true   true  false  false
+ false  false  false  false
+```
+"""
+function Base.reverse(M::Flux.OneHotMatrix{Array{Flux.OneHotVector,1}})
+    Flux.OneHotMatrix(M.height, reverse(M.data))
 end
 
+"""
+    reverse(v)
+
+Return the identity of the one-hot vector.
+"""
 function Base.reverse(v::Flux.OneHotVector)
     v
 end
 
-function Base.reverse(ta::TrackedArray)
+"""
+    reverse(x)
+
+Reverse a tracked array or matrix.
+
+# Examples
+```julia-repl
+
+julia> a = param([1, 2, 3, 4, 5, 6])
+Tracked 6-element Array{Float64,1}:
+ 1.0
+ 2.0
+ 3.0
+ 4.0
+ 5.0
+ 6.0
+
+julia> reverse(a)
+Tracked 6-element Array{Float64,1}:
+ 6.0
+ 5.0
+ 4.0
+ 3.0
+ 2.0
+ 1.0
+
+julia> T = param([1 2 3; 4 5 6])
+Tracked 2×3 Array{Float64,2}:
+ 1.0  2.0  3.0
+ 4.0  5.0  6.0
+
+julia> reverse(T)
+Tracked 2×3 Array{Float64,2}:
+ 3.0  2.0  1.0
+ 6.0  5.0  4.0
+```
+"""
+function Base.reverse(ta::Flux.TrackedArray; dims=2)
     if length(size(ta.data)) == 2
-        # TODO: does this need to be param() or params() or how to propagate the tracking?
-        # reverse(ta.data, dims=2)
-        # param(reverse(ta.data, dims=2))
-        reverse(ta)
+        param(reverse(ta.data, dims=dims))
     else
-        ta
+        param(reverse(ta.data))
     end
 end
 
-function Base.reverse(b::Bool)
-    b
-end
+"""
+    reverse(v)
 
-function Base.reverse(x::Number)
+Reversing a tracked number returns the identity of the number.
+"""
+function Base.reverse(x::Flux.Tracker.TrackedReal)
     x
 end
+
 
 # see:
 #  "SPEECH RECOGNITION WITH DEEP RECURRENT NEURAL NETWORKS" https://arxiv.org/pdf/1303.5778.pdf
 #  "Bidirectional LSTM-CRF Models for Sequence Tagging" https://arxiv.org/pdf/1508.01991.pdf
 #  Bidirectional layer of Keras: https://github.com/keras-team/keras/blob/05d713504852b490afcf2607aea1ce923e93ecfe/keras/layers/wrappers.py#L333
 function Bi(layer::Recur, reduce::Function = concat)
-    map = Dict{Int64,Function}(2 => reverse)
-    Parallel([layer, deepcopy(layer)], map=map, reduce=reduce)
+    mapping = Dict{Int64,Function}(2 => reverse)
+    Parallel([layer, deepcopy(layer)], map=mapping, inv=mapping, reduce=reduce)
 end
 
-function BiLSTM(in::Int, out::Int; reduce::Function = concat)
+function BiLSTM(in::Int, out::Int, reduce::Function = concat)
     Bi(LSTM(in, out), reduce)
 end
 
-function BiPLSTM(in::Int, out::Int; reduce::Function = concat)    
+function BiPLSTM(in::Int, out::Int, reduce::Function = concat)    
     Bi(PLSTM(in, out), reduce)
 end

--- a/src/layers/parallel.jl
+++ b/src/layers/parallel.jl
@@ -95,7 +95,7 @@ Flux.mapchildren(f, p::Parallel) = Parallel(f.(p.layers), p.map, p.inv, p.reduce
 
 function Base.show(io::IO, m::Parallel)
     print(io, "Parallel(\n")
-    print(io, "  layers = ", m.layers, ",\n")
+    print(io, "  ", m.layers, ",\n")
     print(io, "     map = ", m.map, ",\n")
     print(io, "     inv = ", m.inv, ",\n")
     print(io, "  reduce = ", m.reduce, "\n")

--- a/src/layers/parallel.jl
+++ b/src/layers/parallel.jl
@@ -11,7 +11,7 @@ function concat(xs)
     # implicit concatenation
     return vcat(xs...)
 
-    # explcit concatenation
+    # explcit concatenation - preallocated size
     # n = length(xs)
     # m = length(xs[1])
     # concated = Array{eltype(xs[1].data)}(UndefInitializer(), n * m)
@@ -74,7 +74,7 @@ function (p::Parallel)(xs)
     # implicit mapping
     Z = map(l -> apply(l), eachindex(p.layers))
 
-    # explicit mapping - define type and size of Z    
+    # explicit mapping - preallocated size
     # first = apply(1)
     # Z = Vector{typeof(first)}(UndefInitializer(), length(p.layers))
     # for l in eachindex(p.layers)

--- a/src/layers/parallel.jl
+++ b/src/layers/parallel.jl
@@ -75,6 +75,8 @@ function (p::Parallel)(xs)
     p.reduce(Z)
 end
 
+# FIXME: which choice is correct in that case?
+# @treelike Parallel
 @treelike Parallel layers, map, reduce
 
 Base.show(io::IO, m::Parallel) = print(io, "Parallel(", m.layers, ", ", m.map, ", ", m.reduce, ")")
@@ -108,9 +110,9 @@ function reset_parallel!(m)
 end
 
 function Base.reverse(M::Flux.OneHotMatrix{Array{Flux.OneHotVector,1}})
-    Flux.OneHotMatrix(M.height, reverse(M.data))
+    # Flux.OneHotMatrix(M.height, reverse(M.data))
     # M.data = reverse(M.data)
-    # M
+    reverse(M)
 end
 
 function Base.reverse(v::Flux.OneHotVector)
@@ -121,7 +123,8 @@ function Base.reverse(ta::TrackedArray)
     if length(size(ta.data)) == 2
         # TODO: does this need to be param() or params() or how to propagate the tracking?
         # reverse(ta.data, dims=2)
-        params(reverse(ta.data, dims=2))
+        # param(reverse(ta.data, dims=2))
+        reverse(ta)
     else
         ta
     end

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -210,7 +210,8 @@ mutable struct PeepholeLSTMCell{A,V}
   c::V
 end
 
-function PeepholeLSTMCell(in::Integer, out::Integer; init = glorot_uniform)
+function PeepholeLSTMCell(in::Integer, out::Integer;
+                          init = glorot_uniform)
   cell = PeepholeLSTMCell(
       param(init(out*4, in)),  # Wx
       param(init(out*4, out)), # Wh
@@ -218,7 +219,7 @@ function PeepholeLSTMCell(in::Integer, out::Integer; init = glorot_uniform)
       param(zeros(out*4)),     # b
       param(init(out)),        # h
       param(init(out)))        # c
-  cell.b.data[gate(out, 2)] = 1
+  cell.b.data[gate(out, 2)] .= 1
   return cell
 end
 

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -22,7 +22,7 @@ using Base.Iterators: partition
         Parallel([LSTM(10,10), LSTM(10,10)], reduce=sum),
         Chain(Parallel([LSTM(10,10), LSTM(10,10)], reduce=mean)),
 
-        # reduce can be `Flux.concat` -> reduction is effectifly done by a Dense layer
+        # reduce can be `Flux.concat`. Here the reduction is effectifly done by a final Dense layer:
         Chain(Parallel([LSTM(10,10)]), Dense(10,10)),
         Chain(Parallel([LSTM(10,10), LSTM(10,10)]), Dense(20,10)),
 

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -33,7 +33,6 @@ using Base.Iterators: partition
             reduce = sum),
 
         # BiLSTM - a convenience layer, which makes use of `Parallel` and the MapReduce approach
-        # for reduce see also: `sum`, `mean`, `Flux.mul`, `Flux.concat`
         Bi(LSTM(10, 10), sum),
         Chain(BiLSTM(10,10, sum)),
 

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -16,7 +16,8 @@ using Base.Iterators: partition
         Parallel([LSTM(10,10)]),
         Chain(Parallel([LSTM(10,10)])),
 
-        # for reduce see also: `sum`, `mean`, `Flux.mul`
+        # for reduce see: `sum`, `mean`, `Flux.mul`, `Flux.concat`
+        Parallel([LSTM(10,5), LSTM(10,5)]),
         Parallel([LSTM(10,10), LSTM(10,10)], reduce=sum),
         Chain(Parallel([LSTM(10,10), LSTM(10,10)], reduce=mean)),
 
@@ -31,7 +32,7 @@ using Base.Iterators: partition
             reduce = sum),
 
         # BiLSTM - a convenience layer, which makes use of `Parallel` and the MapReduce approach
-        # for reduce see also: `sum`, `mean`, `Flux.mul`
+        # for reduce see also: `sum`, `mean`, `Flux.mul`, `Flux.concat`
         Bi(LSTM(10, 10), sum),
         Chain(BiLSTM(10,10, sum)),
 

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -1,0 +1,56 @@
+using Test, Random
+using Flux
+using Flux: mse, crossentropy, throttle, @epochs, softmax
+using Statistics: mean
+using Base.Iterators: partition
+
+@testset "Parallel" begin
+
+    @testset "one lonely parallel layer - should behave like one LSTM()" begin
+        
+        data = collect(partition(rand(10, 7), 10))
+
+        # m = Chain(Dense(10,10))
+        # m = Chain(LSTM(10,10))
+        # m = Chain(Parallel([LSTM(10,10)]))  # TODO: loss behaves oddly without final Dense layer?!
+        m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))
+        # m = Chain(BiLSTM(10,10))            # TODO: loss behaves oddly without final Dense layer?!
+        # m = Chain(BiLSTM(10,10), Dense(10,10)) # default: reduce=Flux.concat
+        # m = Chain(BiLSTM(10,10, reduce=sum), Dense(10,10))
+        # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))
+        # m = Chain(BiLSTM(10,10, reduce=Flux.mean), Dense(10,10))
+
+        before = Flux.data(m(data[1]))
+        @test length(before) == 10
+
+        function loss(x, y)
+            l = mse(m(x), y)
+            Flux.truncate_parallel!(m)
+            l
+        end
+
+        function evalcb()
+            error = mean(map(x -> loss(x, x), data))
+            @show(error)
+        end
+        opt = ADAM()
+        @epochs 3 Flux.train!(loss, params(m), zip(data, data), opt, cb = evalcb)
+
+        after = Flux.data(m(data[1]))
+        @test length(before) == length(after[:,end])
+        @test before != after[:,end]
+
+        Flux.reset_parallel!(m)
+        after = Flux.data(m(data[1]))
+        @test before != after
+    end
+
+    # @testset "reverse input for second layer" begin
+    #     m = Parallel(layers, map = Dict{Int64,Function}(2 => reverse))
+    # end
+
+    # @testset "bidirectional layers with average merge" begin
+    #     m = Parallel(layers, map = Dict{Int64,Function}(2 => reverse), reduce = mean)
+    # end
+
+end

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -6,51 +6,55 @@ using Base.Iterators: partition
 
 @testset "Parallel" begin
 
-    @testset "one lonely `LSTM()` in a `Parallel` layer - should behave like a single `LSTM()`" begin
-        
-        data = collect(partition(rand(10, 7), 10))
+    data = collect(partition(rand(10, 7), 10))
 
-        # Parallel map/reduce
+    models = [
+        # non recurrent layers
+        Chain(Parallel([Dense(10,10), Dense(10,10)]), Dense(20,10)),
 
-        ## non recurrent
-        # m = Chain(Parallel([Dense(10,10), Dense(10,10)]), Dense(20,10))
+        # recurrent layers - reduce defaults to `Flux.concat: 10 -> 10
+        Parallel([LSTM(10,10)]),
+        Chain(Parallel([LSTM(10,10)])),
 
-        ## recurrent
-        # m = Parallel([LSTM(10,10)])
-        # m = Chain(Parallel([LSTM(10,10)]))
+        # for reduce see also: `sum`, `mean`, `Flux.mul`
+        Parallel([LSTM(10,10), LSTM(10,10)], reduce=sum),
+        Chain(Parallel([LSTM(10,10), LSTM(10,10)], reduce=mean)),
 
-        # FIXME: DimensionMismatch("arrays could not be broadcast to a common size")
-        # m = Parallel([LSTM(10,10), LSTM(10,10)])  
-        # m = Chain(Parallel([LSTM(10,10), LSTM(10,10)]))
+        # reduce can be `Flux.concat` -> reduction is effectifly done by a Dense layer
+        Chain(Parallel([LSTM(10,10)]), Dense(10,10)),
+        Chain(Parallel([LSTM(10,10), LSTM(10,10)]), Dense(20,10)),
 
-        m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))
-        # m = Chain(Parallel([LSTM(10,10),LSTM(10,10)]), Dense(20,10))
-        
-        ## bidirectional LSTM
-        # FIXME: DimensionMismatch("arrays could not be broadcast to a common size")
-        # m = Bi(LSTM(10, 10))
-        # m = Chain(BiLSTM(10,10))
+        # bidirectional LSTM
+        Parallel([LSTM(10,10), LSTM(10,10)],
+            map = Dict{Int64,Function}(2 => reverse),
+            inv = Dict{Int64,Function}(2 => reverse),
+            reduce = sum),
 
-        # m = Chain(BiLSTM(10,10), Dense(20,10))  # default: reduce=Flux.concat
-        # m = Chain(BiLSTM(10,10, reduce=sum), Dense(10,10))
-        # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))
-        # m = Chain(BiLSTM(10,10, reduce=Flux.mean), Dense(10,10))
+        # BiLSTM - a convenience layer, which makes use of `Parallel` and the MapReduce approach
+        # for reduce see also: `sum`, `mean`, `Flux.mul`
+        Bi(LSTM(10, 10), sum),
+        Chain(BiLSTM(10,10, sum)),
 
-        ## peephole LSTM
-        # m = Chain(PLSTM(10,10))
-        # m = Chain(PLSTM(10,10), Dense(10,10))
-        # m = Chain(BiPLSTM(10,10), Dense(20,10))
-        # m = Chain(BiPLSTM(10,10), BiPLSTM(20,10), Dense(20,10))
+        # peephole LSTM - an modified LSTM layer commonly used in image processing.
+        Chain(PLSTM(10,10)),
+        Chain(PLSTM(10,10), Dense(10,10)),
 
-        # @show m
-        # @show params(m)
+        # BiPLSTM - a convenience layer, which makes use of `Parallel` and the MapReduce approach
+        Chain(BiPLSTM(10,10), Dense(20,10)),
+        Chain(BiPLSTM(10,10), BiPLSTM(20,10), Dense(20,10)),
+    ]
+
+    @testset "models using a `Parallel` layer" for (i,m) in enumerate(models)
+        println("\n\ntest ($i)\n")
+        @show m
+        sleep(0.1)
 
         before = Flux.data(m(data[1]))
         @test length(before) == 10 || length(before) == 20
 
         function loss(x, y)
             l = mse(m(x), y)
-            Flux.truncate_parallel!(m)
+            Flux.truncate!(m)
             l
         end
 
@@ -61,22 +65,14 @@ using Base.Iterators: partition
         opt = ADAM()
         @epochs 3 Flux.train!(loss, params(m), zip(data, data), opt, cb = evalcb)
 
-        Flux.reset_parallel!(m)
+        Flux.reset!(m)
         after = Flux.data(m(data[1]))
         @test length(before) == length(after[:,end]) || length(before) == 2 * length(after[:,end])
         @test before != after[:,end]
 
-        Flux.reset_parallel!(m)
+        Flux.reset!(m)
         after = Flux.data(m(data[1]))
         @test before != after
     end
-
-    # @testset "reverse input for second layer" begin
-    #     m = Parallel(layers, map = Dict{Int64,Function}(2 => reverse))
-    # end
-
-    # @testset "bidirectional layers with average merge" begin
-    #     m = Parallel(layers, map = Dict{Int64,Function}(2 => reverse), reduce = mean)
-    # end
 
 end

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -22,13 +22,15 @@ using Base.Iterators: partition
         # m = Chain(Parallel([LSTM(10,10)]))                # NOTE: compare to `Chain(LSTM(10,10))`
         # m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))
         m = Chain(Parallel([LSTM(10,10),LSTM(10,10)]), Dense(20,10))
-        # TODO: I wonder if it would be better not to reduce the `out` size of the LSTM for `concat` automatically:
-        #      `Chain(Parallel([LSTM(10,10)]), Dense(20,10))`
         
         # bidirectional LSTM
         # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
         # m = Chain(BiLSTM(10,10))                          # NOTE: uses internally 2 * LSTM(10, 5)
         # m = Chain(BiLSTM(10,20))                          # NOTE: uses internally 2 * LSTM(10, 10)
+        # TODO: I wonder if it would be better not to reduce the `out` size of the LSTM for `concat` implicitly:
+        #       `Chain(BiLSTM(10,10), Dense(20,10))`
+        #       Then the dimensions won't match by `out`->`in`, but logically.
+
         # m = Chain(BiLSTM(10,10), Dense(10,10))            # default: reduce=Flux.concat
         # m = Chain(BiLSTM(10,10, reduce=sum), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -13,9 +13,18 @@ using Base.Iterators: partition
         # m = Chain(Dense(10,10))
         # m = Chain(LSTM(10,10))
         # m = Chain(LSTM(10,10), Dense(10,10))
-        # m = Chain(Parallel([LSTM(10,10)]))  # TODO: loss behaves oddly without final Dense layer! Is tracking working?
-        m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))
-        # m = Chain(BiLSTM(10,10))            # TODO: loss behaves oddly without final Dense layer! Is tracking working?
+        
+        # map/reduce
+        # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
+        # m = Chain(Parallel([LSTM(10,10)]))
+        m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))  # uses internally 2 * LSTM(10, 5)
+        # m = Chain(Parallel([LSTM(10,20)]), Dense(20,10))  # uses internally 2 * LSTM(10,10)
+        # TODO: I wonder if it would be better not to reduce the `out` size of the LSTM for `concat` automatically:
+        #      `Chain(Parallel([LSTM(10,10)]), Dense(20,10))`
+        
+        # bidirectional LSTM
+        # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
+        # m = Chain(BiLSTM(10,10))
         # m = Chain(BiLSTM(10,10), Dense(10,10)) # default: reduce=Flux.concat
         # m = Chain(BiLSTM(10,10, reduce=sum), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -18,20 +18,17 @@ using Base.Iterators: partition
         # m = Chain(LSTM(10,10), Dense(10,10))
         
         # Parallel map/reduce
-        # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
-        # m = Chain(Parallel([LSTM(10,10)]))                # NOTE: compare to `Chain(LSTM(10,10))`
+        # FIXME: loss behaves oddly without a final Dense layer! Is tracking working for `Parallel`?
+        # m = Chain(Parallel([LSTM(10,10)]))  # NOTE: compare to `Chain(LSTM(10,10))`
+        # m = Chain(Parallel([LSTM(10,10)]))
         # m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))
-        m = Chain(Parallel([LSTM(10,10),LSTM(10,10)]), Dense(20,10))
+        # m = Chain(Parallel([LSTM(10,10),LSTM(10,10)]), Dense(20,10))
         
         # bidirectional LSTM
-        # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
-        # m = Chain(BiLSTM(10,10))                          # NOTE: uses internally 2 * LSTM(10, 5)
-        # m = Chain(BiLSTM(10,20))                          # NOTE: uses internally 2 * LSTM(10, 10)
-        # TODO: I wonder if it would be better not to reduce the `out` size of the LSTM for `concat` implicitly:
-        #       `Chain(BiLSTM(10,10), Dense(20,10))`
-        #       Then the dimensions won't match by `out`->`in`, but logically.
+        # FIXME: loss behaves oddly without a final Dense layer! Is tracking working for `Parallel`?
+        # m = Chain(BiLSTM(10,10))
 
-        # m = Chain(BiLSTM(10,10), Dense(10,10))            # default: reduce=Flux.concat
+        # m = Chain(BiLSTM(10,10), Dense(20,10))  # default: reduce=Flux.concat
         # m = Chain(BiLSTM(10,10, reduce=sum), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mean), Dense(10,10))
@@ -39,7 +36,10 @@ using Base.Iterators: partition
         # peephole LSTM
         # m = Chain(PLSTM(10,10))
         # m = Chain(PLSTM(10,10), Dense(10,10))
-        # m = Chain(BiPLSTM(10,10), Dense(10,10))
+        # m = Chain(BiPLSTM(10,10), Dense(20,10))
+
+        # @show m
+        # @show params(m)
 
         before = Flux.data(m(data[1]))
         @test length(before) == 10
@@ -57,6 +57,7 @@ using Base.Iterators: partition
         opt = ADAM()
         @epochs 3 Flux.train!(loss, params(m), zip(data, data), opt, cb = evalcb)
 
+        Flux.reset_parallel!(m)
         after = Flux.data(m(data[1]))
         @test length(before) == length(after[:,end])
         @test before != after[:,end]

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -10,22 +10,25 @@ using Base.Iterators: partition
         
         data = collect(partition(rand(10, 7), 10))
 
+        # non recurrent
         # m = Chain(Dense(10,10))
+
+        # LSTM
         # m = Chain(LSTM(10,10))
         # m = Chain(LSTM(10,10), Dense(10,10))
         
-        # map/reduce
+        # Parallel map/reduce
         # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
-        # m = Chain(Parallel([LSTM(10,10)]))
-        m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))  # uses internally 2 * LSTM(10, 5)
-        # m = Chain(Parallel([LSTM(10,20)]), Dense(20,10))  # uses internally 2 * LSTM(10,10)
+        # m = Chain(Parallel([LSTM(10,10)]))                # NOTE: compare to `Chain(LSTM(10,10))`
+        # m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))  # NOTE: uses internally 2 * LSTM(10, 5)
+        # m = Chain(Parallel([LSTM(10,20)]), Dense(20,10))  # NOTE: uses internally 2 * LSTM(10,10)
         # TODO: I wonder if it would be better not to reduce the `out` size of the LSTM for `concat` automatically:
         #      `Chain(Parallel([LSTM(10,10)]), Dense(20,10))`
         
         # bidirectional LSTM
         # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
-        # m = Chain(BiLSTM(10,10))
-        # m = Chain(BiLSTM(10,10), Dense(10,10)) # default: reduce=Flux.concat
+        # m = Chain(BiLSTM(10,10))                          # NOTE: compare to `Chain(LSTM(10,10))`
+        # m = Chain(BiLSTM(10,10), Dense(10,10))            # default: reduce=Flux.concat
         # m = Chain(BiLSTM(10,10, reduce=sum), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mean), Dense(10,10))

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -20,14 +20,15 @@ using Base.Iterators: partition
         # Parallel map/reduce
         # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
         # m = Chain(Parallel([LSTM(10,10)]))                # NOTE: compare to `Chain(LSTM(10,10))`
-        # m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))  # NOTE: uses internally 2 * LSTM(10, 5)
-        # m = Chain(Parallel([LSTM(10,20)]), Dense(20,10))  # NOTE: uses internally 2 * LSTM(10,10)
+        # m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))
+        m = Chain(Parallel([LSTM(10,10),LSTM(10,10)]), Dense(20,10))
         # TODO: I wonder if it would be better not to reduce the `out` size of the LSTM for `concat` automatically:
         #      `Chain(Parallel([LSTM(10,10)]), Dense(20,10))`
         
         # bidirectional LSTM
         # FIXME: loss behaves oddly without a final Dense layer! Is tracking working?
-        # m = Chain(BiLSTM(10,10))                          # NOTE: compare to `Chain(LSTM(10,10))`
+        # m = Chain(BiLSTM(10,10))                          # NOTE: uses internally 2 * LSTM(10, 5)
+        # m = Chain(BiLSTM(10,20))                          # NOTE: uses internally 2 * LSTM(10, 10)
         # m = Chain(BiLSTM(10,10), Dense(10,10))            # default: reduce=Flux.concat
         # m = Chain(BiLSTM(10,10, reduce=sum), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -33,6 +33,11 @@ using Base.Iterators: partition
         # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mean), Dense(10,10))
 
+        # peephole LSTM
+        # m = Chain(PLSTM(10,10))
+        # m = Chain(PLSTM(10,10), Dense(10,10))
+        # m = Chain(BiPLSTM(10,10), Dense(10,10))
+
         before = Flux.data(m(data[1]))
         @test length(before) == 10
 

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -12,9 +12,10 @@ using Base.Iterators: partition
 
         # m = Chain(Dense(10,10))
         # m = Chain(LSTM(10,10))
-        # m = Chain(Parallel([LSTM(10,10)]))  # TODO: loss behaves oddly without final Dense layer?!
+        # m = Chain(LSTM(10,10), Dense(10,10))
+        # m = Chain(Parallel([LSTM(10,10)]))  # TODO: loss behaves oddly without final Dense layer! Is tracking working?
         m = Chain(Parallel([LSTM(10,10)]), Dense(10,10))
-        # m = Chain(BiLSTM(10,10))            # TODO: loss behaves oddly without final Dense layer?!
+        # m = Chain(BiLSTM(10,10))            # TODO: loss behaves oddly without final Dense layer! Is tracking working?
         # m = Chain(BiLSTM(10,10), Dense(10,10)) # default: reduce=Flux.concat
         # m = Chain(BiLSTM(10,10, reduce=sum), Dense(10,10))
         # m = Chain(BiLSTM(10,10, reduce=Flux.mul), Dense(10,10))

--- a/test/layers/parallel.jl
+++ b/test/layers/parallel.jl
@@ -6,7 +6,7 @@ using Base.Iterators: partition
 
 @testset "Parallel" begin
 
-    @testset "one lonely parallel layer - should behave like one LSTM()" begin
+    @testset "one lonely `LSTM()` in a `Parallel` layer - should behave like a single `LSTM()`" begin
         
         data = collect(partition(rand(10, 7), 10))
 


### PR DESCRIPTION
I've improved the implementation of my Parallel layer with a MapReduce approach. I hope this is interesting for stacked models. I started this work to enable bidirectional LSTMs, but the current implementation is not only for recurrent models.

The approach goes like this: The user adds some layers and defines custom mappings and inverses for the input. After the mapping-phase comes the reduce-phase, which defaults to concatenation of the parallel layers:

```julia
mutable struct Parallel
    layers::Vector
    map::Vector{Function}
    inv::Vector{Function}
    reduce::Function
end

function (p::Parallel)(xs))
    # y = map(x) |> f |> map^-1
    apply(l) = p.inv[l](p.layers[l](p.map[l](xs)))
    
    Z = map(l -> apply(l), eachindex(p.layers))

    p.reduce(Z)
end
```

For the full implementation see:

https://github.com/swiesend/Flux.jl/blob/parallel/src/layers/parallel.jl

Here I've added run some example models to showcase the usage of the `Parallel` layer and some other convinience layers, like `Bi` or `BiLSTM`:

https://github.com/swiesend/Flux.jl/blob/parallel/test/layers/parallel.jl

For an example of a bidirectional LSTM see:

https://github.com/swiesend/Flux.jl/blob/ce33f606fded250ec2524bd13c47d75245e2de52/test/layers/parallel.jl#L29

I've also added a new peephole LSTM layer (`PLSTM`) in `recurrent.jl`:
https://github.com/swiesend/Flux.jl/blob/ce33f606fded250ec2524bd13c47d75245e2de52/src/layers/recurrent.jl#L202

How to run the examples:
```sh
git clone git@github.com:swiesend/Flux.jl.git .
cd Flux.jl
git checkout parallel
julia
```

```julia-repl
julia> using Pkg; Pkg.activate("."); Pkg.instantiate(); include("test/layers/parallel.jl")
```

## Issues

* The introduced `Base.reverse()` function on Flux data-structures lacks unit tests

* There are some issues, like GPU support, which I could not solve. I ran into a `ReadOnlyMemoryError()`.
