### PR TITLE
outdims: revise implementation for Chain, dimension check for Dense

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -57,7 +57,7 @@ m = Chain(Conv((3, 3), 3 => 16), Conv((3, 3), 16 => 32))
 outdims(m, (10, 10)) == (6, 6)
 ```
 """
-outdims(c::Chain, isize) = foldl(∘, map(l -> (x -> outdims(l, x)), c.layers))(isize)
+outdims(c::Chain, isize) = foldr(outdims, reverse(c.layers), init = isize)
 
 # This is a temporary and naive implementation
 # it might be replaced in the future for better performance
@@ -147,7 +147,10 @@ outdims(m, (5, 2)) == (5,)
 outdims(m, (10,)) == (5,)
 ```
 """
-outdims(l::Dense, isize) = (size(l.W)[1],)
+function outdims(l::Dense, isize)
+    first(isize) == size(l.W, 2) || throw(DimensionMismatch("input size should equal to ($(size(l.W, 2)),), got $isize"))
+    return (size(l.W, 1),)
+end
 
 """
     Diagonal(in::Integer)

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -105,8 +105,14 @@ import Flux: activations
     @test Flux.outdims(m, (10, 10)) == (6, 6)
 
     m = Dense(10, 5)
-    @test Flux.outdims(m, (5, 2)) == (5,)
+    @test_throws DimensionMismatch Flux.outdims(m, (5, 2)) == (5,)
     @test Flux.outdims(m, (10,)) == (5,)
+
+    m = Chain(Dense(10, 8, σ), Dense(8, 5), Dense(5, 2))
+    @test Flux.outdims(m, (10,)) == (2,)
+
+    m = Chain(Dense(10, 8, σ), Dense(8, 4), Dense(5, 2))
+    @test_throws DimensionMismatch Flux.outdims(m, (10,))
 
     m = Flux.Diagonal(10)
     @test Flux.outdims(m, (10,)) == (10,)


### PR DESCRIPTION
This PR reflects the discussion in #1086.
`outdims(c::Chain, isize)` calculated the layers in the wrong order.
The function has been replaced by a performance optimised version following the same idea.

`outdims(c::Dense, isize)` now throws an error if dimensions do not match.

One test, which now throws an error, has been adapted, more tests have been added.

I will setup another PR for further improvements of outdims, as discussed in the corresponding issue.