### PR TITLE
Update travis config and readme file for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,28 @@ language: julia
 
 os:
   - linux
-  # - osx
 
 julia:
   - 1.1
+  - 1.2
   - nightly
 
 matrix:
   allow_failures:
     - julia: nightly
+  fast_finish: true
+
+codecov: true
+
+coveralls: true
 
 jobs:
   include:
-    - stage: "Documentation"
+    - stage: Documentation
       julia: 1.0
-      os: linux
-      script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
-                                               Pkg.instantiate()'
-        - julia --project=docs/ docs/make.jl
+      script: julia --project=docs -e '
+          using Pkg;
+          Pkg.develop(PackageSpec(path=pwd()));
+          Pkg.instantiate();
+          include("docs/make.jl");'
       after_success: skip
-
-## uncomment the following lines to override the default test script
-script:
- - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test()'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 <p align="center">
-<img width="400px" src="https://raw.githubusercontent.com/FluxML/fluxml.github.io/master/logo.png"/>
+    <img width="50%" src="https://fluxml.ai/logo.png" />
 </p>
 
-[![Build Status](https://travis-ci.org/FluxML/Flux.jl.svg?branch=master)](https://travis-ci.org/FluxML/Flux.jl) [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://fluxml.github.io/Flux.jl/stable/) [![](https://img.shields.io/badge/chat-on%20slack-yellow.svg)](https://slackinvite.julialang.org/) [![DOI](https://joss.theoj.org/papers/10.21105/joss.00602/status.svg)](https://doi.org/10.21105/joss.00602)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://fluxml.github.io/Flux.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://fluxml.github.io/Flux.jl/dev/)
+[![Build Status](https://travis-ci.com/FluxML/Flux.jl.svg?branch=master)](https://travis-ci.com/FluxML/Flux.jl)
+[![Codecov](https://codecov.io/gh/FluxML/Flux.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/FluxML/Flux.jl)
+[![Coveralls](https://coveralls.io/repos/github/FluxML/Flux.jl/badge.svg?branch=master)](https://coveralls.io/github/FluxML/Flux.jl?branch=master)
+[![Chat](https://img.shields.io/badge/chat-on%20slack-yellow.svg)](https://slackinvite.julialang.org/)
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.00602/status.svg)](https://doi.org/10.21105/joss.00602)
 
 Flux is an elegant approach to machine learning. It's a 100% pure-Julia stack, and provides lightweight abstractions on top of Julia's native GPU and AD support. Flux makes the easy things easy while remaining fully hackable.
 


### PR DESCRIPTION
Fixes #89

I updated travis config file and added coverage tools to it. Also, I inserted their badges to readme file too. We should use travis-ci.com instead of travis-ci.org because of travis-ci announced that users and projects (both private and public) should only use travis-ci.com. ([ref1](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps) [ref2](https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/))

You can see the results for my fork:
https://codecov.io/gh/hossein-pourbozorg/Flux.jl/branch/issue-89
https://coveralls.io/github/hossein-pourbozorg/Flux.jl

https://travis-ci.com/hossein-pourbozorg/Flux.jl/