### PR TITLE
store apply function in Chain

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -18,7 +18,8 @@ m(x) == m[2](m[1](x))
 """
 struct Chain{T<:Tuple}
   layers::T
-  Chain(xs...) = new{typeof(xs)}(xs)
+  apply::Any
+  Chain(xs...) = new{typeof(xs)}(xs, isempty(xs) ? identity : reduce(∘, reverse(xs)))
 end
 
 @forward Chain.layers Base.getindex, Base.length, Base.first, Base.last,
@@ -27,10 +28,7 @@ end
 children(c::Chain) = c.layers
 mapchildren(f, c::Chain) = Chain(f.(c.layers)...)
 
-applychain(::Tuple{}, x) = x
-applychain(fs::Tuple, x) = applychain(tail(fs), first(fs)(x))
-
-(c::Chain)(x) = applychain(c.layers, x)
+(c::Chain)(x) = c.apply(x)
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i]...)
 


### PR DESCRIPTION
I replace recursive function `applychain` with [a function composition](https://docs.julialang.org/en/v1.3-dev/manual/functions/#Function-composition-and-piping-1) and store result in Chain type.
It can speed up execution a little.