### PR TITLE
Fix erroneous comment in example in docs Basics

### DIFF
--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -72,7 +72,7 @@ function loss(x, y)
 end
 
 x, y = rand(5), rand(2) # Dummy data
-loss(x, y) # ~ 3
+loss(x, y) # ~ 5.77
 ```
 
 To improve the prediction we can take the gradients of `W` and `b` with respect to the loss and perform gradient descent.


### PR DESCRIPTION
This commit fixes an erroneous comment in the doc page [Flux Basics](https://fluxml.ai/Flux.jl/stable/models/basics/).

In the example given in the [Simple Models](https://fluxml.ai/Flux.jl/stable/models/basics/#Simple-Models-1) section, it is written
```
loss(x, y) # ~ 3
```
However, averaging over $10^6$ independent runs of the given code block, I get that it should be `loss(x, y) # ~ 5.77`.