### PR TITLE
naive implementation of activations

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -47,6 +47,9 @@ Calculate the forward results of each layers in Chain `c`
 """
 activations(m, x) = activations(Chain(m), x)
 function activations(c::Chain, x)
+    if length(c) == 0
+        return []
+    end
     rst = [c[1](x), ]
     if length(c) == 1
         return rst

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -46,14 +46,14 @@ end
 Calculate the forward results of each layers in Chain `c`
 """
 function activations(c::Chain, x)
-    if isempty(c)
-        return [x, ]
-    end
-    rst = [x, c[1](x)]
-    for l in c[2:end]
-        push!(rst, l(rst[end]))
-    end
-    return rst
+  if isempty(c)
+    return [x, ]
+  end
+  rst = [x, c[1](x)]
+  for l in c[2:end]
+    push!(rst, l(rst[end]))
+  end
+  return rst
 end
 
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -42,19 +42,18 @@ end
 
 
 # This is a temporary and naive inplementation
+# it might be replaced in the future to get better performance
 # see issue https://github.com/FluxML/Flux.jl/issues/702
+# Johnny Chen -- @johnnychen94
 """
-    activations(c::Chain, x)
-Calculate the forward results of each layers in Chain `c`
+    activations(c::Chain, input)
+Calculate the forward results of each layers in Chain `c` with `input` as model input.
 """
-function activations(c::Chain, x)
-  rst = Array{Any,1}()
-  if isempty(c)
-    return rst
-  end
-  push!(rst, c[1](x))
-  for l in c[2:end]
-    push!(rst, l(rst[end]))
+function activations(c::Chain, input)
+  rst = []
+  for l in c
+    x = get(rst, length(rst), input)
+    push!(rst, l(x))
   end
   return rst
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -41,8 +41,8 @@ function Base.show(io::IO, c::Chain)
 end
 
 
-# This is a temporary and naive inplementation
-# it might be replaced in the future to get better performance
+# This is a temporary and naive implementation
+# it might be replaced in the future for better performance
 # see issue https://github.com/FluxML/Flux.jl/issues/702
 # Johnny Chen -- @johnnychen94
 """

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -42,18 +42,14 @@ end
 
 
 """
-    activations(c::Union{Chain, Any}, x)
+    activations(c::Chain, x)
 Calculate the forward results of each layers in Chain `c`
 """
-activations(m, x) = activations(Chain(m), x)
 function activations(c::Chain, x)
-    if length(c) == 0
-        return []
+    if isempty(c)
+        return [x, ]
     end
-    rst = [c[1](x), ]
-    if length(c) == 1
-        return rst
-    end
+    rst = [x, c[1](x)]
     for l in c[2:end]
         push!(rst, l(rst[end]))
     end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -41,15 +41,18 @@ function Base.show(io::IO, c::Chain)
 end
 
 
+# This is a temporary and naive inplementation
+# see issue https://github.com/FluxML/Flux.jl/issues/702
 """
     activations(c::Chain, x)
 Calculate the forward results of each layers in Chain `c`
 """
 function activations(c::Chain, x)
+  rst = Array{Any,1}()
   if isempty(c)
-    return [x, ]
+    return rst
   end
-  rst = [x, c[1](x)]
+  push!(rst, c[1](x))
   for l in c[2:end]
     push!(rst, l(rst[end]))
   end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -40,7 +40,23 @@ function Base.show(io::IO, c::Chain)
   print(io, ")")
 end
 
-activations(c::Chain, x) = accumulate((x, m) -> m(x), c.layers, init = x)
+
+"""
+    activations(c::Union{Chain, Any}, x)
+Calculate the forward results of each layers in Chain `c`
+"""
+activations(m, x) = activations(Chain(m), x)
+function activations(c::Chain, x)
+    rst = [c[1](x), ]
+    if length(c) == 1
+        return rst
+    end
+    for l in c[2:end]
+        push!(rst, l(rst[end]))
+    end
+    return rst
+end
+
 
 """
     Dense(in::Integer, out::Integer, σ = identity)

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -1,21 +1,21 @@
 using Test, Random
 import Flux: activations
 
-@testset "helpers" begin
-    @testset "activations" begin
-        dummy_model = Chain(Dense(10,5,σ),Dense(5,2),softmax)
-        x = rand(10)
-        @test_nowarn activations(dummy_model[1], x)
-        @test_nowarn activations(dummy_model[1:end-1], x)
-        @test_nowarn activations(dummy_model, x)
-
-        @test activations(Chain(), x) == []
-        @test activations(dummy_model, x)[1] == dummy_model[1](x)
-        @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
-    end
-end
-
 @testset "basic" begin
+    @testset "helpers" begin
+        @testset "activations" begin
+            dummy_model = Chain(Dense(10,5,σ),Dense(5,2),softmax)
+            x = rand(10)
+            @test_nowarn activations(dummy_model[1], x)
+            @test_nowarn activations(dummy_model[1:end-1], x)
+            @test_nowarn activations(dummy_model, x)
+            
+            @test activations(Chain(), x) == []
+            @test activations(dummy_model, x)[1] == dummy_model[1](x)
+            @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
+        end
+    end
+    
     @testset "Chain" begin
         @test_nowarn Chain(Dense(10, 5, σ), Dense(5, 2))(randn(10))
         @test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn(10))

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -6,9 +6,11 @@ import Flux: activations
     @testset "activations" begin
       dummy_model = Chain(Dense(10,5,σ),Dense(5,2),softmax)
       x = rand(10)
-      @test activations(Chain(), x) == [x, ]
-      @test activations(dummy_model, x)[2] == dummy_model[1](x)
-      @test activations(dummy_model, x)[3] == x |> dummy_model[1] |> dummy_model[2]
+      @test activations(Chain(), x) == []
+      @test activations(dummy_model, x)[1] == dummy_model[1](x)
+      @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
+
+      @test_nowarn activations(Chain(identity, x->:foo), 1) # different types
     end
   end
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -1,4 +1,18 @@
 using Test, Random
+import Flux: activations
+
+@testset "helpers" begin
+    @testset "activations" begin
+        dummy_model = Chain(Dense(10,5,σ),Dense(5,2),softmax)
+        x = rand(10)
+        @test_nowarn activations(dummy_model[1], x)
+        @test_nowarn activations(dummy_model[1:end-1], x)
+        @test_nowarn activations(dummy_model, x)
+
+        @test activations(dummy_model, x)[1] == dummy_model[1](x)
+        @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
+    end
+end
 
 @testset "basic" begin
     @testset "Chain" begin

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -2,73 +2,73 @@ using Test, Random
 import Flux: activations
 
 @testset "basic" begin
-    @testset "helpers" begin
-        @testset "activations" begin
-            dummy_model = Chain(Dense(10,5,σ),Dense(5,2),softmax)
-            x = rand(10)
-            @test activations(Chain(), x) == [x, ]
-            @test activations(dummy_model, x)[2] == dummy_model[1](x)
-            @test activations(dummy_model, x)[3] == x |> dummy_model[1] |> dummy_model[2]
-        end
+  @testset "helpers" begin
+    @testset "activations" begin
+      dummy_model = Chain(Dense(10,5,σ),Dense(5,2),softmax)
+      x = rand(10)
+      @test activations(Chain(), x) == [x, ]
+      @test activations(dummy_model, x)[2] == dummy_model[1](x)
+      @test activations(dummy_model, x)[3] == x |> dummy_model[1] |> dummy_model[2]
+    end
+  end
+
+  @testset "Chain" begin
+    @test_nowarn Chain(Dense(10, 5, σ), Dense(5, 2))(randn(10))
+    @test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn(10))
+    # numeric test should be put into testset of corresponding layer
+  end
+
+  @testset "Dense" begin
+    @test  length(Dense(10, 5)(randn(10))) == 5
+    @test_throws DimensionMismatch Dense(10, 5)(randn(1))
+    @test_throws MethodError Dense(10, 5)(1) # avoid broadcasting
+    @test_throws MethodError Dense(10, 5).(randn(10)) # avoid broadcasting
+
+    @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(1, 1)
+    @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
+    @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
+    @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
+
+  end
+
+  @testset "Diagonal" begin
+    @test length(Flux.Diagonal(10)(randn(10))) == 10
+    @test length(Flux.Diagonal(10)(1)) == 10
+    @test length(Flux.Diagonal(10)(randn(1))) == 10
+    @test_throws DimensionMismatch Flux.Diagonal(10)(randn(2))
+
+    @test Flux.Diagonal(2)([1 2]) == [1 2; 1 2]
+    @test Flux.Diagonal(2)([1,2]) == [1,2]
+    @test Flux.Diagonal(2)([1 2; 3 4]) == [1 2; 3 4]
+  end
+
+  @testset "Maxout" begin
+    # Note that the normal common usage of Maxout is as per the docstring
+    # These are abnormal constructors used for testing purposes
+
+    @testset "Constructor" begin
+      mo = Maxout(() -> identity, 4)
+      input = rand(40)
+      @test mo(input) == input
     end
 
-    @testset "Chain" begin
-        @test_nowarn Chain(Dense(10, 5, σ), Dense(5, 2))(randn(10))
-        @test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn(10))
-        # numeric test should be put into testset of corresponding layer
+    @testset "simple alternatives" begin
+      mo = Maxout((x -> x, x -> 2x, x -> 0.5x))
+      input = rand(40)
+      @test mo(input) == 2*input
     end
 
-    @testset "Dense" begin
-        @test  length(Dense(10, 5)(randn(10))) == 5
-        @test_throws DimensionMismatch Dense(10, 5)(randn(1))
-        @test_throws MethodError Dense(10, 5)(1) # avoid broadcasting
-        @test_throws MethodError Dense(10, 5).(randn(10)) # avoid broadcasting
-
-        @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(1, 1)
-        @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
-        @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
-        @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
-
+    @testset "complex alternatives" begin
+      mo = Maxout((x -> [0.5; 0.1]*x, x -> [0.2; 0.7]*x))
+      input = [3.0 2.0]
+      target = [0.5, 0.7].*input
+      @test mo(input) == target
     end
 
-    @testset "Diagonal" begin
-        @test length(Flux.Diagonal(10)(randn(10))) == 10
-        @test length(Flux.Diagonal(10)(1)) == 10
-        @test length(Flux.Diagonal(10)(randn(1))) == 10
-        @test_throws DimensionMismatch Flux.Diagonal(10)(randn(2))
-
-        @test Flux.Diagonal(2)([1 2]) == [1 2; 1 2]
-        @test Flux.Diagonal(2)([1,2]) == [1,2]
-        @test Flux.Diagonal(2)([1 2; 3 4]) == [1 2; 3 4]
+    @testset "params" begin
+      mo = Maxout(()->Dense(32, 64), 4)
+      ps = params(mo)
+      @test length(ps) == 8  #4 alts, each with weight and bias
     end
-
-    @testset "Maxout" begin
-        # Note that the normal common usage of Maxout is as per the docstring
-        # These are abnormal constructors used for testing purposes
-
-        @testset "Constructor" begin
-            mo = Maxout(() -> identity, 4)
-            input = rand(40)
-            @test mo(input) == input
-        end
-
-        @testset "simple alternatives" begin
-            mo = Maxout((x -> x, x -> 2x, x -> 0.5x))
-            input = rand(40)
-            @test mo(input) == 2*input
-        end
-
-        @testset "complex alternatives" begin
-            mo = Maxout((x -> [0.5; 0.1]*x, x -> [0.2; 0.7]*x))
-            input = [3.0 2.0]
-            target = [0.5, 0.7].*input
-            @test mo(input) == target
-        end
-
-        @testset "params" begin
-            mo = Maxout(()->Dense(32, 64), 4)
-            ps = params(mo)
-            @test length(ps) == 8  #4 alts, each with weight and bias
-        end
-    end
+  end
 end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -9,8 +9,7 @@ import Flux: activations
       @test activations(Chain(), x) == []
       @test activations(dummy_model, x)[1] == dummy_model[1](x)
       @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
-
-      @test_nowarn activations(Chain(identity, x->:foo), 1) # different types
+      @test activations(Chain(identity, x->:foo), x)[2] == :foo # results include `Any` type
     end
   end
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -9,7 +9,7 @@ import Flux: activations
         @test_nowarn activations(dummy_model[1:end-1], x)
         @test_nowarn activations(dummy_model, x)
 
-        @test activations(Chain(), x)[1] == []
+        @test activations(Chain(), x) == []
         @test activations(dummy_model, x)[1] == dummy_model[1](x)
         @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
     end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -6,16 +6,12 @@ import Flux: activations
         @testset "activations" begin
             dummy_model = Chain(Dense(10,5,σ),Dense(5,2),softmax)
             x = rand(10)
-            @test_nowarn activations(dummy_model[1], x)
-            @test_nowarn activations(dummy_model[1:end-1], x)
-            @test_nowarn activations(dummy_model, x)
-            
-            @test activations(Chain(), x) == []
-            @test activations(dummy_model, x)[1] == dummy_model[1](x)
-            @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
+            @test activations(Chain(), x) == [x, ]
+            @test activations(dummy_model, x)[2] == dummy_model[1](x)
+            @test activations(dummy_model, x)[3] == x |> dummy_model[1] |> dummy_model[2]
         end
     end
-    
+
     @testset "Chain" begin
         @test_nowarn Chain(Dense(10, 5, σ), Dense(5, 2))(randn(10))
         @test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn(10))

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -9,6 +9,7 @@ import Flux: activations
         @test_nowarn activations(dummy_model[1:end-1], x)
         @test_nowarn activations(dummy_model, x)
 
+        @test activations(Chain(), x)[1] == []
         @test activations(dummy_model, x)[1] == dummy_model[1](x)
         @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
     end


### PR DESCRIPTION
As a temporary patch to https://github.com/FluxML/Flux.jl/issues/702
It's highly possible that there's a better implementation. But this can be a start-point for a stable `activations` function.

According to https://github.com/FluxML/Flux.jl/commit/9d1d5187f349252365e73adb7a2da66caf29bfcf#commitcomment-30267188, we don't export this function.