### PR TITLE
use Buffer when computing params

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -39,9 +39,9 @@ end
 
 trainable(m) = functor(m)[1]
 
-params!(p::Params, x::AbstractArray{<:Number}, seen = IdSet()) = push!(p, x)
+params!(p, x::AbstractArray{<:Number}, seen = IdSet()) = push!(p, x)
 
-function params!(p::Params, x, seen = IdSet())
+function params!(p, x, seen = IdSet())
   x in seen && return
   push!(seen, x)
   for child in trainable(x)
@@ -50,9 +50,9 @@ function params!(p::Params, x, seen = IdSet())
 end
 
 function params(m...)
-  ps = Params()
+  ps = Zygote.Buffer([])
   params!(ps, m)
-  return ps
+  return Params(copy(ps))
 end
 
 # Deprecated stuff


### PR DESCRIPTION
This is an attempt to address the discussion in https://github.com/FluxML/Flux.jl/issues/930#issuecomment-574202189. One would still need to figure out how to create a `Params` object from a vector in a differentiable way (the current approach is `push!` based), and I'm not 100% sure how to do that.

It may be better to figure that out first before merging here, maybe there is a smart trick that makes `push!(ps::Zygote.Params, x)` differentiable and makes this change unnecessary. UPDATE: a differentiable constructor for `Zygote.Params` is now implemented in https://github.com/FluxML/Zygote.jl/pull/471.