### PR TITLE
Ignore Zeros when gathering parameters

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -37,6 +37,8 @@ Possible values include:
 """
 trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
 
+params!(p::Flux.Params, x::Zeros{<:Number}, seen = Flux.IdSet()) = nothing
+
 params!(p::Params, x::AbstractArray{<:Number}, seen = IdSet()) = push!(p, x)
 
 function params!(p::Params, x, seen = IdSet())

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -46,7 +46,7 @@ end
   op = bias(ip)
   @test sum(op) ≈ 0.f0
   gs = gradient(() -> sum(bias(ip)), Flux.params(bias))
-  @test gs[bias.bias] == nothing
+  @test !haskey(gs, bias.bias)
 
   # Train w/o bias and make sure no convergence happens
   # when only bias can be converged

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -43,6 +43,15 @@ end
   @test sum(op) == prod(size(op))
 
   bias = Conv((2,2), 1=>3, bias = Flux.Zeros())
+
+  # Test that disabled bias is not in parameters
+  # and gathered parameters can be loaded back
+  bias_parameters = bias |> Flux.params
+  @test length(bias_parameters) == 1
+  @test Flux.Zeros() ∉ bias_parameters
+  Flux.loadparams!(bias, bias_parameters)
+
+  # Test that disabled bias does not appear in gradients
   op = bias(ip)
   @test sum(op) ≈ 0.f0
   gs = gradient(() -> sum(bias(ip)), Flux.params(bias))


### PR DESCRIPTION
This fixes #1277.
IMO, it makes more sense to ignore disabled parameters when gathering model parameters, than have something that is not used and may lead to confusion.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
