### PR TITLE
Activations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ model = Chain(
 
 loss(x, y) = crossentropy(model(x), y)
 
-Flux.train!(loss, data, ADAM(...))
+Flux.train!(loss, params(model), data, ADAM(...))
 ```
 
 Yet you can easily strip away the layers, and directly write the mathematics for your problem. Flux will seamlessly take gradients of any Julia code, so your model looks just like the paper.

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -31,6 +31,8 @@ applychain(fs::Tuple, x) = applychain(tail(fs), first(fs)(x))
 
 (c::Chain)(x) = applychain(c.layers, x)
 
+(c::Chain)(x, i) = extraChain(c.layers, x)[i]
+
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i]...)
 
 function Base.show(io::IO, c::Chain)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -51,9 +51,11 @@ Calculate the forward results of each layers in Chain `c` with `input` as model 
 """
 function activations(c::Chain, input)
   res = Zygote.Buffer([], length(c))
-  res[1] = c[1](input)
-  for (i,l) in enumerate(c[2:end])
-    res[i+1] = l(res[i])
+  if length(c) > 0
+    res[1] = c[1](input)
+    for (i,l) in enumerate(c[2:end])
+      res[i+1] = l(res[i])
+    end
   end
   return copy(res)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -44,17 +44,15 @@ end
 # it might be replaced in the future for better performance
 # see issue https://github.com/FluxML/Flux.jl/issues/702
 # Johnny Chen -- @johnnychen94
+# only slightly changed to better handle interaction with Zygote @dsweber2
 """
     activations(c::Chain, input)
 Calculate the forward results of each layers in Chain `c` with `input` as model input.
 """
 function activations(c::Chain, input)
-  rst = []
-  for l in c
-    x = get(rst, length(rst), input)
-    push!(rst, l(x))
-  end
-  return rst
+  buffed = accumulate!((x,y)->y(x), Zygote.Buffer([], length(c)),
+                       [l for l in c], dims=1, init=input) 
+  return copy(buffed)
 end
 
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -50,9 +50,12 @@ end
 Calculate the forward results of each layers in Chain `c` with `input` as model input.
 """
 function activations(c::Chain, input)
-  buffed = accumulate!((x,y)->y(x), Zygote.Buffer([], length(c)),
-                       [l for l in c], dims=1, init=input) 
-  return copy(buffed)
+  res = Zygote.Buffer([], length(c))
+  res[1] = c[1](input)
+  for (i,l) in enumerate(c[2:end])
+    res[i+1] = l(res[i])
+  end
+  return copy(res)
 end
 
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -50,15 +50,16 @@ end
 Calculate the forward results of each layers in Chain `c` with `input` as model input.
 """
 function activations(c::Chain, input)
-  res = Zygote.Buffer([], length(c))
-  if length(c) > 0
-    res[1] = c[1](input)
-    for (i,l) in enumerate(c[2:end])
-      res[i+1] = l(res[i])
-    end
-  end
-  return copy(res)
+    extraChain(c.layers, input)
 end
+
+function extraChain(fs::Tuple, x)
+    res = first(fs)(x)
+    return (res, extraChain(Base.tail(fs), res)...)
+end
+
+extraChain(::Tuple{}, x) = []
+
 
 
 """

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -31,7 +31,7 @@ applychain(fs::Tuple, x) = applychain(tail(fs), first(fs)(x))
 
 (c::Chain)(x) = applychain(c.layers, x)
 
-(c::Chain)(x, i) = extraChain(c.layers, x)[i]
+(c::Chain)(x) = extraChain(c.layers, x)
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i]...)
 
@@ -60,7 +60,7 @@ function extraChain(fs::Tuple, x)
     return (res, extraChain(Base.tail(fs), res)...)
 end
 
-extraChain(::Tuple{}, x) = []
+extraChain(::Tuple{}, x) = ()
 
 
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -31,8 +31,6 @@ applychain(fs::Tuple, x) = applychain(tail(fs), first(fs)(x))
 
 (c::Chain)(x) = applychain(c.layers, x)
 
-(c::Chain)(x) = extraChain(c.layers, x)
-
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i]...)
 
 function Base.show(io::IO, c::Chain)

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -19,6 +19,12 @@ import Flux: activations
     # numeric test should be put into testset of corresponding layer
   end
 
+  @testset "Activations" begin
+    c = Chain(Dense(3,5,relu), Dense(5,1,relu))
+    X = Float32.([1.0; 1.0; 1.0])
+    @test_nowarn gradient(()->Flux.activations(c, X)[2][1], params(c))
+  end
+
   @testset "Dense" begin
     @test  length(Dense(10, 5)(randn(10))) == 5
     @test_throws DimensionMismatch Dense(10, 5)(randn(1))

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -4,11 +4,13 @@ import Flux: activations
 @testset "basic" begin
   @testset "helpers" begin
     @testset "activations" begin
-      dummy_model = Chain(Dense(10,5,σ),Dense(5,2),softmax)
-      x = rand(10)
-      @test activations(Chain(), x) == []
-      @test activations(dummy_model, x)[1] == dummy_model[1](x)
-      @test activations(dummy_model, x)[2] == x |> dummy_model[1] |> dummy_model[2]
+      dummy_model = Chain(x->x.^2, x->x .- 3, x -> tan.(x))
+      x = randn(10)
+      @test activations(dummy_model, x)[1] == x.^2
+      @test activations(dummy_model, x)[2] == (x.^2 .- 3)
+      @test activations(dummy_model, x)[3] == tan.(x.^2 .- 3)
+
+      @test activations(Chain(), x) == ()
       @test activations(Chain(identity, x->:foo), x)[2] == :foo # results include `Any` type
     end
   end


### PR DESCRIPTION
Taking derivatives w.r.t. the parameters results in complaints about mutability (mwe below). To get around this, I made the storage array a `Zygote.Buffer`, and then return a copy after inserting everything. I tried an `accumulate!` based version, which worked on commit ecc9ce9d, but broke when I caught up.

Simple example:
```
c = Chain(Dense(3,5,relu), Dense(5,1,relu))
X = Float32.([1.0; 1.0; 1.0])
gradient(()->Flux.activations(c, X)[2][1], params(c))
```