### PR TITLE
Fix printing of SkipConnection

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -208,7 +208,6 @@ sm = SkipConnection(m, (mx, x) -> cat(mx, x, dims=3))
 size(sm(x)) == (5, 5, 11, 10)
 ```
 """
-function SkipConnection end
 struct SkipConnection
   layers
   connection  #user can pass arbitrary connections here, such as (a,b) -> a + b

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -217,7 +217,7 @@ end
 
 function Base.show(io::IO, b::SkipConnection)
   print(io, "SkipConnection(")
-  b.layers isa Chain ? join(io, b.layers, ", ") : print(io, b.layers)
-  print(io, ",", b.connection)
-  print(io, ")")
+  b.layers isa Chain ? print(io, "Chain(", join(b.layers, ", "), "), ") :
+    print(io, b.layers, ", ")
+  print(io, b.connection, ")")
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -192,17 +192,23 @@ end
 """
     SkipConnection(layers, connection)
 
-Creates a Skip Connection, which constitutes of a layer or `Chain` of consecutive layers
-and a shortcut connection linking the input to the block to the
-output through a user-supplied callable.
+Creates a Skip Connection, of a layer or `Chain` of consecutive layers
+plus a shortcut connection. The connection function will combine the result of the layers
+with the original input, to give the final output.
 
-`SkipConnection` requires the output dimension to be the same as the input.
+The simplest 'ResNet'-type connection is just `SkipConnection(layer, +)`,
+and requires the output of the layers to be the same shape as the input.
+Here is a more complicated example:
+```
+m = Conv((3,3), 4=>7, pad=(1,1))
+x = ones(5,5,4,10);
+size(m(x)) == (5, 5, 7, 10)
 
-A 'ResNet'-type skip-connection with identity shortcut would simply be
-```julia
-    SkipConnection(layer, +)
+sm = SkipConnection(m, (mx, x) -> cat(mx, x, dims=3))
+size(sm(x)) == (5, 5, 11, 10)
 ```
 """
+function SkipConnection end
 struct SkipConnection
   layers
   connection  #user can pass arbitrary connections here, such as (a,b) -> a + b

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -190,9 +190,9 @@ function (mo::Maxout)(input::AbstractArray)
 end
 
 """
-    SkipConnection(layers...)
+    SkipConnection(layers, connection)
 
-Creates a Skip Connection, which constitutes of a layer or Chain of consecutive layers
+Creates a Skip Connection, which constitutes of a layer or `Chain` of consecutive layers
 and a shortcut connection linking the input to the block to the
 output through a user-supplied callable.
 
@@ -200,7 +200,7 @@ output through a user-supplied callable.
 
 A 'ResNet'-type skip-connection with identity shortcut would simply be
 ```julia
-    SkipConnection(layer, (a,b) -> a + b)
+    SkipConnection(layer, +)
 ```
 """
 struct SkipConnection
@@ -217,6 +217,7 @@ end
 
 function Base.show(io::IO, b::SkipConnection)
   print(io, "SkipConnection(")
-  join(io, b.layers, ", ")
+  b.layers isa Chain ? join(io, b.layers, ", ") : print(io, b.layers)
+  print(io, ",", b.connection)
   print(io, ")")
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -211,13 +211,9 @@ end
 @functor SkipConnection
 
 function (skip::SkipConnection)(input)
-  #We apply the layers to the input and return the result of the application of the layers and the original input
   skip.connection(skip.layers(input), input)
 end
 
 function Base.show(io::IO, b::SkipConnection)
-  print(io, "SkipConnection(")
-  b.layers isa Chain ? print(io, "Chain(", join(b.layers, ", "), "), ") :
-    print(io, b.layers, ", ")
-  print(io, b.connection, ")")
+  print(io, "SkipConnection(", b.layers, ", ", b.connection, ")")
 end


### PR DESCRIPTION
Before:
```
julia> SkipConnection(Dense(2,2),+)
SkipConnection(Error showing value of type SkipConnection:
ERROR: MethodError: no method matching iterate(::Dense{typeof(identity),TrackedArray{…,Array{Float32,2}},TrackedArray{…,Array{Float32,1}}})

julia> SkipConnection(Chain(Dense(2,3), Dense(3,2), LayerNorm(2)),+)
SkipConnection(Dense(2, 3), Dense(3, 2), LayerNorm(2))

julia> SkipConnection(Dense(2, 3), Dense(3, 2), LayerNorm(2))
ERROR: MethodError: no method matching SkipConnection(::Dense{typeof(identity),TrackedArray{…,Array{Float32,2}},TrackedArray{…,Array{Float32,1}}}, ::Dense{typeof(identity),TrackedArray{…,Array{Float32,2}},TrackedArray{…,Array{Float32,1}}}, ::LayerNorm{TrackedArray{…,Array{Float32,1}}})
```
After:
```
julia> SkipConnection(Dense(2,2),+)
SkipConnection(Dense(2, 2), +)

julia> SkipConnection(Chain(Dense(2,3), Dense(3,2), LayerNorm(2)),+)
SkipConnection(Chain(Dense(2, 3), Dense(3, 2), LayerNorm(2)), +)

julia> SkipConnection(Dense(2,2), (a,b) -> a .+ b./2)
SkipConnection(Dense(2, 2), #9)
```