### PR TITLE
WIP: Make optimize work on structs

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -26,7 +26,7 @@ update!(opt, x::AbstractArray, x̄::Nothing) = nothing
 update!(opt, m::M, ∇m::Nothing) where M = nothing
 
 function update!(opt, x::AbstractArray, x̄)
-  x .-= apply!(opt, x::AbstractArray, x̄)
+  x .-= apply!(opt, x, x̄)
   return
 end
 

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -29,12 +29,6 @@ end
 
 update!(opt, m::M, ∇m::Nothing) where M = nothing
 
-function update!(opt, m::Tuple, ∇m::Tuple)
-  for (x, ∇x) in zip(m, ∇m)
-    update!(opt, x, ∇x)
-  end
-end
-
 # NOTE: since there won't be real loop in a struct
 #       we could always flatten it, which is a bit
 #       faster.

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -20,15 +20,15 @@ function update!(x::AbstractArray, x̄)
   return
 end
 
+# skip, if gradient is nothing
 update!(x::AbstractArray, x̄::Nothing) = nothing
 update!(opt, x::AbstractArray, x̄::Nothing) = nothing
+update!(opt, m::M, ∇m::Nothing) where M = nothing
 
 function update!(opt, x::AbstractArray, x̄)
   x .-= apply!(opt, x::AbstractArray, x̄)
   return
 end
-
-update!(opt, m::M, ∇m::Nothing) where M = nothing
 
 # NOTE: since there won't be real loop in a struct
 #       we could always flatten it, which is a bit

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -44,7 +44,6 @@ end
 
 function update!(opt, xs::Params, gs)
   for x in xs
-    gs[x] == nothing && continue
     update!(opt, x, gs[x])
   end
   return

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -17,10 +17,23 @@ Update the array `x` according to `x .-= x̄`.
 """
 function update!(x::AbstractArray, x̄)
   x .-= x̄
+  return
 end
 
-function update!(opt, x, x̄)
-  x .-= apply!(opt, x, x̄)
+update!(x::AbstractArray, x̄::Nothing) = nothing
+
+function update!(opt, x::AbstractArray, x̄)
+  x .-= apply!(opt, x::AbstractArray, x̄)
+  return
+end
+
+update!(opt, m::M, ∇m::Nothing) where M = nothing
+
+function update!(opt, m::M, ∇m) where M
+  for each in fieldnames(M)
+    update!(opt, getfield(m, each), getfield(∇m, each))
+  end
+  return
 end
 
 function update!(opt, xs::Params, gs)
@@ -28,6 +41,7 @@ function update!(opt, xs::Params, gs)
     gs[x] == nothing && continue
     update!(opt, x, gs[x])
   end
+  return
 end
 
 # Callback niceties

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -21,6 +21,7 @@ function update!(x::AbstractArray, x̄)
 end
 
 update!(x::AbstractArray, x̄::Nothing) = nothing
+update!(opt, x::AbstractArray, x̄::Nothing) = nothing
 
 function update!(opt, x::AbstractArray, x̄)
   x .-= apply!(opt, x::AbstractArray, x̄)

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -1,5 +1,5 @@
 using Flux.Optimise
-using Flux.Optimise: runall
+using Flux.Optimise: runall, update!
 using Flux: Params, gradient
 using Test
 
@@ -88,4 +88,25 @@ end
     end
     @test decay_steps == ground_truth
     @test o.eta == o.clip
+end
+
+@testset "update!" begin
+  opt = ADAM()
+  A = rand(2, 2)
+  B = copy(A)
+  @test update!(opt, A, nothing) == nothing
+  @test A == B
+
+  A = Dense(10, 10)
+  B = deepcopy(A)
+  @test update!(opt, A, nothing) == nothing
+  @test A.W == B.W && A.b == B.b
+
+  gs = (W=rand(10, 10), b=rand(10), σ=nothing)
+  update!(opt, A, gs)
+
+  update!(opt, B.W, gs.W)
+  update!(opt, B.b, gs.b)
+
+  @test A.W ≈ B.W && A.b ≈ B.b
 end


### PR DESCRIPTION
So I tried to implement what was proposed in #637 
I guess this is what @MikeInnes wanted? But I didn't see why need `isimmutable` trait tho. With this PR, the following would work at least and a bit faster since it's type stable now.

```julia
using Flux
using Flux.Optimise: update!, ADAM

m = Chain(Dense(100, 100, tanh), Dense(100, 100, tanh))
opt = ADAM()
x = rand(Float32, 100)
loss(m, x) = sum(m(x))
∇m, _ = gradient(loss, m, x)
update!(opt, m, ∇m)
```
