### PR TITLE
replace Base.tanh with faster tanh

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -113,6 +113,7 @@ Dense(W, b) = Dense(W, b, identity)
 
 function Dense(in::Integer, out::Integer, σ = identity;
                initW = glorot_uniform, initb = zeros)
+  σ = typeof(σ) <: typeof(tanh) ? SLEEFPriates.tanh : σ
   return Dense(initW(out, in), initb(out), σ)
 end
 


### PR DESCRIPTION
This is a speculative change based on some recent discussions to help speedup common tasks in Flux, and the tanh from SLEEFPirates was found to make a significant difference. This is to discuss the viability of doing this by default in Flux and any different kinds of considerations we would have while doing so.

cc @ChrisRackauckas

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
