### PR TITLE
Add binary crossentropy fallback functions

### DIFF
--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -25,6 +25,11 @@ Return `-y*log(ŷ + ϵ) - (1-y)*log(1-ŷ + ϵ)`. The ϵ term provides numerica
 """
 binarycrossentropy(ŷ, y; ϵ=eps(ŷ)) = -y*log(ŷ + ϵ) - (1 - y)*log(1 - ŷ + ϵ)
 
+function binarycrossentropy(ŷ::AbstractVector, y::Number; kwargs...)
+    length(ŷ) == 1 || throw(DimensionMismatch("expected scalar value"))
+    binarycrossentropy(ŷ[1], y; kwargs...)
+end
+
 """
     logitbinarycrossentropy(logŷ, y)
 
@@ -38,6 +43,11 @@ but it is more numerically stable.
      0.86167
 """
 logitbinarycrossentropy(logŷ, y) = (1 - y)*logŷ - logσ(logŷ)
+
+function logitbinarycrossentropy(logŷ::AbstractVector, y::Number)
+    length(logŷ) == 1 || throw(DimensionMismatch("expected scalar value"))
+    logitbinarycrossentropy(logŷ[1], y)
+end
 
 """
     normalise(x::AbstractArray; dims=1)

--- a/test/layers/stateless.jl
+++ b/test/layers/stateless.jl
@@ -44,10 +44,12 @@ const ϵ = 1e-7
   @testset "binarycrossentropy" begin
     @test binarycrossentropy.(σ.(logŷ), y; ϵ=0) ≈ -y.*log.(σ.(logŷ)) - (1 .- y).*log.(1 .- σ.(logŷ))
     @test binarycrossentropy.(σ.(logŷ), y) ≈ -y.*log.(σ.(logŷ) .+ eps.(σ.(logŷ))) - (1 .- y).*log.(1 .- σ.(logŷ) .+ eps.(σ.(logŷ)))
+    @test binarycrossentropy([σ(0)], 1) ≈ -log(σ(0) + eps(σ(0)))
   end
 
   @testset "logitbinarycrossentropy" begin
     @test logitbinarycrossentropy.(logŷ, y) ≈ binarycrossentropy.(σ.(logŷ), y; ϵ=0)
+    @test logitbinarycrossentropy([0.0], 1) ≈ binarycrossentropy(σ(0), 1; ϵ=0)
   end
 
   @testset "no spurious promotions" begin


### PR DESCRIPTION
These fallbacks assume that if the first argument is a 1-element
`Vector` (as given by a model's output) and the second argument is a
scalar, the first argument should also be interpreted as a scalar.
Ref #850.

The use case is putting a model's scalar output right into the loss function instead of having to manually index into the 1-element `Vector` which is easily forgotten.

Not sure if this is desired, otherwise just close this. It does have the benefit of preventing not so obvious errors that – in my opinion – should not happen.