### PR TITLE
add Flux.stop to training docs

### DIFF
--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -93,3 +93,11 @@ evalcb() = @show(loss(test_x, test_y))
 Flux.train!(objective, ps, data, opt,
             cb = throttle(evalcb, 5))
 ```
+
+Calling `Flux.stop()` in a callback will exit the training loop early.
+
+```julia
+cb = function ()
+  accuracy() > 0.9 && Flux.stop()
+end
+```


### PR DESCRIPTION
In a recent [post](https://discourse.julialang.org/t/rmsprop-and-early-stopping-in-flux-jl/21065) on the Julia discourse, someone new to Flux didn't know about using `Flux.stop` to exit the training loop. This PR adds a note about this feature in the training section of the docs to (hopefully!) make this feature a little more discoverable.