### PR TITLE
Refactor train!

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -42,6 +42,13 @@ function stop()
   throw(StopException())
 end
 
+function step!(loss, ps, minibatch, opt)
+  gs = gradient(ps) do
+    loss(minibatch...)
+  end
+  update!(opt, ps, gs)
+end
+
 """
     train!(loss, params, data, opt; cb)
 
@@ -65,10 +72,11 @@ function train!(loss, ps, data, opt; cb = () -> ())
   cb = runall(cb)
   @progress for d in data
     try
-      gs = gradient(ps) do
-        loss(d...)
-      end
-      update!(opt, ps, gs)
+      # gs = gradient(ps) do
+      #   loss(d...)
+      # end
+      # update!(opt, ps, gs)
+      step!(loss, ps, d, opt)
       cb()
     catch ex
       if ex isa StopException


### PR DESCRIPTION
This is in response to #666 where we can visualise `train!` as a wrapper around the `step!` function, while maintaining the same api.

To actually accumulate the loss as in https://github.com/FluxML/Flux.jl/issues/666#issuecomment-471307139, we could of course go with the loss function being a simple closure here, getting rid of the need to send around the mini batch.

With the changes to Zygote, it might be nice to actually have this in our interface.

cc @MikeInnes @oxinabox 