### PR TITLE
Debugging messages about type mismatches

### DIFF
--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -45,6 +45,13 @@ the idiomatic (and safe way) is to use `oftype`.
     leaky_tanh(x) = oftype(x/1, 0.01)x + tanh(x)
 ```
 
+There are some warnings about potential type problems, emitted by `@debug` statements. 
+To see these you will usually need to change Julia's logging level, 
+for instance by running this before your model:
+
+```
+    ENV["JULIA_DEBUG"] = "all"
+```
 
 ## Evaluate batches as Matrices of features, rather than sequences of Vector features
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -142,7 +142,7 @@ end
   invoke(a, Tuple{AbstractArray}, x)
 
 function (a::Dense{<:Any,W})(x::AbstractArray{<:AbstractFloat}) where {T <: Union{Float32,Float64}, W <: AbstractArray{T}}
-  debug_string("Layer ", a, " has parameters of eltype ", T," but acts on data ", typeof(x).
+  debug_string("Layer ", a, " has parameters of eltype ", T," but acts on data ", typeof(x),
     ", which will be converted to match.")
   a(T.(x))
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -45,12 +45,12 @@ end
   y, back = Zygote.pullback(applychain, c.layers, x)
   eltype(x) == eltype(y) || debug_string(
     "Chain(...) receives input of eltype ", eltype(x), " but creates output of eltype ",
-    eltype(y), ". \nThis is likely to indicate a performance issue.")
+    eltype(y), ". \nThis is may indicate a performance problem with one of the layers.")
   T = typeof(y)
   y, dy -> begin
     eltype(y) == eltype(dy) || debug_string(
       "Chain(...) creates output of eltype ", eltype(y), " but receives gradient of eltype ",
-      eltype(dy), ". \nThis is likely to indicate a performance issue.")
+      eltype(dy), ". \nThis is likely to be slow, and the loss function may be the problem.")
     back(dy)
   end
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -52,9 +52,9 @@ end
   end
 end
 
-Zygote.@nograd debug_string
-
 debug_string(arg...) = @debug string(arg...)
+
+Zygote.@nograd debug_string
 
 """
     outdims(c::Chain, isize)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -43,11 +43,14 @@ end
 
 @adjoint function (c::Chain)(x)
   y, back = Zygote.pullback(applychain, c.layers, x)
+  eltype(x) == eltype(y) || debug_string(
+    "Chain(...) receives input of eltype ", eltype(x), " but creates output of eltype ",
+    eltype(y), ". \nThis is likely to indicate a performance issue.")
   T = typeof(y)
   y, dy -> begin
     eltype(y) == eltype(dy) || debug_string(
-      "Chain(...) has output of eltype ", eltype(y),
-      " but receives gradient of eltype ", eltype(dy))
+      "Chain(...) creates output of eltype ", eltype(y), " but receives gradient of eltype ",
+      eltype(dy), ". \nThis is likely to indicate a performance issue.")
     back(dy)
   end
 end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -109,7 +109,7 @@ import Flux: activations
   end
 
   @testset "type mismatches" begin
-    env = ENV["JULIA_DEBUG"]
+    env = haskey(ENV, "JULIA_DEBUG") ? ENV["JULIA_DEBUG"] : nothing
     ENV["JULIA_DEBUG"] = "all"
 
     m = Chain(Dense(2,2)); x= rand(Float32, 2); y=rand(2); # labels are Float64
@@ -129,6 +129,10 @@ import Flux: activations
         "Chain(...) receives input of eltype Float64 but creates output of eltype Float32. \nThis is may indicate a performance problem with one of the layers."
         ) gradient(() -> sum(m(x) .- y), params(m))
 
-    ENV["JULIA_DEBUG"] = env
+    if env === nothing
+        delete!(ENV, "JULIA_DEBUG")
+    else
+        ENV["JULIA_DEBUG"] = env
+    end
   end
 end


### PR DESCRIPTION
This adds a few warning messages about conversions to Float64 or worse, which seem to be a common problem, today #1026, last week #815.

These are behind `@debug`, which I see is also used by NNlib for some such warnings. Another option would be to make these errors, controlled by some `Flux.allowconvert(false)` along the lines of what CuArrays does for scalar access, see earlier commit. 

I'm not sure they will catch all the activation-function bugs mentioned in `performance.md`. Perhaps it would be better to attach the warning to every layer, not to `Chain`. 