### PR TITLE
Fix for onecold broadcast bug

### DIFF
--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -121,8 +121,7 @@ onecold(y::AbstractVector, labels = 1:length(y)) = labels[Base.argmax(y)]
 onecold(y::AbstractMatrix, labels...) =
   dropdims(mapslices(y -> onecold(y, labels...), y, dims=1), dims=1)
 
-onecold(y::OneHotMatrix, labels...) =
-  mapreduce(x -> Flux.onecold(x, labels...), |, y.data, dims = 2, init = 0)
+onecold(y::OneHotMatrix, labels...) = map(x -> Flux.onecold(x, labels...), y.data)
 
 function argmax(xs...)
   Base.depwarn("`argmax(...)` is deprecated, use `onecold(...)` instead.", :argmax)

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -10,6 +10,13 @@ using Test
   @test onecold(A) == [3, 1, 4]
   @test onecold(a, labels) == 'C'
   @test onecold(A, labels) == ['C', 'A', 'D']
+
+  data = [:b, :a, :c]
+  labels = [:a, :b, :c]
+  hot = onehotbatch(data, labels)
+  cold = onecold(hot, labels)
+
+  @test cold == data
 end
 
 @testset "onehotbatch indexing" begin

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -13,7 +13,7 @@ using Test
 
   data = [:b, :a, :c]
   labels = [:a, :b, :c]
-  hot = onehotbatch(data, labels)
+  hot = Flux.onehotbatch(data, labels)
   cold = onecold(hot, labels)
 
   @test cold == data


### PR DESCRIPTION
Using `mapreduce` was returning an `Array` when used with `OneHotMatrix{CuArray}`. This causes issues down the chain. `map` avoids that, and also avoids the reduction giving slightly better speed (~40x).