### PR TITLE
Fixing indentation in train! docstring

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -68,8 +68,7 @@ and compute the gradient of `loss(d)`.
 A callback is given with the keyword argument `cb`. For example, this will print
 "training" every 10 seconds (using [`Flux.throttle`](@ref)):
 
-  train!(loss, params, data, opt,
-         cb = throttle(() -> println("training"), 10))
+    train!(loss, params, data, opt, cb = throttle(() -> println("training"), 10))
 
 The callback can call [`Flux.stop`](@ref) to interrupt the training loop.
 


### PR DESCRIPTION
One code block is not correctly displayed in the doc of [Flux.Optimise.train!
](https://fluxml.ai/Flux.jl/stable/training/training/#Flux.Optimise.train!). 
Based on the previous code block, I guess it's an indentation problem.
