### PR TITLE
More complex models: multiple inputs, multiple outputs, and parallel paths inside a model

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -39,6 +39,7 @@ include("layers/basic.jl")
 include("layers/conv.jl")
 include("layers/recurrent.jl")
 include("layers/normalise.jl")
+include("layers/structure.jl")
 
 include("data/Data.jl")
 

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -15,7 +15,7 @@ export Chain, Dense, Maxout, RNN, LSTM, GRU, SamePad, Conv, CrossCor, ConvTransp
        AdaptiveMaxPool, AdaptiveMeanPool, GlobalMaxPool, GlobalMeanPool, MaxPool,
        MeanPool, flatten, DepthwiseConv, Dropout, AlphaDropout, LayerNorm, BatchNorm,
        InstanceNorm, GroupNorm, SkipConnection, params, fmap, cpu, gpu, f32, f64,
-       testmode!, trainmode!
+       testmode!, trainmode!, Join, Split, Parallel, Nop
 
 include("optimise/Optimise.jl")
 using .Optimise

--- a/src/layers/structure.jl
+++ b/src/layers/structure.jl
@@ -36,7 +36,7 @@ struct Join{F}
   fs::F
 end
 
-function Join(fs ...)
+function Join(fs...)
   Join(fs)
 end
 
@@ -51,20 +51,22 @@ end
 Base.getindex(c::Join, i::AbstractArray) = Join(c.fs[i]...)
 
 function Base.show(io::IO, j::Join)
-  print(io, "Join(", length(fs), ", ")
+  print(io, "Join(", length(j.fs), ", ")
   join(io, j.fs, ", ")
   print(io, ")")
-end # todo test
+end
 
 
 """
     Split(parallel_layers...)
 
-Create a new `Split` layer, which deploys the input array to multiple paths and 
-outputs the results as a tuple with multiple vector.
+Create a new 'split' layer that distributes the input array over multiple paths 
+and outputs the results as tuples with multiple vectors.
 
-The input `x` must be a common input format. 
-The out `y` will be a tuple with n vectors.
+The input 'x' must be a common input format. The out 'y' will be a tuple with 
+n vectors.
+
+Important: because of the multiple output you need a custom loss function!
 
 # Example
 ```
@@ -84,6 +86,16 @@ julia> model = Chain(
 julia> model(cu(rand(1)))
 (Float32[0.12], Float32[0.52], Float32[0.23])
 ```
+
+# Info: use a custom loss function!
+Split() doesnt output a singe vector, therefore you need a custom loss function, e.g.:
+```
+using Statistics
+function loss(x, y)
+  # returns the rms over all the mse
+  sqrt(mean([Flux.mse(modelSplit(x)[i], y[i]) for i in 1:length(y)].^2.))
+end
+```
 """
 struct Split{F}
   fs::F
@@ -97,26 +109,26 @@ Flux.@functor Split
 
 function (w::Split)(x::AbstractArray)
   # may have performance issues ... some julia/flux pro should maybe rework this
-  tuple([w.fs[i](x) for i in 1:length(w.fs)])
+  tuple([w.fs[i](x) for i in 1:length(w.fs)]...)
 end
 
 Base.getindex(c::Split, i::AbstractArray) = Split(c.fs[i]...)
 
 function Base.show(io::IO, j::Split)
-  print(io, "Split(", length(fs), ", ")
+  print(io, "Split(", length(j.fs), ", ")
   join(io, j.fs, ", ")
   print(io, ")")
-end # todo test
+end
 
 
 """
     Parallel(parallel_layers...)
 
-Create a new `Parallel` layer, which deploys the input array into multiple paths 
-and concatenates the results to a single output vector.
+Create a new 'Parallel' layer that makes a single input array available to 
+multiple paths, processes them separately in defined layers or chains, and 
+then combines the results into a single output vector.
 
-The input `x` must be a common input format. 
-The out `y` will be vector.
+The input format 'x' must be a common input format. The output 'y' is a vector.
 
 # Example
 ```
@@ -159,13 +171,58 @@ end
 Base.getindex(c::Parallel, i::AbstractArray) = Parallel(c.fs[i]...)
 
 function Base.show(io::IO, j::Parallel)
-  print(io, "Parallel(", length(fs), ", ")
+  print(io, "Parallel(", length(j.fs), ", ")
   join(io, j.fs, ", ")
   print(io, ")")
-end # todo test
+end
 
 
+"""
+    Nop() - No-OPeration
 
+Create a new 'Nop' layer that does nothing and just passes the value on. 
+This can be useful if you want to pass the output of a split layer directly 
+to the output.
+
+The input 'x' must be a common input format. The out 'y' has the same format 
+as the input format.
+
+The internal action is `x->x`
+
+# Example
+```
+julia> using flux
+
+julia> using CUDA
+
+julia> model = Chain(
+  Dense(1, 2),
+  Split(
+    Dense(2, 1),
+    Nop
+  )
+)
+
+julia> julia> model(cu(rand(1)))
+(Float32[0.12], (Float32[0.52], Float32[0.23]))
+```
+"""
+
+struct Nop
+  empt # workaround?, 'empt' ~ empty
+end
+
+function Nop()
+  Nop(nothing)
+end
+
+function (w::Nop)(x::AbstractArray)
+  return x
+end
+
+function Base.show(io::IO, j::Nop)
+  print(io, "Nop")
+end
 
 
 

--- a/src/layers/structure.jl
+++ b/src/layers/structure.jl
@@ -1,0 +1,172 @@
+
+
+
+"""
+    Join(parallel_layers...)
+
+Create a new `Join` layer, which deploys multiple inputs to multiple paths and 
+concatenates the results to a single output vector.
+
+The input `x` must be a tuple of length `parallel_layers`. 
+The out `y` will be a vector.
+
+# Example
+```
+julia> using flux
+
+julia> using CUDA
+
+julia> model = Chain(
+  Join(
+    Chain(
+      Dense(1, 5),
+      Dense(5, 1)
+    ),
+    Dense(1, 2),
+    Dense(1, 1),
+  ),
+  Dense(4, 1)
+) |> gpu
+
+julia> model(cu(rand(1), rand(1), rand(1)))
+Float32[0.32]
+```
+"""
+struct Join{F}
+  fs::F
+end
+
+function Join(fs ...)
+  Join(fs)
+end
+
+@functor Join
+
+function (w::Join)(t::Tuple)
+  # may have performance issues ... some julia/flux pro should maybe rework this
+  @assert length(w.fs) == length(t)
+  vcat([w.fs[i](t[i]) for i in 1:length(w.fs)]...)
+end
+
+Base.getindex(c::Join, i::AbstractArray) = Join(c.fs[i]...)
+
+function Base.show(io::IO, j::Join)
+  print(io, "Join(", length(fs), ", ")
+  join(io, j.fs, ", ")
+  print(io, ")")
+end # todo test
+
+
+"""
+    Split(parallel_layers...)
+
+Create a new `Split` layer, which deploys the input array to multiple paths and 
+outputs the results as a tuple with multiple vector.
+
+The input `x` must be a common input format. 
+The out `y` will be a tuple with n vectors.
+
+# Example
+```
+julia> using flux
+
+julia> using CUDA
+
+julia> model = Chain(
+  Dense(1, 1),
+  Split(
+    Dense(1, 1),
+    Dense(1, 1),
+    Dense(1, 1)
+  )
+) |> gpu
+
+julia> model(cu(rand(1)))
+(Float32[0.12], Float32[0.52], Float32[0.23])
+```
+"""
+struct Split{F}
+  fs::F
+end
+
+function Split(fs...)
+  Split(fs)
+end
+
+Flux.@functor Split
+
+function (w::Split)(x::AbstractArray)
+  # may have performance issues ... some julia/flux pro should maybe rework this
+  tuple([w.fs[i](x) for i in 1:length(w.fs)])
+end
+
+Base.getindex(c::Split, i::AbstractArray) = Split(c.fs[i]...)
+
+function Base.show(io::IO, j::Split)
+  print(io, "Split(", length(fs), ", ")
+  join(io, j.fs, ", ")
+  print(io, ")")
+end # todo test
+
+
+"""
+    Parallel(parallel_layers...)
+
+Create a new `Parallel` layer, which deploys the input array into multiple paths 
+and concatenates the results to a single output vector.
+
+The input `x` must be a common input format. 
+The out `y` will be vector.
+
+# Example
+```
+julia> using flux
+
+julia> using CUDA
+
+julia> model = Chain(
+  Dense(1, 1),
+  Parallel(
+    Dense(1, 1),
+    Dense(1, 3),
+    Chain(
+      Dense(1, 5),
+      Dense(5, 2),
+    )
+  ),
+  Dense(6, 1)
+) |> gpu
+
+julia> model(cu((rand(1))))
+Float32[0.27]
+```
+"""
+struct Parallel{F}
+  fs::F
+end
+
+function Parallel(fs...)
+  Parallel(fs)
+end
+
+Flux.@functor Parallel
+
+function (w::Parallel)(x::AbstractArray)
+  # may have performance issues ... some julia/flux pro should maybe rework this
+  vcat([w.fs[i](x) for i in 1:length(w.fs)]...)
+end
+
+Base.getindex(c::Parallel, i::AbstractArray) = Parallel(c.fs[i]...)
+
+function Base.show(io::IO, j::Parallel)
+  print(io, "Parallel(", length(fs), ", ")
+  join(io, j.fs, ", ")
+  print(io, ")")
+end # todo test
+
+
+
+
+
+
+

--- a/test/layers/structure.jl
+++ b/test/layers/structure.jl
@@ -1,0 +1,95 @@
+using Test, Random
+import Flux
+
+@testset "structure" begin
+  
+  @testset "Join" begin
+    @testset "model_creation" begin
+      @test_nowarn Chain(Join(Dense(10,6),Dense(10,5)), Dense(11,1))
+      #@test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn(10))
+    end
+    @testset "model_training" begin
+      model = Chain(
+        Join(
+          Chain(
+            Dense(1, 5),
+            Dense(5, 1)
+          ),
+          Dense(1, 2),
+          Dense(1, 1),
+        ),
+        Dense(4, 1)
+      )
+      opt = Descent(0.1)
+      loss(x, y) = Flux.mse(model(x), y)
+      ps = Flux.params(model)
+      x = map( x -> ( rand(1),rand(1),rand(1) ), 1:10 )
+      y = map( x -> ( rand(1) ), 1:10)
+      dat = zip(x, y)
+      before = loss(x[1], y[1])
+      map(x -> Flux.train!(loss, ps, dat, opt), 1:3)
+      after = loss(x[1], y[1])
+      @test after < before
+    end
+  end
+  
+  @testset "Split" begin
+    @testset "model_creation" begin
+      @test_nowarn Chain(Dense(1, 1),Split(Dense(1, 1),Dense(1, 1),Dense(1, 1)))
+      #@test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn(10))
+    end
+    @testset "model_training" begin
+      model = Chain(
+        Dense(1, 1),
+        Split(
+          Dense(1, 1),
+          Dense(1, 1),
+          Dense(1, 1)
+        )
+      )
+      opt = Descent(0.1)
+      loss(x, y) = Flux.mse(model(x), y)
+      ps = Flux.params(model)
+      x = map( x -> ( rand(1) ), 1:10)
+      y = map( x -> ( rand(1),rand(1),rand(1) ), 1:10 )
+      dat = zip(x, y)
+      before = loss(x[1], y[1])
+      map(x -> Flux.train!(loss, ps, dat, opt), 1:3)
+      after = loss(x[1], y[1])
+      @test after < before
+    end
+  end
+  
+  @testset "Parallel" begin
+    @testset "model_creation" begin
+      @test_nowarn Chain(Dense(1, 1),Split(Dense(1, 1),Dense(1, 1),Dense(1, 1)))
+      model = Chain(Dense(1, 1),Parallel(Dense(1, 1),Dense(1, 3),Chain(Dense(1, 5),Dense(5, 2),)),Dense(6, 1))
+      #@test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn(10))
+    end
+    @testset "model_training" begin
+      model = Chain(
+        Dense(1, 1),
+        Parallel(
+          Dense(1, 1),
+          Dense(1, 3),
+          Chain(
+            Dense(1, 5),
+            Dense(5, 2),
+          )
+        ),
+        Dense(6, 1)
+      ) 
+      opt = Descent(0.1)
+      loss(x, y) = Flux.mse(model(x), y)
+      ps = Flux.params(model)
+      x = map( x -> ( rand(1) ), 1:10)
+      y = map( x -> ( rand(1) ), 1:10 )
+      dat = zip(x, y)
+      before = loss(x[1], y[1])
+      map(x -> Flux.train!(loss, ps, dat, opt), 1:3)
+      after = loss(x[1], y[1])
+      @test after < before
+    end
+  end
+  
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Flux 
+using Flux
 using Flux.Data
 using Test 
 using Random, Statistics, LinearAlgebra
@@ -31,6 +31,7 @@ end
   include("layers/normalisation.jl")
   include("layers/stateless.jl")
   include("layers/conv.jl")
+  include("layers/structure.jl")
 end
 
 @testset "CUDA" begin


### PR DESCRIPTION
In coordination with @DhairyaLGandhi I added new parts to the docs and added new layers for a feature that I have been missing for some time now:

- Multiple Input Layer ("Join")
- Multiple Output Layer ("Split")
- Multiple Internal Path Layer ("Parallel")

The documentation has been extended with examples for custom implementations of these layers (see "advanced model building"), and the new layers Join, Split and Parallel have been added to the src.

The new layers run on GPU (yet not tested with more complex layers, e.g. conv). Any number of inputs, outputs or parallel paths should be possible. Simple testing and documentation is also implemented. Maybe a real Julia pro can take a look at the layers to improve the performance or replace vcat with something better.

Additionally a "No-OPeration" Layer ("Nop") is added, so that paths without an action are also possible, instead of writing "x->x".

I tried to stay simple with the design. I would be happy about good ideas and comments, and if these changes are accepted somehow, so that we can use this or a similar implementation soon.

### PR Checklist

- [X] Tests are added
- [ ] Entry in NEWS.md
- [X] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
