### PR TITLE
Remove get! macro

### DIFF
--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -1,5 +1,4 @@
 using Flux
-using Base: @get!
 using MacroTools: @forward
 
 const ϵ = 1e-8


### PR DESCRIPTION
The get! macro is imported but unused. It was deprecated from Base by JuliaLang/julia#34611, JuliaLang/julia#34646