### PR TITLE
Prevent breakage due to new `active` field in normalise layers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -80,9 +80,6 @@ mutable struct AlphaDropout{F}
   end
 end
 
-# TODO: deprecate in v0.11
-AlphaDropout(p) = AlphaDropout(p, nothing)
-
 function (a::AlphaDropout)(x)
   _isactive(a) || return x
   λ = eltype(x)(1.0507009873554804934193349852946)

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -157,6 +157,8 @@ mutable struct BatchNorm{F,V,W,N}
   active::Union{Bool, Nothing}
 end
 
+BatchNorm(λ, β, γ, μ, σ², ϵ, momentum) = BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, nothing)
+
 BatchNorm(chs::Integer, λ = identity;
           initβ = (i) -> zeros(Float32, i), initγ = (i) -> ones(Float32, i), ϵ = 1f-5, momentum = 0.1f0) =
   BatchNorm(λ, initβ(chs), initγ(chs),

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -40,6 +40,7 @@ mutable struct Dropout{F,D}
   active::Union{Bool, Nothing}
 end
 
+# TODO: deprecate in v0.11
 Dropout(p, dims) = Dropout(p, dims, nothing)
 
 function Dropout(p; dims = :)
@@ -79,6 +80,7 @@ mutable struct AlphaDropout{F}
   end
 end
 
+# TODO: deprecate in v0.11
 AlphaDropout(p) = AlphaDropout(p, nothing)
 
 function (a::AlphaDropout)(x)
@@ -161,6 +163,7 @@ mutable struct BatchNorm{F,V,W,N}
   active::Union{Bool, Nothing}
 end
 
+# TODO: deprecate in v0.11
 BatchNorm(λ, β, γ, μ, σ², ϵ, momentum) = BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, nothing)
 
 BatchNorm(chs::Integer, λ = identity;
@@ -257,6 +260,7 @@ mutable struct InstanceNorm{F,V,W,N}
   active::Union{Bool, Nothing}
 end
 
+# TODO: deprecate in v0.11
 InstanceNorm(λ, β, γ, μ, σ², ϵ, momentum) = InstanceNorm(λ, β, γ, μ, σ², ϵ, momentum, nothing)
 
 InstanceNorm(chs::Integer, λ = identity;
@@ -350,6 +354,7 @@ mutable struct GroupNorm{F,V,W,N,T}
   active::Union{Bool, Nothing}
 end
 
+# TODO: deprecate in v0.11
 GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum) = GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum, nothing)
 
 GroupNorm(chs::Integer, G::Integer, λ = identity;

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -40,6 +40,8 @@ mutable struct Dropout{F,D}
   active::Union{Bool, Nothing}
 end
 
+Dropout(p, dims) = Dropout(p, dims, nothing)
+
 function Dropout(p; dims = :)
   @assert 0 ≤ p ≤ 1
   Dropout{typeof(p),typeof(dims)}(p, dims, nothing)
@@ -76,6 +78,8 @@ mutable struct AlphaDropout{F}
     new{typeof(p)}(p, active)
   end
 end
+
+AlphaDropout(p) = AlphaDropout(p, nothing)
 
 function (a::AlphaDropout)(x)
   _isactive(a) || return x
@@ -253,6 +257,8 @@ mutable struct InstanceNorm{F,V,W,N}
   active::Union{Bool, Nothing}
 end
 
+InstanceNorm(λ, β, γ, μ, σ², ϵ, momentum) = InstanceNorm(λ, β, γ, μ, σ², ϵ, momentum, nothing)
+
 InstanceNorm(chs::Integer, λ = identity;
           initβ = (i) -> zeros(Float32, i), initγ = (i) -> ones(Float32, i), ϵ = 1f-5, momentum = 0.1f0) =
   InstanceNorm(λ, initβ(chs), initγ(chs),
@@ -343,6 +349,8 @@ mutable struct GroupNorm{F,V,W,N,T}
   momentum::N
   active::Union{Bool, Nothing}
 end
+
+GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum) = GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum, nothing)
 
 GroupNorm(chs::Integer, G::Integer, λ = identity;
           initβ = (i) -> zeros(Float32, i), initγ = (i) -> ones(Float32, i), ϵ = 1f-5, momentum = 0.1f0) =


### PR DESCRIPTION
Prevents breakage where the normalise structs, such as `BatchNorm`, have been directly defined but missing the new `active` field

cc. @darsnack 