### PR TITLE
Adapt to GPUArrays/CuArrays changes

### DIFF
--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -25,7 +25,7 @@ cm = gpu(m)
 @test all(p isa CuArray for p in params(cm))
 @test cm(gpu(rand(10, 10))) isa CuArray{Float32,2}
 
-x = [1,2,3]
+x = [1.,2.,3.]
 cx = gpu(x)
 @test Flux.crossentropy(x,x) ≈ Flux.crossentropy(cx,cx)
 @test Flux.crossentropy(x,x, weight=1.0) ≈ Flux.crossentropy(cx,cx, weight=1.0)

--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -33,8 +33,8 @@ cx = gpu(x)
 
 x = [-1.1491, 0.8619, 0.3127]
 y = [1, 1, 0.]
-@test Flux.binarycrossentropy.(σ.(x),y) ≈ Flux.binarycrossentropy.(cu(σ.(x)),cu(y))
-@test Flux.logitbinarycrossentropy.(x,y) ≈ Flux.logitbinarycrossentropy.(cu(x),cu(y))
+@test Flux.binarycrossentropy.(σ.(x),y) ≈ Array(Flux.binarycrossentropy.(cu(σ.(x)),cu(y)))
+@test Flux.logitbinarycrossentropy.(x,y) ≈ Array(Flux.logitbinarycrossentropy.(cu(x),cu(y)))
 
 xs = rand(5, 5)
 ys = Flux.onehotbatch(1:5,1:5)


### PR DESCRIPTION
Changes in response to https://github.com/JuliaGPU/GPUArrays.jl/commit/a29df67184a0fe2afda71331bb9833ef00ad4be3 and https://github.com/JuliaGPU/CuArrays.jl/pull/576. I suppose the next CuArrays release will need to be breaking because of this.

Maybe the `crossentropy` signature needs to be adjusted to support integer vectors, but I'll leave that decision up to Flux developers. This at least is the quick fix to get the tests passing again.