### PR TITLE
Fixed Dimension Mismatch - AbtractMatrix and OneHotVector

### DIFF
--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -11,7 +11,12 @@ Base.getindex(xs::OneHotVector, i::Integer) = i == xs.ix
 
 Base.getindex(xs::OneHotVector, ::Colon) = OneHotVector(xs.ix, xs.of)
 
-A::AbstractMatrix * b::OneHotVector = A[:, b.ix]
+function Base.:*(A::AbstractMatrix, b::OneHotVector)
+  if size(A)[2] != b.of
+    throw(DimensionMismatch("Matrix column must correspond with OneHotVector size"))
+  end
+  return A[:, b.ix]
+end
 
 struct OneHotMatrix{A<:AbstractVector{OneHotVector}} <: AbstractMatrix{Bool}
   height::Int

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -12,7 +12,7 @@ Base.getindex(xs::OneHotVector, i::Integer) = i == xs.ix
 Base.getindex(xs::OneHotVector, ::Colon) = OneHotVector(xs.ix, xs.of)
 
 function Base.:*(A::AbstractMatrix, b::OneHotVector)
-  if size(A)[2] != b.of
+  if size(A, 2) != b.of
     throw(DimensionMismatch("Matrix column must correspond with OneHotVector size"))
   end
   return A[:, b.ix]

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -17,3 +17,12 @@ end
   @test y[:,1] isa Flux.OneHotVector
   @test y[:,:] isa Flux.OneHotMatrix
 end
+
+@testset "abstractmatrix onehotvector multiplication" begin
+  A = [1 3 5; 2 4 6; 3 6 9]
+  b1 = Flux.OneHotVector(1,3)
+  b2 = Flux.OneHotVector(3,5)
+
+  @test A*b1 == A[:,1]
+  @test_throws DimensionMismatch A*b2
+end


### PR DESCRIPTION
Fixed the multiplication function so that it only works when the column of matrix matches with the size of onehotvector.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@MikeInnes` or `@dhairyagandhi96` (for API changes).
