### PR TITLE
Swap comma for full stop

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -383,7 +383,7 @@ children(gn::GroupNorm) =
   (gn.λ, gn.β, gn.γ, gn.μ, gn.σ², gn.ϵ, gn.momentum, gn.active)
 
 mapchildren(f, gn::GroupNorm) =  # e.g. mapchildren(cu, BN)
-  GroupNorm(gn,G,gn.λ, f(gn.β), f(gn.γ), f(gn.μ), f(gn.σ²), gn.ϵ, gn.momentum, gn.active)
+  GroupNorm(gn.G,gn.λ, f(gn.β), f(gn.γ), f(gn.μ), f(gn.σ²), gn.ϵ, gn.momentum, gn.active)
 
 _testmode!(gn::GroupNorm, test) = (gn.active = !test)
 


### PR DESCRIPTION
"ERROR: LoadError: UndefVarError: G not defined" caused by "gn,G" rather than "gn.G" in line 386. Swapping for full stop should fix this