### PR TITLE
Update has_cudnn

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -26,6 +26,7 @@ const consider_cuda = allow_cuda()
 
 using CUDAapi
 const use_cuda = consider_cuda && has_cuda()
+has_cudnn() = find_cuda_library("cudnn", find_toolkit()) !== nothing
 if use_cuda
   try
     using CuArrays

--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -2,7 +2,7 @@ module CUDA
 
 using ..CuArrays
 
-if CuArrays.libcudnn !== nothing  # TODO: use CuArrays.has_cudnn()
+if CuArrays.has_cudnn()
   using CuArrays: CUDNN
   include("curnn.jl")
   include("cudnn.jl")

--- a/src/cuda/cuda.jl
+++ b/src/cuda/cuda.jl
@@ -1,9 +1,9 @@
 module CUDA
 
+using ..Flux: has_cudnn
 using ..CuArrays
 
-if CuArrays.has_cudnn()
-  using CuArrays: CUDNN
+if has_cudnn()
   include("curnn.jl")
   include("cudnn.jl")
 else

--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -53,7 +53,7 @@ end
   @test y[3,:] isa CuArray
 end
 
-if CuArrays.libcudnn != nothing
+if CuArrays.has_cudnn()
   @info "Testing Flux/CUDNN"
   include("cudnn.jl")
   include("curnn.jl")


### PR DESCRIPTION
The current master of CuArrays doesn't export `libcudnn` string any more. It also doesn't export `has_cudnn()` during precompilation time for other packages. So I implement a `has_cudnn()` inside Flux using CUDAapi.