### PR TITLE
Dense with optional reshape

### DIFF
--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -30,6 +30,14 @@ import Flux: activations
     @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
     @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
 
+    @test size(Dense(10 => 5)(randn(10))) == (5,)
+    @test size(Dense(10 => (5,))(randn(10))) == (5,)
+    @test size(Dense(10 => (5,))(randn(10,7))) == (5,7)
+    @test size(Dense(10 => (5,3))(randn(10,7))) == (5,3,7)
+    @test size(Dense((10,7) => 5)(randn(10,7))) == (5,)
+
+    @test Dense(10, (2,2), identity, initW=ones, initb=ones)(ones(10,3)) == 11 .* ones(2,2,3)
+    @test Dense((3,3) => (2,2), sqrt, initW=ones, initb=zeros)(ones(3,3,5)) == 3 .* ones(2,2,5)
   end
 
   @testset "Diagonal" begin


### PR DESCRIPTION
Fixes #282, by allowing `Dense((5, 3), (2, 7))` as suggested. Also closes #293, #617.

For `d = Dense(15, 14)` I wanted to leave the original behaviour alone, but attempting to do this by dispatch landed me in ambiguity hell, so it's an `if` statement (which I think ought to get compiled out). Possibly this should have `&& ndims(x)<=2` so that such `d` does allow higher-dimensional data. 

I also added a line to allow `Dense(15 => 14)` and `Dense((5, 3) => (2, 7))`, more like `Conv` and less confusing I think. But will remove if anyone objects / thinks this deserves its own issue. 

Note by the way the following `::Any` problem. Since this persists after `] free Flux`, I don't think it's my fault. (This is on Julia 1.1)
```
julia> d = Dense(5,2)
Dense(5 => 2)

julia> @code_warntype d(rand(Float32, 5))
Body::Any
```