### PR TITLE
Make flip Zygote compatible

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -55,7 +55,13 @@ Assuming you have a `Recur` layer `rnn`, this is roughly equivalent to
 reset!(m::Recur) = (m.state = m.init)
 reset!(m) = foreach(reset!, functor(m)[1])
 
-flip(f, xs) = reverse(f.(reverse(xs)))
+function flip(f, xs)
+   flipped_xs = Zygote.Buffer(xs)
+   for t ∈ Iterators.reverse(eachindex(xs))
+      flipped_xs[t] = f(xs[t])
+   end
+   return copy(flipped_xs)
+end
 
 # Vanilla RNN
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -56,11 +56,8 @@ reset!(m::Recur) = (m.state = m.init)
 reset!(m) = foreach(reset!, functor(m)[1])
 
 function flip(f, xs)
-   flipped_xs = Zygote.Buffer(xs)
-   for t ∈ Iterators.reverse(eachindex(xs))
-      flipped_xs[t] = f(xs[t])
-   end
-   return copy(flipped_xs)
+  rev_time = reverse(eachindex(xs))
+  return getindex.(Ref(f.(getindex.(Ref(xs), rev_time))), rev_time)
 end
 
 # Vanilla RNN

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -56,7 +56,7 @@ reset!(m::Recur) = (m.state = m.init)
 reset!(m) = foreach(reset!, functor(m)[1])
 
 function flip(f, xs)
-  rev_time = reverse(eachindex(xs))
+  rev_time = Iterators.reverse(eachindex(xs))
   return getindex.(Ref(f.(getindex.(Ref(xs), rev_time))), rev_time)
 end
 


### PR DESCRIPTION
The current definition of `flip` uses `reverse`, which implemented using mutation, so it is not compatible with Zygote.
The proposed version uses `Zygote.Buffer` instead. As a consequence, the proposed version avoids unnecessary allocations so is also more efficient