### PR TITLE
Fix #816: unnecessary typeasserts in implementations of apply!

### DIFF
--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -37,7 +37,7 @@ Momentum(η = 0.01, ρ = 0.9) = Momentum(η, ρ, IdDict())
 
 function apply!(o::Momentum, x, Δ)
   η, ρ = o.eta, o.rho
-  v = get!(o.velocity, x, zero(x))::typeof(data(x))
+  v = get!(o.velocity, x, zero(x))
   @. v = ρ * v - η * Δ
   @. Δ = -v
 end
@@ -57,7 +57,7 @@ Nesterov(η = 0.001, ρ = 0.9) = Nesterov(η, ρ, IdDict())
 
 function apply!(o::Nesterov, x, Δ)
   η, ρ = o.eta, o.rho
-  v = get!(o.velocity, x, zero(x))::typeof(data(x))
+  v = get!(o.velocity, x, zero(x))
   d = @. ρ^2 * v - (1+ρ) * η * Δ
   @. v = ρ*v - η*Δ
   @. Δ = -d
@@ -80,7 +80,7 @@ RMSProp(η = 0.001, ρ = 0.9) = RMSProp(η, ρ, IdDict())
 
 function apply!(o::RMSProp, x, Δ)
   η, ρ = o.eta, o.rho
-  acc = get!(o.acc, x, zero(x))::typeof(data(x))
+  acc = get!(o.acc, x, zero(x))
   @. acc = ρ * acc + (1 - ρ) * Δ^2
   @. Δ *= η / (√acc + ϵ)
 end
@@ -147,7 +147,7 @@ ADAGrad(η = 0.1) = ADAGrad(η, IdDict())
 
 function apply!(o::ADAGrad, x, Δ)
   η = o.eta
-  acc = get!(o.acc, x, fill(ϵ, size(x)))::typeof(data(x))
+  acc = get!(o.acc, x, fill(ϵ, size(x)))
   @. acc += Δ^2
   @. Δ *= η / (√acc + ϵ)
 end


### PR DESCRIPTION
As I mention in #816, typeasserts of the form `get!(...)::typeof(data(x))` cause training to fail in some edge cases involving custom layers. This change would just remove the typeasserts from the definitions of `apply!` for the optimisers `Momentum`, `Nesterov`, `RMSProp`, and `ADAGrad` (the only optimisers where #816 is relevant).