### PR TITLE
fix travis for documentation build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ julia:
   - 1.3
   - nightly
 
-matrix:
-  allow_failures:
-    - julia: nightly
+notifications:
+  email: false
 
 jobs:
   include:
@@ -24,6 +23,5 @@ jobs:
         - julia --project=docs/ docs/make.jl
       after_success: skip
 
-## uncomment the following lines to override the default test script
-script:
- - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test()'
+  allow_failures:
+    - julia: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,7 @@ jobs:
 
   allow_failures:
     - julia: nightly
+
+## uncomment the following lines to override the default test script
+script:
+ - julia --color=yes -e 'using Pkg; Pkg.activate(); Pkg.instantiate(); Pkg.test()'


### PR DESCRIPTION
The previous build doesn't trigger the documentation stage because the matrix doesn't get expanded for the sole job.

Not very clear how Travis reads the config but this change fixes the issue.

😕 weird that it doesn't allow failures on nightly here... The one in my fork works as expected. https://github.com/johnnychen94/Flux.jl/runs/479502998

cc: @CarloLucibello