### PR TITLE
Added Adaptive Pooling Layers.

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -6,8 +6,8 @@ using Base: tail
 using MacroTools, Juno, Requires, Reexport, Statistics, Random
 using MacroTools: @forward
 
-export Chain, Dense, RNN, LSTM, GRU, Conv, ConvTranspose, MaxPool, MeanPool,
-       DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm,
+export Chain, Dense, RNN, LSTM, GRU, Conv, ConvTranspose, MaxPool, MeanPool, AdaptiveMaxPool,
+       AdaptiveMeanPool, DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm,
        params, mapleaves, cpu, gpu, f32, f64
 
 @reexport using NNlib

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -208,3 +208,45 @@ MeanPool(k::NTuple{N,Integer}; pad = 0, stride = k) where N =
 function Base.show(io::IO, m::MeanPool)
   print(io, "MeanPool(", m.k, ", pad = ", m.pad, ", stride = ", m.stride, ")")
 end
+
+"""
+    AdaptiveMaxPool(target_out) 
+
+Adaptive max pooling layer. 'target_out' stands for the size of one layer(channel) of output.
+
+Irrespective of Input size and pooling window size, it returns the target output dimensions.
+"""
+struct AdaptiveMaxPool{N}
+  target_out::NTuple{N, Int}
+end
+
+AdaptiveMaxPool(target_out::NTuple{N, Integer}) where N = 
+  AdaptiveMaxPool(target_out)
+
+function (m::AdaptiveMaxPool)(x)
+  w = size(x, 1) - m.target_out[1] + 1
+  h = size(x, 2) - m.target_out[2] + 1
+  return maxpool(x, (w, h); pad = (0, 0), stride = (1, 1))
+end
+
+"""
+    AdaptiveMeanPool(target_out) 
+
+Adaptive mean pooling layer. 'target_out' stands for the size of one layer(channel) of output.
+
+Irrespective of Input size and pooling window size, it returns the target output dimensions.
+"""
+struct AdaptiveMeanPool{N}
+  target_out::NTuple{N, Int}
+end
+
+AdaptiveMeanPool(target_out::NTuple{N, Integer}) where N = 
+  AdaptiveMeanPool(target_out)
+
+function (m::AdaptiveMeanPool)(x)
+  w = size(x, 1) - m.target_out[1] + 1
+  h = size(x, 2) - m.target_out[2] + 1
+  return meanpool(x, (w, h); pad = (0, 0), stride = (1, 1))
+end
+
+

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -7,6 +7,10 @@ using Flux: maxpool, meanpool
   @test mp(x) == maxpool(x, (2,2))
   mp = MeanPool((2, 2))
   @test mp(x) == meanpool(x, (2,2))
+  mp = AdaptiveMaxPool((3,4))
+  @test size(mp(x)) == (3, 4, 3, 2)
+  mp = AdaptiveMeanPool((2,2))
+  @test size(mp(x)) == (2, 2, 3, 2)
 end
 
 @testset "CNN" begin


### PR DESCRIPTION
These Adaptive Pooling layers will be useful in the middle of a long convolutional chain when the user doesn't know the size of input but wants a required target output size.