### PR TITLE
Speed up recurrent layers by seperating broadcasting of tanh/sigmoid from other parts

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -122,7 +122,7 @@ function (m::LSTMCell)((h, c), x)
   cell = tanh.(gate(g, o, 3))
   output = σ.(gate(g, o, 4))
   c = forget .* c .+ input .* cell
-  h′ = output .* tanh.(c)
+  h′ = output .* (c_ = tanh.(c))
   return (h′, c), h′
 end
 
@@ -160,9 +160,9 @@ GRUCell(in, out; init = glorot_uniform) =
 function (m::GRUCell)(h, x)
   b, o = m.b, size(h, 1)
   gx, gh = m.Wi*x, m.Wh*h
-  r = σ.(gate(gx, o, 1) .+ gate(gh, o, 1) .+ gate(b, o, 1))
-  z = σ.(gate(gx, o, 2) .+ gate(gh, o, 2) .+ gate(b, o, 2))
-  h̃ = tanh.(gate(gx, o, 3) .+ r .* gate(gh, o, 3) .+ gate(b, o, 3))
+  r = σ.((r_ = gate(gx, o, 1) .+ gate(gh, o, 1) .+ gate(b, o, 1);))
+  z = σ.((z_ = gate(gx, o, 2) .+ gate(gh, o, 2) .+ gate(b, o, 2));)
+  h̃ = tanh.((h̃_ = gate(gx, o, 3) .+ r .* gate(gh, o, 3) .+ gate(b, o, 3);))
   h′ = (1 .- z).*h̃ .+ z.*h
   return h′, h′
 end


### PR DESCRIPTION
Fusing broadcasting of tanh/sigmoid to other parts can block julia from vectorizing the code. 

```julia
julia> using Random, BenchmarkTools, Flux

julia> using Flux: GRUCell, gate

julia> model = GRUCell(100, 100);

julia> h = x = randn(Float32, 100, 128);

julia> function (m::GRUCell)(h, x)
           b, o = m.b, size(h, 1)
           gx, gh = m.Wi*x, m.Wh*h
           r = σ.(gate(gx, o, 1) .+ gate(gh, o, 1) .+ gate(b, o, 1))
           z = σ.(gate(gx, o, 2) .+ gate(gh, o, 2) .+ gate(b, o, 2))
           h̃ = tanh.(gate(gx, o, 3) .+ r .* gate(gh, o, 3) .+ gate(b, o, 3))
           h′ = (1 .- z).*h̃ .+ z.*h
           return h′, h′
       end

julia> @btime model($h, $x);
  1.242 ms (42 allocations: 801.44 KiB)

julia> function (m::GRUCell)(h, x)
           b, o = m.b, size(h, 1)
           gx, gh = m.Wi*x, m.Wh*h
           r = σ.((r_ = gate(gx, o, 1) .+ gate(gh, o, 1) .+ gate(b, o, 1);))
           z = σ.((z_ = gate(gx, o, 2) .+ gate(gh, o, 2) .+ gate(b, o, 2);))
           h̃ = tanh.((h_ = gate(gx, o, 3) .+ r .* gate(gh, o, 3) .+ gate(b, o, 3);))
           h′ = (1 .- z).*h̃ .+ z.*h
           return h′, h′
       end

julia> @btime model($h, $x);
  391.418 μs (34 allocations: 951.34 KiB)
```