### PR TITLE
Do not learn RNN initial state by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build/
 docs/site/
 deps
+.tags*

--- a/docs/src/models/recurrence.md
+++ b/docs/src/models/recurrence.md
@@ -124,3 +124,11 @@ function loss(x,y)
   return l
 end
 ```
+
+## Learning the Initial State
+
+By default, the hidden state of RNN cells is initialised to zero, and is reset to zero every time `Flux.reset!` is called. Some models treat this initial state as a learnable parameter, which must be optimised during training. For such models, *learn_initial_state!* must be invoked:
+
+```julia
+Flux.learn_initial_state!(m)
+```

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -1,0 +1,24 @@
+using Flux, Test
+using Flux: gradient, Optimise, reset!, learn_initial_state!
+using Flux.Optimise: update!
+
+dummyloss(rnn, x) = sum(rnn(x))
+
+function test_init_reset_nolearn(rnn, x, test_init)
+  opt = ADAM()
+  ps = params(rnn)
+  @test rnn.init == test_init
+  @test rnn.state == test_init
+  gs = gradient(()->dummyloss(rnn, x), ps)
+  update!(opt, ps, gs)
+  @test rnn.state != test_init
+  @test rnn.init == test_init
+  reset!(rnn)
+  @test rnn.state == test_init
+end
+
+@testset "RNN init/reset default workflow" begin
+  test_init_reset_nolearn(RNN(5, 10), rand(5), zeros(10))
+  test_init_reset_nolearn(LSTM(5, 10), rand(5), (zeros(10), zeros(10)))
+  test_init_reset_nolearn(GRU(5, 10), rand(5), zeros(10))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ include("layers/basic.jl")
 include("layers/normalisation.jl")
 include("layers/stateless.jl")
 include("layers/conv.jl")
+include("layers/recurrent.jl")
 
 @info "Running Gradient Checks"
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,6 @@
 using Flux
-using Flux: throttle, jacobian, glorot_uniform, glorot_normal, stack, unstack
+using Flux: throttle, jacobian, glorot_uniform, glorot_normal, stack, unstack,
+  learn_initial_state!
 using StatsBase: std
 using Random
 using Test
@@ -84,6 +85,8 @@ end
   m = Dense(10, 5)
   @test size.(params(m)) == [(5, 10), (5,)]
   m = RNN(10, 5)
+  @test size.(params(m)) == [(5, 10), (5, 5), (5,)]
+  learn_initial_state!(m)
   @test size.(params(m)) == [(5, 10), (5, 5), (5,), (5,)]
 end
 


### PR DESCRIPTION
Do not learn RNN initial state during backprop by default; leave this as an option
#807 