### PR TITLE
Towards Hypernet Layer

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -9,6 +9,7 @@ using MacroTools: @forward
 export Chain, Dense, Maxout, RNN, LSTM, GRU, Conv, CrossCor, ConvTranspose, MaxPool, MeanPool,
        DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm,
        SkipConnection,
+       HyperNet, HyperDense,
        params, mapleaves, cpu, gpu, f32, f64
 
 @reexport using NNlib
@@ -33,6 +34,7 @@ include("layers/basic.jl")
 include("layers/conv.jl")
 include("layers/recurrent.jl")
 include("layers/normalise.jl")
+include("layers/hypernet.jl")
 
 include("data/Data.jl")
 

--- a/src/layers/hypernet.jl
+++ b/src/layers/hypernet.jl
@@ -1,0 +1,22 @@
+using Flux: @treelike
+
+# should this be HyperNet{H,M} ?
+struct HyperNet
+    h
+    m
+end
+
+@treelike HyperNet
+
+function (H::HyperNet)(t)
+    _, re = destructure(H.m)
+    ps = H.h(t)
+    return re(ps)
+end
+
+function HyperDense(in_dim,m,σ)
+    p,_ = destructure(m)
+    return Dense(in_dim,length(p),σ)
+end
+
+HyperDense(in_dim,m) = HyperDense(in_dim,m,identity)

--- a/test/layers/hypernet.jl
+++ b/test/layers/hypernet.jl
@@ -1,0 +1,21 @@
+using Flux
+using Flux: destructure,restructure
+using Test
+
+
+@testset "Correct Dimensions for HyperDense" begin
+    m = Chain(Dense(4,5),Dense(5,2))
+    ps, re = destructure(m)
+    hyper = Chain(Dense(1,10,tanh),HyperDense(10,m))
+    @test length(hyper([1])) == length(ps)
+    hyper = Chain(Dense(1,10,tanh),HyperDense(10,m,tanh))
+    @test length(hyper([1])) == length(ps)
+end
+
+@testset "Define HyperNet for Chain" begin
+    m = Chain(Dense(5,10,σ),Dense(10,2))
+    h = Chain(Dense(1,10,tanh),HyperDense(10,m))
+    hyper = HyperNet(h,m)
+    x = rand(5)
+    @test restructure(m,h([1]))(x) == hyper([1])(x)
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,6 @@
 using Flux
 using Flux: throttle, jacobian, glorot_uniform, glorot_normal, stack, unstack
+using Flux: destructure
 using StatsBase: std
 using Random
 using Test
@@ -110,4 +111,27 @@ end
   @test unstack(stacked_array, 2) == unstacked_array
   @test stack(unstacked_array, 2) == stacked_array
   @test stack(unstack(stacked_array, 1), 1) == stacked_array
+end
+
+
+@testset "De/Re-Structuring" begin
+    #Single Dense Layer
+    m_orig = Dense(1,2)
+    ps, re = destructure(m_orig)
+    m_reparamed = re(ps)
+    ps_new = param(randn!(similar(ps))) # needs param o/w no restructure...
+    m2=re(ps_new)
+    @test destructure(m_orig)[1] == destructure(m_reparamed)[1]
+    @test destructure(m2)[1] == ps_new
+    # Chain
+    m_orig = Chain(Dense(10,2,tanh),Dense(2,4))
+    ps, re = destructure(m_orig)
+    m_reparamed = re(ps)
+    ps_new = param(randn!(similar(ps))) # needs param o/w no restructure...
+    m2=re(ps_new)
+    @test destructure(m_orig)[1] == destructure(m_reparamed)[1]
+    @test destructure(m2)[1] == ps_new
+end
+
+@testset begin
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -133,5 +133,12 @@ end
     @test destructure(m2)[1] == ps_new
 end
 
-@testset begin
+@testset "Restructure with Untracked" begin
+    m = Dense(2,3)
+    ps, re = destructure(m)
+    m2 = re(Flux.data(ps))
+    ps2,_ = destructure(m2)
+    println(ps)
+    println(ps2)
+    @test_broken ps == ps2
 end


### PR DESCRIPTION
Implementation towards the discussion in #797 including the explicit/implicit parameterization tools discussed in #742. 

@MikeInnes Can you take a look at the `HyperNet` struct. In particular, do you think it should have type annotation like `HyperNet{H,M}` I don't know how to get such a thing working.

Also, I ran into a problem where `restructure` expects the parameters to be tracked going in. This is annoying as it fails silently, and the resulting model is just reparamterized with nothing as you can see in the broken test. If you supply `restructure` with an untracked array it will create the model with an empty `Any[]` array and fail silently. The check for `TrackedArray` was included in the DiffEqFlux implementation. @ChrisRackauckas do you remember why? If this is required it should produce an error possibly.