### PR TITLE
Added WeightNorm

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -11,7 +11,7 @@ export gradient
 
 export Chain, Dense, Maxout, RNN, LSTM, GRU, Conv, CrossCor, ConvTranspose, MaxPool, MeanPool,
        DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm,
-       WeightNorm, WeightNormWeight, SkipConnection, params, fmap, cpu, gpu, f32, f64
+       WeightNorm, WeightNormParam, SkipConnection, params, fmap, cpu, gpu, f32, f64
 
 include("optimise/Optimise.jl")
 using .Optimise

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -11,7 +11,7 @@ export gradient
 
 export Chain, Dense, Maxout, RNN, LSTM, GRU, Conv, CrossCor, ConvTranspose, MaxPool, MeanPool,
        DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm,
-       WeightNorm, SkipConnection, params, fmap, cpu, gpu, f32, f64
+       WeightNorm, WeightNormWeight, SkipConnection, params, fmap, cpu, gpu, f32, f64
 
 include("optimise/Optimise.jl")
 using .Optimise

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -11,7 +11,7 @@ export gradient
 
 export Chain, Dense, Maxout, RNN, LSTM, GRU, Conv, CrossCor, ConvTranspose, MaxPool, MeanPool,
        DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm,
-       SkipConnection, params, fmap, cpu, gpu, f32, f64
+       WeightNorm, SkipConnection, params, fmap, cpu, gpu, f32, f64
 
 include("optimise/Optimise.jl")
 using .Optimise

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -370,6 +370,7 @@ end
 """
 Weight Normalization.
 This layer reparametrizes weights (w) of a layer with its decomposition into magnitude (g) and direction (v).
+WeightNorm has been implemented solely for `Dense` layers in Flux.
 
 	WeightNorm(layer, weight, dim)
 
@@ -384,7 +385,7 @@ Example:
 ```
 d = Dense(10, 9, tanh);
 wndA = WeightNorm(d, :W, 2); #The param d.W is now normalized in the second dimension, i.e normalization per output channel
-wndB = WeightNorm(d, :W, 1:2); #Now we normalize all directions together, keeping a single magnitude
+wndB = WeightNorm(d, :W, [1:2]); #Now we normalize all directions together, keeping a single magnitude
 ```
 
 Link : https://arxiv.org/pdf/1602.07868.pdf
@@ -429,6 +430,9 @@ function Base.show(io::IO, wn::WeightNorm)
 end
 
 function WeightNorm(layer, weight::Vector, dim::Vector)
+  if !isa(layer, Dense)
+    error("WeightNorm is defined only for Dense layers!")
+  end
   #Expose layer fields and constructor
   func, re = Flux.functor(layer)
   #Get the fields

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -435,7 +435,7 @@ function WeightNorm(layer, weight::Union{Symbol,Int}, dim)
   g = WN_mag(w, dim)
   v = WN_dir(w, g)
   par[findfirst(keys(func) .== weight)] = WeightNormWeight(g, v)
-  return WeightNorm(re(par), eps(Float32),dim,weight)
+  return WeightNorm(re(par), eps(Float32), weight, dim)
 end
 
 function (wn::WeightNorm)(x)

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -191,6 +191,20 @@ end
 
 end
 
+@testset "WeightNorm" begin
+  let d = Dense(10, 9, tanh);
+    wnd = WeightNorm(d, :W, 1:2)
+    gs = gradient(() -> sum(abs2, d(fake_data)), params(d))
+    gswn = gradient(() -> sum(abs2, wnd(fake_data)), params(wnd))
+    ΔW = gs[d.W]
+    Δg = gswn[wnd.layer.W.g]
+    Δv = gswn[wnd.layer.W.v]
+    @test size(Δv) == size(ΔW)
+    @test isa(wnd.layer.W, WeightNormWeight)
+    @test sum(ΔW .* wnd.layer.W.v ./ Flux.WN_mag(wnd.layer.W.v, 1:2), dims = 1:2) ≈ Δg
+  end
+end
+
 if VERSION >= v"1.1"
 @testset "GroupNorm" begin
   # begin tests


### PR DESCRIPTION
In light of #993 I wanted to create a WeightNorm constructor that could operate over any layer, param and dim.

This proved harder than I thought, but with the help of @chengchingwen and @mcabbott I could finally make this work.

So the execution is simply this:

1. User calls `WeightNorm` on a layer
2. We catch the param they want to normalize, and keep its direction and magnitude in a new type, `WeightNormWeight`
3. We redefine several operations over this type (so it operates like an Array) while Zygote can transparently see that it's actually a direction and magnitude
4. We reconstruct the layer using the `functor` functionality with the substitution in place

The catch is that it is not ready though.

~~- [ ] Make it work with `NNlib.conv`~~ (I really want to make this work, but now I noticed it's not only Conv that will be laborious to fix, simple stuff like RNNs will also require some iterations to get working simply because they hide their params inside cells)
- [x] Remove dead code (I'm pretty sure some things I did there should not be needed, specially regarding the `Base` array operations. But I couldn't subtype `WeightNormWeight` into `AbstractArray` either
- [x] Make it accept more than one `weight` at a time, potentially with differing `dim` as well.
- [x] Add tests

So, here's a first try at least. I could throw an error to `Conv`, but I want to make it work and perhaps it'll be better to wait out until everything is right.

Inputs welcome!