### PR TITLE
Add CUDA tests for stateless layers

### DIFF
--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -25,11 +25,27 @@ cm = gpu(m)
 @test all(p isa CuArray for p in params(cm))
 @test cm(gpu(rand(10, 10))) isa CuArray{Float32,2}
 
+x = rand(3) 
+y = rand(3) 
+cx = gpu(x)
+cy = gpu(y)
+@test Flux.mse(cx, cy) ≈ Flux.mse(x, y)
 x = [1,2,3]
 cx = gpu(x)
 @test Flux.crossentropy(x,x) ≈ Flux.crossentropy(cx,cx)
 @test Flux.crossentropy(x,x, weight=1.0) ≈ Flux.crossentropy(cx,cx, weight=1.0)
 @test Flux.crossentropy(x,x, weight=[1.0;2.0;3.0]) ≈ Flux.crossentropy(cx,cx, weight=cu([1.0;2.0;3.0]))
+x = [-1.1491, 0.8619, 0.3127]
+y = [1, 1, 0]
+cx = gpu(x)
+scx = σ.(cx)
+cy = gpu(y)
+@test_broken Flux.binarycrossentropy.(σ.(x), y) ≈ Flux.binarycrossentropy.(scx, cy)
+@test_broken Flux.logitbinarycrossentropy.(x,y) ≈ Flux.logitbinarycrossentropy.(cx, cy)
+
+xs = rand(5, 5)
+# fails due to scalar getindex
+@test_broken collect(Flux.normalise(cu(xs))) ≈ Flux.normalise(xs)
 
 xs = rand(5, 5)
 ys = Flux.onehotbatch(1:5,1:5)


### PR DESCRIPTION
A lot of `@test_broken` here because of CUDAnative `log` fighting and scalar `getindex` being disallowed.