### PR TITLE
Implemented vectorized LRNorm

### DIFF
--- a/docs/src/models/layers.md
+++ b/docs/src/models/layers.md
@@ -47,6 +47,7 @@ Flux.testmode!
 BatchNorm
 Dropout
 LayerNorm
+LRNorm
 ```
 
 ## Activation Functions

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -8,7 +8,7 @@ using MacroTools: @forward
 
 export Chain, Dense, Maxout, RNN, LSTM, GRU, Conv, ConvTranspose, MaxPool, MeanPool,
        DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm, 
-       params, mapleaves, cpu, gpu, f32, f64
+       LRNorm, params, mapleaves, cpu, gpu, f32, f64
 
 @reexport using NNlib
 

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -420,8 +420,8 @@ function (lrn::LRNorm)(x)
   num_channels = size(x, 3)
   y = zeros(eltype(data(x)), 1, 1, num_channels, num_channels)
   for i in 1:num_channels
-    lower_lim = max(1, trunc(Int, i - lrn.n/2))
-    upper_lim = min(num_channels, trunc(Int, i + lrn.n/2))
+    lower_lim = max(1, trunc(Int, i - div(lrn.n,2)))
+    upper_lim = min(num_channels, trunc(Int, i + div(lrn.n,2)))
     y[1, 1, lower_lim:upper_lim, i] .= 1
   end
   norm = lrn.α .* NNlib.conv(x .^ 2, y)

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -392,3 +392,48 @@ function Base.show(io::IO, l::GroupNorm)
   (l.λ == identity) || print(io, ", λ = $(l.λ)")
   print(io, ")")
 end
+
+"""
+    LRNorm(α, β, n, k)
+Local Response Normalization layer. The `n` input should be the number of 
+adjacent kernel maps to sum over.
+See [ImageNet Classification with Deep Convolutional
+Neural Networks](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf).
+
+Example : 
+```julia
+m = LRNorm(0.0001, 0.75, 5, 2.0)
+m(x) #x is a 4-D input
+```
+"""
+mutable struct LRNorm{F, V, W, N}
+  α :: F
+  β :: V
+  n :: W
+  k :: N
+  active :: Bool
+end
+
+LRNorm(α = 10.0 ^ (-4), β = 0.75, n = 5, k = 2.0) = LRNorm(α, β, n, k, true)
+
+function (lrn::LRNorm)(x)
+  num_channels = size(x, 3)
+  y = zeros(eltype(x), size(x))
+  for i in size(y, 3)
+    lower_lim = max(1, trunc(Int, i + 1 - lrn.n/2))
+    upper_lim = min(num_channels, trunc(Int, i + 1 + lrn.n/2))
+    y[:, :, lower_lim:upper_lim, :] .= 1
+  end
+  y = lrn.α .* sum(y .* (x .^ 2), dims = 3)
+  y = y .+ lrn.k
+  y = y .^ lrn.β
+  return x ./ y 
+end 
+
+children(lrn::LRNorm) =
+  (lrn.α, lrn.β, lrn.n, lrn.k, lrn.active)
+
+mapchildren(f, lrn::LRNorm) =  # e.g. mapchildren(cu, BN)
+  LRNorm(lrn.α, f(lrn.β), f(lrn.n), f(lrn.k), lrn.active)
+
+_testmode!(lrn::LRNorm, test) = (lrn.active = !test)

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -418,12 +418,8 @@ LRNorm(α = 10.0 ^ (-4), β = 0.75, n = 5, k = 2.0) = LRNorm(α, β, n, k, true)
 
 function (lrn::LRNorm)(x)
   num_channels = size(x, 3)
-  if typeof(x) <: TrackedArray
-    y = zeros(eltype(x.data), 1, 1, num_channels, num_channels)
-  else
-    y = zeros(eltype(x), 1, 1, num_channels, num_channels)
-  end
-  for i in num_channels
+  y = zeros(eltype(data(x)), 1, 1, num_channels, num_channels)
+  for i in 1:num_channels
     lower_lim = max(1, trunc(Int, i - lrn.n/2))
     upper_lim = min(num_channels, trunc(Int, i + lrn.n/2))
     y[1, 1, lower_lim:upper_lim, i] .= 1

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -314,25 +314,4 @@ end
 @testset "LRNorm" begin
   x = param(reshape(Float32[1:96;], 4, 4, 3, 2))
   @test size(LRNorm()(x)) == size(x) 
-
-  function iterative_lrnorm(x, a, b, n, k)
-    num_channels = size(x, 3)
-    y = ones(size(x))
-    for i in CartesianIndices(x)
-      norm_term = 0
-      lower_lim = max(1, trunc(Int, i[3] + 1 - n/2))
-      upper_lim = min(num_channels, trunc(Int, i[3] + 1 + n/2))
-      for j in lower_lim:upper_lim
-        norm_term += a * (x[i[1],i[2], j, i[4]]) ^ 2  
-      end
-      norm_term += k
-      norm_term = norm_term ^ b
-      norm_term = norm_term.data
-      y[i] = y[i] / norm_term     #Every spatial location normalised.
-    end
-    return y .* x
-  end
-
-  m = LRNorm()
-  @test m(x) ≈ iterative_lrnorm(x, 10.0^(-4), 0.75, 5, 2.0)
 end

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -311,3 +311,28 @@ end
   end
 
 end
+@testset "LRNorm" begin
+  x = param(reshape(Float32[1:96;], 4, 4, 3, 2))
+  @test size(LRNorm()(x)) == size(x) 
+
+  function iterative_lrnorm(x, a, b, n, k)
+    num_channels = size(x, 3)
+    y = ones(size(x))
+    for i in CartesianIndices(x)
+      norm_term = 0
+      lower_lim = max(1, trunc(Int, i[3] + 1 - n/2))
+      upper_lim = min(num_channels, trunc(Int, i[3] + 1 + n/2))
+      for j in lower_lim:upper_lim
+        norm_term += a * (x[i[1],i[2], j, i[4]]) ^ 2  
+      end
+      norm_term += k
+      norm_term = norm_term ^ b
+      norm_term = norm_term.data
+      y[i] = y[i] / norm_term     #Every spatial location normalised.
+    end
+    return y .* x
+  end
+
+  m = LRNorm()
+  @test m(x) ≈ iterative_lrnorm(x, 10.0^(-4), 0.75, 5, 2.0)
+end

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -311,7 +311,25 @@ end
   end
 
 end
+
 @testset "LRNorm" begin
   x = param(reshape(Float32[1:96;], 4, 4, 3, 2))
-  @test size(LRNorm()(x)) == size(x) 
+  @test size(LRNorm()(x)) == size(x)
+
+  #Show that when bias k = 0, and n = 0, alpha = 1, and beta = 0.5, all spatial locations will be normalised to a value of 1
+  m = LRNorm(1, 0.5, 0, 0)
+  @test m(x) ≈ ones(4, 4, 3, 2) 
+
+  #Show the trivial case when beta = 0, output is equal to input
+  m1 = LRNorm(1, 0, 5 ,2)
+  @test m1(x) ≈ x
+
+  m2 = LRNorm()
+  x2 = param(reshape(Float32[1:10;], 1, 1, 10, 1))
+  answer = [0.59 1.19 1.78 2.37 2.96 3.54 4.12 4.69 5.29 5.88]     #These values are computed using tensorflow's LRNorm. 
+  answer = reshape(answer, 1, 1, 10, 1)
+  #The value computed by LRNorm is approximately equal to that computed by tensorflow
+  computed = m2(x2)
+  approx = round.(computed, digits = 2)
+  @test approx ≈ answer
 end

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -326,7 +326,7 @@ end
 
   m2 = LRNorm()
   x2 = param(reshape(Float32[1:10;], 1, 1, 10, 1))
-  answer = [0.59 1.19 1.78 2.37 2.96 3.54 4.12 4.69 5.29 5.88]     #These values are computed using tensorflow's LRNorm. 
+  answer = [0.59 1.19 1.78 2.37 2.96 3.54 4.12 4.70 5.29 5.89]     #These values are computed using tensorflow's LRNorm. 
   answer = reshape(answer, 1, 1, 10, 1)
   #The value computed by LRNorm is approximately equal to that computed by tensorflow
   computed = m2(x2)


### PR DESCRIPTION
Added function for Local Response Normalization. Reference: https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf. The previous PRs on adding LRNorm used for loops and indexing, due to which automatic differentiation was not supported. I have implemented a vectorized version of LRNorm. 