### PR TITLE
Give `NNPACK` a bit of numerical leeway

### DIFF
--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -66,7 +66,7 @@ end
   w = rand(2,2,1,1)
   y = CrossCor(w, [0.0])
 
-  @test sum(w .* x[1:2, 1:2, :, :]) == y(x)[1, 1, 1, 1]
+  @test isapprox(sum(w .* x[1:2, 1:2, :, :]), y(x)[1, 1, 1, 1], rtol=1e-7)
 
   r = zeros(Float32, 28, 28, 1, 5)
   m = Chain(
@@ -89,17 +89,17 @@ end
   l = Conv((3,3), 1=>1)
   expected = zeros(eltype(l.weight),5,5,1,1)
   expected[2:end-1,2:end-1,1,1] = l.weight
-  @test expected == l(data)
+  @test expected ≈ l(data)
 
   l = Conv((3,1), 1=>1)
   expected = zeros(eltype(l.weight),5,7,1,1)
   expected[2:end-1,4,1,1] = l.weight
-  @test expected == l(data)
+  @test expected ≈ l(data)
 
   l = Conv((1,3), 1=>1)
   expected = zeros(eltype(l.weight),7,5,1,1)
   expected[4,2:end-1,1,1] = l.weight
-  @test expected == l(data)
+  @test expected ≈ l(data)
 
   @test begin
     # we test that the next expression does not throw


### PR DESCRIPTION
We were very strict on NNlib's ability to fudge numbers a bit; this loosens some of the requirements, since `NNPACK` is definitely running in the DNN-world equivalent of `@fastmath`.