### PR TITLE
multi input layer

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -6,8 +6,8 @@ using Base: tail
 using MacroTools, Juno, Requires, Reexport, Statistics, Random
 using MacroTools: @forward
 
-export Chain, Dense, Maxout, RNN, LSTM, GRU, Conv, ConvTranspose, MaxPool, MeanPool,
-       DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm, 
+export Chain, MultiInput, Dense, Maxout, RNN, LSTM, GRU, Conv, ConvTranspose, MaxPool, MeanPool,
+       DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm,
        params, mapleaves, cpu, gpu, f32, f64
 
 @reexport using NNlib

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -88,7 +88,7 @@ end
 children(m::MultiInput) = m.layers
 mapchildren(f, m::MultiInput) = MultiInput(f.(m.layers)...)
 
-(m::MultiInput)(xs) = [layer(x) for (layer, x) in zip(m.layers, xs)]
+(m::MultiInput)(xs) = map((layer, x) -> layer(x), m.layers, xs)
 
 Base.getindex(m::MultiInput, i::AbstractArray) = MultiInput(m.layers[i]...)
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -19,6 +19,14 @@ import Flux: activations
     # numeric test should be put into testset of corresponding layer
   end
 
+  @testset "MultiInput" begin
+    model = MultiInput(Dense(10, 5, σ), Dense(5, 2, σ))
+    x = (randn(10), randn(5))
+    @test_nowarn model(x)
+    @test_throws DimensionMismatch MultiInput(Dense(10, 5, σ),Dense(2, 1))(x)
+    @test model(x) == [model[1](x[1]), model[2](x[2])]
+  end
+
   @testset "Dense" begin
     @test  length(Dense(10, 5)(randn(10))) == 5
     @test_throws DimensionMismatch Dense(10, 5)(randn(1))

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -24,7 +24,7 @@ import Flux: activations
     x = (randn(10), randn(5))
     @test_nowarn model(x)
     @test_throws DimensionMismatch MultiInput(Dense(10, 5, σ),Dense(2, 1))(x)
-    @test model(x) == [model[1](x[1]), model[2](x[2])]
+    @test model(x) == (model[1](x[1]), model[2](x[2]))
   end
 
   @testset "Dense" begin


### PR DESCRIPTION
This layer can be helpful in the case when your model takes in multiple inputs. For a Q network you take in both the state and the action and try to predict the expected sum of discounted rewards. Typically you would have to write this by constructing the different inputs separately.

```
state, action = randn(4), randn(2)

state_input = Dense(4, 20)
action_input = Dense(2, 20)
model = Chain(Dense(40, 20, elu), Dense(20, 1))
Q = model(vcat(state_input(state), action_input(action)))
```

However, this makes it awkward when trying to collect all the parameters or pass around the entire model as one struct.

Instead we can have a combinator which allows for multiple inputs and the whole implementation becomes simpler.

```
state, action = randn(4), randn(2)

model = Chain(MultiInput(Dense(4, 20), Dense(2, 20)),
              x -> vcat(x...),
              Dense(40, 20, elu),
              Dense(20, 1))

Q = model((state, action))
```

Now we have something which looks like a function again, and it just takes in multiple inputs. You can query for the parameters and make it part of a longer chain if needed.