### PR TITLE
Corrections in the Optimisers section of documents

### DIFF
--- a/docs/src/training/optimisers.md
+++ b/docs/src/training/optimisers.md
@@ -14,7 +14,7 @@ loss(x, y) = sum((predict(x) .- y).^2)
 x, y = rand(5), rand(2) # Dummy data
 l = loss(x, y) # ~ 3
 
-θ = Params([W, b])
+θ = params([W, b])
 grads = gradient(() -> loss(x, y), θ)
 ```
 
@@ -25,7 +25,7 @@ using Flux.Optimise: update!
 
 η = 0.1 # Learning Rate
 for p in (W, b)
-  update!(p, -η * grads[p])
+  update!(p, η * grads[p])
 end
 ```
 


### PR DESCRIPTION
`update!(x, x̄)` updates the array x according to `x .-= x̄`, so the minus sign is not needed when passing the argument
`update!(p, -η * grads[p])` will actually increase the loss, this is just wrong
also, `Params`  is not imported in the context, should use `params` instead