### PR TITLE
Extend docs about `train!`

### DIFF
--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -1,6 +1,6 @@
 # Training
 
-To actually train a model we need three things:
+To actually train a model we need three things, in addition to the tracked parameters that will be fitted:
 
 * A *objective function*, that evaluates how well a model is doing given some input data.
 * A collection of data points that will be provided to the objective function.
@@ -11,6 +11,7 @@ With these we can call `Flux.train!`:
 ```julia
 Flux.train!(objective, params, data, opt)
 ```
+At first glance it may seem strange that the model that we want to train is not part of the input arguments of `Flux.train!`. However the target of the optimizer is not the model itself, but the objective function that represents the departure between modelled and observed data. In other words, the model is implicitly defined in the objective function, and there is no need to give it explicitly. Passing the objective function instead of the model and a cost function separately (see below) provides more flexibility, and the possibility of optimizing the calculations.
 
 There are plenty of examples in the [model zoo](https://github.com/FluxML/model-zoo).
 

--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -3,7 +3,7 @@
 To actually train a model we need four things:
 
 * A *objective function*, that evaluates how well a model is doing given some input data.
-* The parameters of the model.
+* The trainable parameters of the model.
 * A collection of data points that will be provided to the objective function.
 * An [optimiser](optimisers.md) that will update the model parameters appropriately.
 

--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -1,8 +1,9 @@
 # Training
 
-To actually train a model we need three things, in addition to the tracked parameters that will be fitted:
+To actually train a model we need four things:
 
 * A *objective function*, that evaluates how well a model is doing given some input data.
+* The parameters of the model.
 * A collection of data points that will be provided to the objective function.
 * An [optimiser](optimisers.md) that will update the model parameters appropriately.
 
@@ -33,6 +34,12 @@ Flux.train!(loss, ps, data, opt)
 The objective will almost always be defined in terms of some *cost function* that measures the distance of the prediction `m(x)` from the target `y`. Flux has several of these built in, like `mse` for mean squared error or `crossentropy` for cross entropy loss, but you can calculate it however you want.
 
 At first glance it may seem strange that the model that we want to train is not part of the input arguments of `Flux.train!` too. However the target of the optimizer is not the model itself, but the objective function that represents the departure between modelled and observed data. In other words, the model is implicitly defined in the objective function, and there is no need to give it explicitly. Passing the objective function instead of the model and a cost function separately provides more flexibility, and the possibility of optimizing the calculations.
+
+## Model parameters
+
+The model to be trained must have a set of tracked parameters that are used to calculate the gradients of the objective function. In the [basics](../models/basics.md) section it is explained how to create models with such parameters. The second argument of the function `Flux.train!` must be an object containing those parameters, which can be obtained from a model `m` as `params(m)`.
+
+Such an object contains a reference to the model's parameters, not a copy, such that after their training, the model behaves according to their updated values.
 
 ## Datasets
 

--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -11,7 +11,6 @@ With these we can call `Flux.train!`:
 ```julia
 Flux.train!(objective, params, data, opt)
 ```
-At first glance it may seem strange that the model that we want to train is not part of the input arguments of `Flux.train!`. However the target of the optimizer is not the model itself, but the objective function that represents the departure between modelled and observed data. In other words, the model is implicitly defined in the objective function, and there is no need to give it explicitly. Passing the objective function instead of the model and a cost function separately (see below) provides more flexibility, and the possibility of optimizing the calculations.
 
 There are plenty of examples in the [model zoo](https://github.com/FluxML/model-zoo).
 
@@ -32,6 +31,8 @@ Flux.train!(loss, ps, data, opt)
 ```
 
 The objective will almost always be defined in terms of some *cost function* that measures the distance of the prediction `m(x)` from the target `y`. Flux has several of these built in, like `mse` for mean squared error or `crossentropy` for cross entropy loss, but you can calculate it however you want.
+
+At first glance it may seem strange that the model that we want to train is not part of the input arguments of `Flux.train!` too. However the target of the optimizer is not the model itself, but the objective function that represents the departure between modelled and observed data. In other words, the model is implicitly defined in the objective function, and there is no need to give it explicitly. Passing the objective function instead of the model and a cost function separately provides more flexibility, and the possibility of optimizing the calculations.
 
 ## Datasets
 


### PR DESCRIPTION
Related to #921: explain why it is not needed to pass the model as argument.