### PR TITLE
LayerNorm regularization

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -104,24 +104,19 @@ A [normalisation layer](https://arxiv.org/pdf/1607.06450.pdf) designed to be
 used with recurrent hidden states of size `h`. Normalises the mean and standard
 deviation of each input before applying a per-neuron gain/bias.
 """
-struct LayerNorm{T,N}
+struct LayerNorm{T}
   diag::Diagonal{T}
-  ϵ::N
 end
 
-trainable(ln::LayerNorm) = trainable(ln.diag)
-
-LayerNorm(h::Integer; ϵ = sqrt(eps(Float32))) =
-  LayerNorm(Diagonal(h), ϵ)
+LayerNorm(h::Integer) =
+  LayerNorm(Diagonal(h))
 
 @functor LayerNorm
 
-(a::LayerNorm)(x) = a.diag(normalise(x; ϵ = a.ϵ))
+(a::LayerNorm)(x) = a.diag(normalise(x))
 
 function Base.show(io::IO, l::LayerNorm)
-  print(io, "LayerNorm(", length(l.diag.α))
-  (l.ϵ == sqrt(eps(Float32))) || print(io, "; ϵ = $(l.ϵ)")
-  print(io, ")")
+  print(io, "LayerNorm(", length(l.diag.α), ")")
 end
 
 """

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -151,10 +151,10 @@ logitbinarycrossentropy(ŷ, y) = (1 - y)*ŷ - logσ(ŷ)
 CuArrays.@cufunc logitbinarycrossentropy(ŷ, y) = (1 - y)*ŷ - logσ(ŷ)
 
 """
-    normalise(x; dims=1)
+    normalise(x; dims=1, ϵ = sqrt(eps(Float32))
 
 Normalise `x` to mean 0 and standard deviation 1 across the dimensions given by `dims`.
-Defaults to normalising over columns.
+Defaults to normalising over columns. Regularizes the standard deviation by `ϵ`.
 
 ```jldoctest
 julia> a = reshape(collect(1:9), 3, 3)
@@ -165,21 +165,21 @@ julia> a = reshape(collect(1:9), 3, 3)
 
 julia> Flux.normalise(a)
 3×3 Array{Float64,2}:
- -1.22474  -1.22474  -1.22474
+ -1.22423  -1.22423  -1.22423
   0.0       0.0       0.0
-  1.22474   1.22474   1.22474
+  1.22423   1.22423   1.22423
 
 julia> Flux.normalise(a, dims=2)
 3×3 Array{Float64,2}:
- -1.22474  0.0  1.22474
- -1.22474  0.0  1.22474
- -1.22474  0.0  1.22474
+ -1.22457  0.0  1.22457
+ -1.22457  0.0  1.22457
+ -1.22457  0.0  1.22457
 ```
 """
-function normalise(x::AbstractArray; dims=1)
+function normalise(x::AbstractArray; dims=1, ϵ = sqrt(eps(Float32)))
   μ′ = mean(x, dims = dims)
   σ′ = std(x, dims = dims, mean = μ′, corrected=false)
-  return (x .- μ′) ./ σ′
+  return (x .- μ′) ./ (σ′ .+ ϵ)
 end
 
 """

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -151,7 +151,7 @@ logitbinarycrossentropy(ŷ, y) = (1 - y)*ŷ - logσ(ŷ)
 CuArrays.@cufunc logitbinarycrossentropy(ŷ, y) = (1 - y)*ŷ - logσ(ŷ)
 
 """
-    normalise(x; dims=1, ϵ = sqrt(eps(eltype(x))))
+    normalise(x; dims=1, ϵ=1.0e-5))
 
 Normalise `x` to mean 0 and standard deviation 1 across the dimensions given by `dims`.
 Defaults to normalising over columns. Regularizes the standard deviation by `ϵ`.
@@ -165,9 +165,9 @@ julia> a = reshape(collect(1:9), 3, 3)
 
 julia> Flux.normalise(a)
 3×3 Array{Float64,2}:
- -1.22474  -1.22474  -1.22474
+ -1.22473  -1.22473  -1.22473
   0.0       0.0       0.0
-  1.22474   1.22474   1.22474
+  1.22473   1.22473   1.22473
 
 julia> Flux.normalise(a, dims=2)
 3×3 Array{Float64,2}:
@@ -176,7 +176,7 @@ julia> Flux.normalise(a, dims=2)
  -1.22474  0.0  1.22474
 ```
 """
-function normalise(x::AbstractArray; dims=1, ϵ = sqrt(eps(eltype(x/1))))
+function normalise(x::AbstractArray; dims=1, ϵ=1.0f-5)
   μ′ = mean(x, dims = dims)
   σ′ = std(x, dims = dims, mean = μ′, corrected=false)
   return (x .- μ′) ./ (σ′ .+ ϵ)

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -151,7 +151,7 @@ logitbinarycrossentropy(ŷ, y) = (1 - y)*ŷ - logσ(ŷ)
 CuArrays.@cufunc logitbinarycrossentropy(ŷ, y) = (1 - y)*ŷ - logσ(ŷ)
 
 """
-    normalise(x; dims=1, ϵ = sqrt(eps(Float32))
+    normalise(x; dims=1, ϵ = sqrt(eps(eltype(x))))
 
 Normalise `x` to mean 0 and standard deviation 1 across the dimensions given by `dims`.
 Defaults to normalising over columns. Regularizes the standard deviation by `ϵ`.
@@ -165,18 +165,18 @@ julia> a = reshape(collect(1:9), 3, 3)
 
 julia> Flux.normalise(a)
 3×3 Array{Float64,2}:
- -1.22423  -1.22423  -1.22423
+ -1.22474  -1.22474  -1.22474
   0.0       0.0       0.0
-  1.22423   1.22423   1.22423
+  1.22474   1.22474   1.22474
 
 julia> Flux.normalise(a, dims=2)
 3×3 Array{Float64,2}:
- -1.22457  0.0  1.22457
- -1.22457  0.0  1.22457
- -1.22457  0.0  1.22457
+ -1.22474  0.0  1.22474
+ -1.22474  0.0  1.22474
+ -1.22474  0.0  1.22474
 ```
 """
-function normalise(x::AbstractArray; dims=1, ϵ = sqrt(eps(Float32)))
+function normalise(x::AbstractArray; dims=1, ϵ = sqrt(eps(eltype(x/1))))
   μ′ = mean(x, dims = dims)
   σ′ = std(x, dims = dims, mean = μ′, corrected=false)
   return (x .- μ′) ./ (σ′ .+ ϵ)


### PR DESCRIPTION
This PR adds regularisation to the `LayerNorm` layer by changing the return value of the `normalise`-function to `(x .- μ′) ./ (σ′ .+ ϵ)`, with a standard value of `ϵ = sqrt(eps(Float32))`. The value of `ϵ` can be changed via a keyword argument. This avoids `NaN`s in the output.

Related discussion on Slack can be found [here](https://julialang.slack.com/archives/C7LFJTXV5/p1589714643448000). This type of regularisation is in line with other ML frameworks, see for example [PyTorch](https://pytorch.org/docs/stable/nn.html?highlight=layernorm#torch.nn.LayerNorm).