### PR TITLE
parallel layer

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -6,8 +6,8 @@ using Base: tail
 using MacroTools, Juno, Requires, Reexport, Statistics, Random
 using MacroTools: @forward
 
-export Chain, Dense, Maxout, RNN, LSTM, GRU, Conv, ConvTranspose, MaxPool, MeanPool,
-       DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm, 
+export Chain, Parallel, Dense, Maxout, RNN, LSTM, GRU, Conv, ConvTranspose, MaxPool, MeanPool,
+       DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm,
        params, mapleaves, cpu, gpu, f32, f64
 
 @reexport using NNlib

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -19,6 +19,14 @@ import Flux: activations
     # numeric test should be put into testset of corresponding layer
   end
 
+  @testset "Parallel" begin
+    input = randn(10)
+    model = Parallel(Dense(10, 5, σ), Dense(10, 5, σ))
+    @test_nowarn model(input)
+    @test model(input) == [model[1](input), model[2](input)]
+    @test_throws DimensionMismatch Parallel(Dense(10, 5, σ), Dense(5, 2, σ))(input)
+  end
+
   @testset "Dense" begin
     @test  length(Dense(10, 5)(randn(10))) == 5
     @test_throws DimensionMismatch Dense(10, 5)(randn(1))


### PR DESCRIPTION
This is aimed to simply the case when you wish to call multiple layers in parallel rather than in sequence. For example in the resnet style approach you apply a layer and the identity function then sum them. This can be written like so

```
model = Chain(Parallel(Conv((3, 3), 3=>3, pad=1),
                       x -> x),
              sum)

inputs = randn(28, 28, 3, 1)
model(inputs)
```

If you wish to have a set of convolutional layers that can extract different sized features and then concat them together of the feature dimension.

```
model = Chain(Parallel(Conv((3, 3), 3=>3),
                       Conv((5, 5), 3=>3, pad=1),
                       Conv((7, 7), 3=>3, pad=2)),
              x -> cat(x..., dims=3))


inputs = randn(28, 28, 3, 1)
model(inputs)
```