### PR TITLE
[WIP] Per-parameter optimiser options

### DIFF
--- a/docs/src/training/optimisers.md
+++ b/docs/src/training/optimisers.md
@@ -41,6 +41,20 @@ end
 
 An optimiser `update!` accepts a parameter and a gradient, and updates the parameter according to the chosen rule. We can also pass `opt` to our [training loop](training.md), which will update all parameters of the model in a loop. However, we can now easily replace `Descent` with a more advanced optimiser such as `ADAM`.
 
+All optimisers also support per-parameter options, specified using `IdDict`s. For example, if we wanted to learn `b` at a slower rate than `W`, we could achieve it like this.
+
+```julia
+eta_dict = IdDict()
+eta_dict[b] = 0.01
+opt = Descent(0.1, eta_dict)
+
+for p in (W, b)
+  update!(opt, p, grads[p])
+end
+```
+
+This will use the default value 0.1 for `W` and 0.01 for `b` through the `eta_dict`.
+
 ## Optimiser Reference
 
 All optimisers return an object that, when passed to `train!`, will update the parameters passed to it.

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -295,12 +295,14 @@ mutable struct OADAM
   eta::Float64
   beta::Tuple{Float64,Float64}
   state::IdDict
+  eta_dict::IdDict
+  beta_dict::IdDict
 end
 
-OADAM(η = 0.0001, β = (0.5, 0.9)) = OADAM(η, β, IdDict())
+OADAM(η = 0.0001, β = (0.5, 0.9)) = OADAM(η, β, IdDict(), IdDict(), IdDict())
 
 function apply!(o::OADAM, x, Δ)
-  η, β = o.eta, o.beta
+  η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
   mt, vt, Δ_, βp = get!(o.state, x, (zero(x), zero(x), zero(x), β))
   @. mt = β[1] * mt + (1 - β[1]) * Δ
   @. vt = β[2] * vt + (1 - β[2]) * Δ^2

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -591,12 +591,13 @@ Decay weights by `wd`.
 """
 mutable struct WeightDecay
   wd::Real
+  decay_dict::IdDict
 end
 
-WeightDecay() = WeightDecay(0)
+WeightDecay(decay = 0) = WeightDecay(decay, IdDict())
 
 function apply!(o::WeightDecay, x, Δ)
-  wd = o.wd
+  wd = get(o.decay_dict, x, o.wd)
   @. Δ += wd * x
 end
 

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -35,7 +35,7 @@ mutable struct Descent
   eta_dict::IdDict
 end
 
-Descent(η = 0.1) = Descent(η, IdDict())
+Descent(η = 0.1; η_dict = IdDict()) = Descent(η, η_dict)
 
 function apply!(o::Descent, x, Δ)
   η = get(o.eta_dict, x, o.eta)
@@ -68,7 +68,7 @@ mutable struct Momentum
   rho_dict::IdDict
 end
 
-Momentum(η = 0.01, ρ = 0.9) = Momentum(η, ρ, IdDict(), IdDict(), IdDict())
+Momentum(η = 0.01, ρ = 0.9; η_dict = IdDict(), ρ_dict = IdDict()) = Momentum(η, ρ, IdDict(), η_dict, ρ_dict)
 
 function apply!(o::Momentum, x, Δ)
   η, ρ = get(o.eta_dict, x, o.eta), get(o.rho_dict, x, o.rho)
@@ -103,7 +103,7 @@ mutable struct Nesterov
   rho_dict::IdDict
 end
 
-Nesterov(η = 0.001, ρ = 0.9) = Nesterov(η, ρ, IdDict(), IdDict(), IdDict())
+Nesterov(η = 0.001, ρ = 0.9; η_dict = IdDict(), ρ_dict = IdDict()) = Nesterov(η, ρ, IdDict(), η_dict, ρ_dict)
 
 function apply!(o::Nesterov, x, Δ)
   η, ρ = get(o.eta_dict, x, o.eta), get(o.rho_dict, x, o.rho)
@@ -142,7 +142,7 @@ mutable struct RMSProp
   rho_dict::IdDict
 end
 
-RMSProp(η = 0.001, ρ = 0.9) = RMSProp(η, ρ, IdDict(), IdDict(), IdDict())
+RMSProp(η = 0.001, ρ = 0.9; η_dict = IdDict(), ρ_dict = IdDict()) = RMSProp(η, ρ, IdDict(), η_dict, ρ_dict)
 
 function apply!(o::RMSProp, x, Δ)
   η, ρ = get(o.eta_dict, x, o.eta), get(o.rho_dict, x, o.rho)
@@ -177,7 +177,7 @@ mutable struct ADAM
   beta_dict::IdDict
 end
 
-ADAM(η = 0.001, β = (0.9, 0.999)) = ADAM(η, β, IdDict(), IdDict(), IdDict())
+ADAM(η = 0.001, β = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict()) = ADAM(η, β, IdDict(), η_dict, β_dict)
 
 function apply!(o::ADAM, x, Δ)
   η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
@@ -215,7 +215,7 @@ mutable struct RADAM
   beta_dict::IdDict
 end
 
-RADAM(η = 0.001, β = (0.9, 0.999)) = RADAM(η, β, IdDict(), IdDict(), IdDict())
+RADAM(η = 0.001, β = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict()) = RADAM(η, β, IdDict(), η_dict, β_dict)
 
 function apply!(o::RADAM, x, Δ)
   η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
@@ -260,7 +260,7 @@ mutable struct AdaMax
   beta_dict::IdDict
 end
 
-AdaMax(η = 0.001, β = (0.9, 0.999)) = AdaMax(η, β, IdDict(), IdDict(), IdDict())
+AdaMax(η = 0.001, β = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict()) = AdaMax(η, β, IdDict(), η_dict, β_dict)
 
 function apply!(o::AdaMax, x, Δ)
   η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
@@ -299,7 +299,7 @@ mutable struct OADAM
   beta_dict::IdDict
 end
 
-OADAM(η = 0.0001, β = (0.5, 0.9)) = OADAM(η, β, IdDict(), IdDict(), IdDict())
+OADAM(η = 0.0001, β = (0.5, 0.9); η_dict = IdDict(), β_dict = IdDict()) = OADAM(η, β, IdDict(), η_dict, β_dict)
 
 function apply!(o::OADAM, x, Δ)
   η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
@@ -337,7 +337,7 @@ mutable struct ADAGrad
   eta_dict::IdDict
 end
 
-ADAGrad(η = 0.1) = ADAGrad(η, IdDict(), IdDict())
+ADAGrad(η = 0.1; η_dict = IdDict()) = ADAGrad(η, IdDict(), η_dict)
 
 function apply!(o::ADAGrad, x, Δ)
   η = get(o.eta_dict, x, o.eta)
@@ -369,7 +369,7 @@ mutable struct ADADelta
   rho_dict::IdDict
 end
 
-ADADelta(ρ = 0.9) = ADADelta(ρ, IdDict(), IdDict())
+ADADelta(ρ = 0.9; ρ_dict = IdDict()) = ADADelta(ρ, IdDict(), ρ_dict)
 
 function apply!(o::ADADelta, x, Δ)
   ρ = get(o.rho_dict, x, o.rho)
@@ -407,7 +407,7 @@ mutable struct AMSGrad
   beta_dict::IdDict
 end
 
-AMSGrad(η = 0.001, β = (0.9, 0.999)) = AMSGrad(η, β, IdDict(), IdDict(), IdDict())
+AMSGrad(η = 0.001, β = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict()) = AMSGrad(η, β, IdDict(), η_dict, β_dict)
 
 function apply!(o::AMSGrad, x, Δ)
   η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
@@ -445,7 +445,7 @@ mutable struct NADAM
   beta_dict::IdDict
 end
 
-NADAM(η = 0.001, β = (0.9, 0.999)) = NADAM(η, β, IdDict(), IdDict(), IdDict())
+NADAM(η = 0.001, β = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict()) = NADAM(η, β, IdDict(), η_dict, β_dict)
 
 function apply!(o::NADAM, x, Δ)
   η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
@@ -477,8 +477,8 @@ opt = ADAMW()
 opt = ADAMW(0.001, (0.89, 0.995), 0.1)
 ```
 """
-ADAMW(η = 0.001, β = (0.9, 0.999), decay = 0) =
-  Optimiser(ADAM(η, β), WeightDecay(decay))
+ADAMW(η = 0.001, β = (0.9, 0.999), decay = 0; η_dict = IdDict(), β_dict = IdDict(), decay_dict = IdDict()) =
+  Optimiser(ADAM(η, β; η_dict = η_dict, β_dict = β_dict), WeightDecay(decay; decay_dict = decay_dict))
 
 # Compose optimizers
 
@@ -525,7 +525,7 @@ mutable struct InvDecay
   gamma_dict::IdDict
 end
 
-InvDecay(γ = 0.001) = InvDecay(γ, IdDict(), IdDict())
+InvDecay(γ = 0.001; γ_dict = IdDict()) = InvDecay(γ, IdDict(), γ_dict)
 
 function apply!(o::InvDecay, x, Δ)
   γ = get(o.gamma_dict, x, o.gamma)
@@ -569,7 +569,9 @@ mutable struct ExpDecay
   clip_dict::IdDict
 end
 
-ExpDecay(opt = 0.001, decay = 0.1, decay_step = 1000, clip = 1e-4) = ExpDecay(opt, decay, decay_step, clip, IdDict(), IdDict(), IdDict(), IdDict(), IdDict())
+ExpDecay(opt = 0.001, decay = 0.1, decay_step = 1000, clip = 1e-4;
+η_dict = IdDict(), decay_dict = IdDict(), step_dict = IdDict(), clip_dict = IdDict()) = 
+  ExpDecay(opt, decay, decay_step, clip, IdDict(), η_dict, decay_dict, step_dict, clip_dict)
 
 function apply!(o::ExpDecay, x, Δ)
   η, s, decay, clip = get(o.eta_dict, x, o.eta), get(o.step_dict, x, o.step), get(o.decay_dict, x, o.decay), get(o.clip_dict, x, o.clip)
@@ -594,7 +596,7 @@ mutable struct WeightDecay
   decay_dict::IdDict
 end
 
-WeightDecay(decay = 0) = WeightDecay(decay, IdDict())
+WeightDecay(decay = 0; decay_dict = IdDict()) = WeightDecay(decay, decay_dict)
 
 function apply!(o::WeightDecay, x, Δ)
   wd = get(o.decay_dict, x, o.wd)
@@ -611,7 +613,7 @@ mutable struct ClipValue{T}
   thresh_dict::IdDict
 end
 
-ClipValue(thresh) = ClipValue(thresh, IdDict())
+ClipValue(thresh; thresh_dict = IdDict()) = ClipValue(thresh, thresh_dict)
 
 function apply!(o::ClipValue, x, Δ)
   thresh = get(o.thresh_dict, x, o.thresh)
@@ -628,7 +630,7 @@ mutable struct ClipNorm{T}
   thresh_dict::IdDict
 end
 
-ClipNorm(thresh) = ClipNorm(thresh, IdDict())
+ClipNorm(thresh; thresh_dict = IdDict()) = ClipNorm(thresh, thresh_dict)
 
 function apply!(o::ClipNorm, x, Δ)
   thresh = get(o.thresh_dict, x, o.thresh)

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -99,12 +99,14 @@ mutable struct Nesterov
   eta::Float64
   rho::Float64
   velocity::IdDict
+  eta_dict::IdDict
+  rho_dict::IdDict
 end
 
-Nesterov(η = 0.001, ρ = 0.9) = Nesterov(η, ρ, IdDict())
+Nesterov(η = 0.001, ρ = 0.9) = Nesterov(η, ρ, IdDict(), IdDict(), IdDict())
 
 function apply!(o::Nesterov, x, Δ)
-  η, ρ = o.eta, o.rho
+  η, ρ = get(o.eta_dict, x, o.eta), get(o.rho_dict, x, o.rho)
   v = get!(o.velocity, x, zero(x))::typeof(x)
   d = @. ρ^2 * v - (1+ρ) * η * Δ
   @. v = ρ*v - η*Δ

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -403,12 +403,14 @@ mutable struct AMSGrad
   eta::Float64
   beta::Tuple{Float64, Float64}
   state::IdDict
+  eta_dict::IdDict
+  beta_dict::IdDict
 end
 
-AMSGrad(η = 0.001, β = (0.9, 0.999)) = AMSGrad(η, β, IdDict())
+AMSGrad(η = 0.001, β = (0.9, 0.999)) = AMSGrad(η, β, IdDict(), IdDict(), IdDict())
 
 function apply!(o::AMSGrad, x, Δ)
-  η, β = o.eta, o.beta
+  η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
   mt, vt, v̂t = get!(o.state, x, (fill!(zero(x), ϵ), fill!(zero(x), ϵ), fill!(zero(x), ϵ)))
   @. mt = β[1] * mt + (1 - β[1]) * Δ
   @. vt = β[2] * vt + (1 - β[2]) * Δ ^ 2

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -211,12 +211,14 @@ mutable struct RADAM
   eta::Float64
   beta::Tuple{Float64,Float64}
   state::IdDict
+  eta_dict::IdDict
+  beta_dict::IdDict
 end
 
-RADAM(η = 0.001, β = (0.9, 0.999)) = RADAM(η, β, IdDict())
+RADAM(η = 0.001, β = (0.9, 0.999)) = RADAM(η, β, IdDict(), IdDict(), IdDict())
 
 function apply!(o::RADAM, x, Δ)
-  η, β = o.eta, o.beta
+  η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
   ρ∞ = 2/(1-β[2])-1
   mt, vt, βp, t = get!(o.state, x, (zero(x), zero(x), β, 1))
   @. mt = β[1] * mt + (1 - β[1]) * Δ

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -35,7 +35,7 @@ mutable struct Descent
   eta_dict::IdDict
 end
 
-Descent(eta = 0.1) = Descent(eta, IdDict())
+Descent(η = 0.1) = Descent(η, IdDict())
 
 function apply!(o::Descent, x, Δ)
   η = get(o.eta_dict, x, o.eta)

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -334,12 +334,13 @@ opt = ADAGrad(0.001)
 mutable struct ADAGrad
   eta::Float64
   acc::IdDict
+  eta_dict::IdDict
 end
 
-ADAGrad(η = 0.1) = ADAGrad(η, IdDict())
+ADAGrad(η = 0.1) = ADAGrad(η, IdDict(), IdDict())
 
 function apply!(o::ADAGrad, x, Δ)
-  η = o.eta
+  η = get(o.eta_dict, x, o.eta)
   acc = get!(o.acc, x, fill!(zero(x), ϵ))::typeof(x)
   @. acc += Δ^2
   @. Δ *= η / (√acc + ϵ)

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -138,12 +138,14 @@ mutable struct RMSProp
   eta::Float64
   rho::Float64
   acc::IdDict
+  eta_dict::IdDict
+  rho_dict::IdDict
 end
 
-RMSProp(η = 0.001, ρ = 0.9) = RMSProp(η, ρ, IdDict())
+RMSProp(η = 0.001, ρ = 0.9) = RMSProp(η, ρ, IdDict(), IdDict(), IdDict())
 
 function apply!(o::RMSProp, x, Δ)
-  η, ρ = o.eta, o.rho
+  η, ρ = get(o.eta_dict, x, o.eta), get(o.rho_dict, x, o.rho)
   acc = get!(o.acc, x, zero(x))::typeof(x)
   @. acc = ρ * acc + (1 - ρ) * Δ^2
   @. Δ *= η / (√acc + ϵ)

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -64,12 +64,14 @@ mutable struct Momentum
   eta::Float64
   rho::Float64
   velocity::IdDict
+  eta_dict::IdDict
+  rho_dict::IdDict
 end
 
-Momentum(η = 0.01, ρ = 0.9) = Momentum(η, ρ, IdDict())
+Momentum(η = 0.01, ρ = 0.9) = Momentum(η, ρ, IdDict(), IdDict(), IdDict())
 
 function apply!(o::Momentum, x, Δ)
-  η, ρ = o.eta, o.rho
+  η, ρ = get(o.eta_dict, x, o.eta), get(o.rho_dict, x, o.rho)
   v = get!(o.velocity, x, zero(x))::typeof(x)
   @. v = ρ * v - η * Δ
   @. Δ = -v

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -173,12 +173,14 @@ mutable struct ADAM
   eta::Float64
   beta::Tuple{Float64,Float64}
   state::IdDict
+  eta_dict::IdDict
+  beta_dict::IdDict
 end
 
-ADAM(η = 0.001, β = (0.9, 0.999)) = ADAM(η, β, IdDict())
+ADAM(η = 0.001, β = (0.9, 0.999)) = ADAM(η, β, IdDict(), IdDict(), IdDict())
 
 function apply!(o::ADAM, x, Δ)
-  η, β = o.eta, o.beta
+  η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
   mt, vt, βp = get!(o.state, x, (zero(x), zero(x), β))
   @. mt = β[1] * mt + (1 - β[1]) * Δ
   @. vt = β[2] * vt + (1 - β[2]) * Δ^2

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -32,12 +32,14 @@ Flux.Optimise.update!(opt, ps, gs)
 """
 mutable struct Descent
   eta::Float64
+  eta_dict::IdDict
 end
 
-Descent() = Descent(0.1)
+Descent(eta = 0.1) = Descent(eta, IdDict())
 
 function apply!(o::Descent, x, Δ)
-  Δ .*= o.eta
+  η = get(o.eta_dict, x, o.eta)
+  Δ .*= η
 end
 
 """

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -441,12 +441,14 @@ mutable struct NADAM
   eta::Float64
   beta::Tuple{Float64, Float64}
   state::IdDict
+  eta_dict::IdDict
+  beta_dict::IdDict
 end
 
-NADAM(η = 0.001, β = (0.9, 0.999)) = NADAM(η, β, IdDict())
+NADAM(η = 0.001, β = (0.9, 0.999)) = NADAM(η, β, IdDict(), IdDict(), IdDict())
 
 function apply!(o::NADAM, x, Δ)
-  η, β = o.eta, o.beta
+  η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
   mt, vt, (β1p, β2p) = get!(o.state, x, (zero(x), zero(x), o.beta))
   @. mt = β[1] * mt + (1 - β[1]) * Δ
   @. vt = β[2] * vt + (1 - β[2]) * Δ^2

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -563,15 +563,19 @@ mutable struct ExpDecay
   step::Int64
   clip::Float64
   current::IdDict
+  eta_dict::IdDict
+  decay_dict::IdDict
+  step_dict::IdDict
+  clip_dict::IdDict
 end
 
-ExpDecay(opt = 0.001, decay = 0.1, decay_step = 1000, clip = 1e-4) = ExpDecay(opt, decay, decay_step, clip, IdDict())
+ExpDecay(opt = 0.001, decay = 0.1, decay_step = 1000, clip = 1e-4) = ExpDecay(opt, decay, decay_step, clip, IdDict(), IdDict(), IdDict(), IdDict(), IdDict())
 
 function apply!(o::ExpDecay, x, Δ)
-  η, s, decay = o.eta, o.step, o.decay
+  η, s, decay, clip = get(o.eta_dict, x, o.eta), get(o.step_dict, x, o.step), get(o.decay_dict, x, o.decay), get(o.clip_dict, x, o.clip)
   n = o.current[x] = get(o.current, x, 0) + 1
   if o.current[x]%s == 0 && count(x -> x%s == 0, values(o.current)) == 1
-    η = max(η * decay, o.clip)
+    η = max(η * decay, clip)
     o.eta = η
   end
   @. Δ *= η

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -628,7 +628,7 @@ mutable struct ClipNorm{T}
   thresh_dict::IdDict
 end
 
-ClipNorm(thresh) = ClipNorm(thresh, IdDict)
+ClipNorm(thresh) = ClipNorm(thresh, IdDict())
 
 function apply!(o::ClipNorm, x, Δ)
   thresh = get(o.thresh_dict, x, o.thresh)

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -256,12 +256,14 @@ mutable struct AdaMax
   eta::Float64
   beta::Tuple{Float64,Float64}
   state::IdDict
+  eta_dict::IdDict
+  beta_dict::IdDict
 end
 
-AdaMax(η = 0.001, β = (0.9, 0.999)) = AdaMax(η, β, IdDict())
+AdaMax(η = 0.001, β = (0.9, 0.999)) = AdaMax(η, β, IdDict(), IdDict(), IdDict())
 
 function apply!(o::AdaMax, x, Δ)
-  η, β = o.eta, o.beta
+  η, β = get(o.eta_dict, x, o.eta), get(o.beta_dict, x, o.beta)
   mt, ut, βp = get!(o.state, x, (zero(x), zero(x), β))
   @. mt = β[1] * mt + (1 - β[1]) * Δ
   @. ut = max(β[2] * ut, abs(Δ))

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -607,10 +607,16 @@ end
 Clip gradients when their absolute value exceeds `thresh`.
 """
 mutable struct ClipValue{T}
-    thresh::T
+  thresh::T
+  thresh_dict::IdDict
 end
 
-apply!(o::ClipValue, x, Δ) = clamp!(Δ, -o.thresh, o.thresh)
+ClipValue(thresh) = ClipValue(thresh, IdDict())
+
+function apply!(o::ClipValue, x, Δ)
+  thresh = get(o.thresh_dict, x, o.thresh)
+  clamp!(Δ, -thresh, thresh)
+end
 
 """
     ClipNorm(thresh)

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -6,14 +6,19 @@ const ϵ = 1e-8
 # TODO: should use weak refs
 
 """
-    Descent(η = 0.1)
+    Descent(η = 0.1; η_dict = IdDict())
 
 Classic gradient descent optimiser with learning rate `η`.
 For each parameter `p` and its gradient `δp`, this runs `p -= η*δp`
+Optionally, different learning rates can be specified for different parameters
+through `η_dict`. The parameters without specific learning rates will use the
+`η` value.
 
 # Parameters
 - Learning rate (`η`): Amount by which gradients are discounted before updating
                        the weights.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
 
 # Examples
 ```julia
@@ -22,6 +27,9 @@ opt = Descent()
 opt = Descent(0.3)
 
 ps = params(model)
+
+# Use 0.3 η for all parameters except ps[2], use 0.2 for ps[2]
+opt = Descent(0.3, IdDict([(ps[2], 0.2)]))
 
 gs = gradient(ps) do
     loss(x, y)
@@ -43,7 +51,7 @@ function apply!(o::Descent, x, Δ)
 end
 
 """
-    Momentum(η = 0.01, ρ = 0.9)
+    Momentum(η = 0.01, ρ = 0.9; η_dict = IdDict(), ρ_dict = IdDict())
 
 Gradient descent optimizer with learning rate `η` and momentum `ρ`.
 
@@ -52,6 +60,10 @@ Gradient descent optimizer with learning rate `η` and momentum `ρ`.
                        the weights.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
                   prominent direction, in effect dampening oscillations.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum (`ρ_dict`): Same as the momentum but specific for each
+                                     parameter.
 
 # Examples
 ```julia
@@ -78,7 +90,7 @@ function apply!(o::Momentum, x, Δ)
 end
 
 """
-    Nesterov(η = 0.001, ρ = 0.9)
+    Nesterov(η = 0.001, ρ = 0.9; η_dict = IdDict(), ρ_dict = IdDict())
 
 Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
 
@@ -87,6 +99,10 @@ Gradient descent optimizer with learning rate `η` and Nesterov momentum `ρ`.
                        the weights.
 - Nesterov momentum (`ρ`): Controls the acceleration of gradient descent in the
                            prominent direction, in effect dampening oscillations.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum (`ρ_dict`): Same as the momentum but specific for each
+                                     parameter.
 
 # Examples
 ```julia
@@ -114,7 +130,7 @@ function apply!(o::Nesterov, x, Δ)
 end
 
 """
-    RMSProp(η = 0.001, ρ = 0.9)
+    RMSProp(η = 0.001, ρ = 0.9; η_dict = IdDict(), ρ_dict = IdDict())
 
 Optimizer using the
 [RMSProp](https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
@@ -126,6 +142,10 @@ generally don't need tuning.
                        the weights.
 - Momentum (`ρ`): Controls the acceleration of gradient descent in the
                   prominent direction, in effect dampening oscillations.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum (`ρ_dict`): Same as the momentum but specific for each
+                                     parameter.
 
 # Examples
 ```julia
@@ -152,7 +172,7 @@ function apply!(o::RMSProp, x, Δ)
 end
 
 """
-    ADAM(η = 0.001, β::Tuple = (0.9, 0.999))
+    ADAM(η = 0.001, β::Tuple = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict())
 
 [ADAM](https://arxiv.org/abs/1412.6980) optimiser.
 
@@ -161,6 +181,10 @@ end
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum decay (`β_dict`): Same as the decay of momentum but
+                                           specific for each parameter.
 
 # Examples
 ```julia
@@ -190,7 +214,7 @@ function apply!(o::ADAM, x, Δ)
 end
 
 """
-    RADAM(η = 0.001, β::Tuple = (0.9, 0.999))
+    RADAM(η = 0.001, β::Tuple = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict())
 
 [Rectified ADAM](https://arxiv.org/abs/1908.03265) optimizer.
 
@@ -199,6 +223,10 @@ end
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum decay (`β_dict`): Same as the decay of momentum but
+                                           specific for each parameter.
 
 # Examples
 ```julia
@@ -235,7 +263,7 @@ function apply!(o::RADAM, x, Δ)
 end
 
 """
-    AdaMax(η = 0.001, β::Tuple = (0.9, 0.999))
+    AdaMax(η = 0.001, β::Tuple = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict())
 
 [AdaMax](https://arxiv.org/abs/1412.6980) is a variant of ADAM based on the ∞-norm.
 
@@ -244,6 +272,10 @@ end
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum decay (`β_dict`): Same as the decay of momentum but
+                                           specific for each parameter.
 
 # Examples
 ```julia
@@ -273,7 +305,7 @@ function apply!(o::AdaMax, x, Δ)
 end
 
 """
-    OADAM(η = 0.0001, β::Tuple = (0.5, 0.9))
+    OADAM(η = 0.0001, β::Tuple = (0.5, 0.9); η_dict = IdDict(), β_dict = IdDict())
 
 [OADAM](https://arxiv.org/abs/1711.00141) (Optimistic ADAM)
 is a variant of ADAM adding an "optimistic" term suitable for adversarial training.
@@ -283,6 +315,10 @@ is a variant of ADAM adding an "optimistic" term suitable for adversarial traini
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum decay (`β_dict`): Same as the decay of momentum but
+                                           specific for each parameter.
 
 # Examples
 ```julia
@@ -314,7 +350,7 @@ function apply!(o::OADAM, x, Δ)
 end
 
 """
-    ADAGrad(η = 0.1)
+    ADAGrad(η = 0.1; η_dict = IdDict())
 
 [ADAGrad](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf) optimizer. It has
 parameter specific learning rates based on how frequently it is updated.
@@ -323,6 +359,8 @@ Parameters don't need tuning.
 # Parameters
 - Learning rate (`η`): Amount by which gradients are discounted before updating
                        the weights.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
 
 # Examples
 ```julia
@@ -347,7 +385,7 @@ function apply!(o::ADAGrad, x, Δ)
 end
 
 """
-    ADADelta(ρ = 0.9)
+    ADADelta(ρ = 0.9; ρ_dict = IdDict())
 
 [ADADelta](https://arxiv.org/abs/1212.5701) is a version of ADAGrad adapting its learning
 rate based on a window of past gradient updates.
@@ -355,6 +393,8 @@ Parameters don't need tuning.
 
 # Parameters
 - Rho (`ρ`): Factor by which the gradient is decayed at each time step.
+- Per-parameter momentum decay (`ρ_dict`): Same as `ρ` but specific for each
+                                           parameter.
 
 # Examples
 ```julia
@@ -381,7 +421,7 @@ function apply!(o::ADADelta, x, Δ)
 end
 
 """
-    AMSGrad(η = 0.001, β::Tuple = (0.9, 0.999))
+    AMSGrad(η = 0.001, β::Tuple = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict())
 
 The [AMSGrad](https://openreview.net/forum?id=ryQu7f-RZ) version of the ADAM
 optimiser. Parameters don't need tuning.
@@ -391,6 +431,10 @@ optimiser. Parameters don't need tuning.
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum decay (`β_dict`): Same as the decay of momentum but
+                                           specific for each parameter.
 
 # Examples
 ```julia
@@ -419,7 +463,7 @@ function apply!(o::AMSGrad, x, Δ)
 end
 
 """
-    NADAM(η = 0.001, β::Tuple = (0.9, 0.999))
+    NADAM(η = 0.001, β::Tuple = (0.9, 0.999); η_dict = IdDict(), β_dict = IdDict())
 
 [NADAM](http://cs229.stanford.edu/proj2015/054_report.pdf) is a Nesterov variant of ADAM.
 Parameters don't need tuning.
@@ -429,6 +473,10 @@ Parameters don't need tuning.
                        the weights.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum decay (`β_dict`): Same as the decay of momentum but
+                                           specific for each parameter.
 
 # Examples
 ```julia
@@ -458,7 +506,7 @@ function apply!(o::NADAM, x, Δ)
 end
 
 """
-    ADAMW(η = 0.001, β::Tuple = (0.9, 0.999), decay = 0)
+    ADAMW(η = 0.001, β::Tuple = (0.9, 0.999), decay = 0; η_dict = IdDict(), β_dict = IdDict(), decay_dict = IdDict())
 
 [ADAMW](https://arxiv.org/abs/1711.05101) is a variant of ADAM fixing (as in repairing) its
 weight decay regularization.
@@ -469,6 +517,12 @@ weight decay regularization.
 - Decay of momentums (`β::Tuple`): Exponential decay for the first (β1) and the
                                    second (β2) momentum estimate.
 - `decay`: Decay applied to weights during optimisation.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter momentum decay (`β_dict`): Same as the decay of momentum but
+                                           specific for each parameter.
+- Per-parameter decay (`decay_dict`): Same as the decay but specific for each
+                                      parameter.
 
 # Examples
 ```julia
@@ -508,11 +562,16 @@ function apply!(o::Optimiser, x, Δ)
 end
 
 """
-    InvDecay(γ = 0.001)
+    InvDecay(γ = 0.001; γ_dict = IdDict())
 
 Apply inverse time decay to an optimiser, so that the effective step size at
 iteration `n` is `eta / (1 + γ * n)` where `eta` is the initial step size.
 The wrapped optimiser's step size is not modified.
+
+# Parameters
+- Decay rate (`γ`): Multiplicative factor for the decay calculation.
+- Per-parameter decay rate (`γ_dict`): Same as the decay rate but specific for
+                                       each parameter.
 
 # Examples
 ```julia
@@ -536,7 +595,8 @@ function apply!(o::InvDecay, x, Δ)
 end
 
 """
-    ExpDecay(η = 0.001, decay = 0.1, decay_step = 1000, clip = 1e-4)
+    ExpDecay(η = 0.001, decay = 0.1, decay_step = 1000, clip = 1e-4;
+    η_dict = IdDict(), decay_dict = IdDict(), step_dict = IdDict(), clip_dict = IdDict())
 
 Discount the learning rate `η` by the factor `decay` every `decay_step` steps till
 a minimum of `clip`.
@@ -548,6 +608,14 @@ a minimum of `clip`.
 - `decay_step`: Schedule decay operations by setting the number of steps between
                 two decay operations.
 - `clip`: Minimum value of learning rate.
+- Per-parameter learning rates (`η_dict`): Same as the learning rate but
+                                           specific for each parameter.
+- Per-parameter decay (`decay_dict`): Same as the decay but specific for each
+                                      parameter.
+- Per-parameter step (`step_dict`): Same as the step but specific for each
+                                    parameter.
+- Per-parameter clip (`clip_dict`): Same as the clip but specific for each
+                                    parameter.
 
 # Examples
 To apply exponential decay to an optimiser:
@@ -584,12 +652,14 @@ function apply!(o::ExpDecay, x, Δ)
 end
 
 """
-    WeightDecay(wd = 0)
+    WeightDecay(wd = 0; decay_dict = IdDict())
 
 Decay weights by `wd`.
 
 # Parameters
 - Weight decay (`wd`)
+- Per-parameter weigth decay (`decay_dict`): Same as weight decay but specific
+                                             for each parameter (weight).
 """
 mutable struct WeightDecay
   wd::Real
@@ -604,9 +674,10 @@ function apply!(o::WeightDecay, x, Δ)
 end
 
 """
-    ClipValue(thresh)
+    ClipValue(thresh; thresh_dict = IdDict())
 
-Clip gradients when their absolute value exceeds `thresh`.
+Clip gradients when their absolute value exceeds `thresh`. Thresholds can be
+specified for individual parameters through thresh_dict.
 """
 mutable struct ClipValue{T}
   thresh::T
@@ -621,9 +692,10 @@ function apply!(o::ClipValue, x, Δ)
 end
 
 """
-    ClipNorm(thresh)
+    ClipNorm(thresh; thresh_dict = IdDict())
 
-Clip gradients when their L2 norm exceeds `thresh`.
+Clip gradients when their L2 norm exceeds `thresh`. Thresholds can be specified
+for individual parameters through thresh_dict.
 """
 mutable struct ClipNorm{T}
   thresh::T

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -624,13 +624,17 @@ end
 Clip gradients when their L2 norm exceeds `thresh`.
 """
 mutable struct ClipNorm{T}
-    thresh::T
+  thresh::T
+  thresh_dict::IdDict
 end
 
+ClipNorm(thresh) = ClipNorm(thresh, IdDict)
+
 function apply!(o::ClipNorm, x, Δ)
-    Δnrm = norm(Δ)
-    if Δnrm > o.thresh
-        rmul!(Δ, o.thresh / Δnrm)
-    end
-    return Δ
+  thresh = get(o.thresh_dict, x, o.thresh)
+  Δnrm = norm(Δ)
+  if Δnrm > o.thresh
+      rmul!(Δ, thresh / Δnrm)
+  end
+  return Δ
 end

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -522,12 +522,13 @@ Optimiser(InvDecay(..), Opt(..))
 mutable struct InvDecay
   gamma::Float64
   state::IdDict
+  gamma_dict::IdDict
 end
 
-InvDecay(γ = 0.001) = InvDecay(γ, IdDict())
+InvDecay(γ = 0.001) = InvDecay(γ, IdDict(), IdDict())
 
 function apply!(o::InvDecay, x, Δ)
-  γ = o.gamma
+  γ = get(o.gamma_dict, x, o.gamma)
   n = get!(o.state, x, 1)
   Δ .*= 1 / (1 + γ * n)
   o.state[x] = n + 1

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -366,12 +366,13 @@ opt = ADADelta(0.89)
 mutable struct ADADelta
   rho::Float64
   state::IdDict
+  rho_dict::IdDict
 end
 
-ADADelta(ρ = 0.9) = ADADelta(ρ, IdDict())
+ADADelta(ρ = 0.9) = ADADelta(ρ, IdDict(), IdDict())
 
 function apply!(o::ADADelta, x, Δ)
-  ρ = o.rho
+  ρ = get(o.rho_dict, x, o.rho)
   acc, Δacc = get!(o.state, x, (zero(x), zero(x)))
   @. acc = ρ * acc + (1 - ρ) * Δ^2
   @. Δ *= √Δacc/ (√acc + ϵ)


### PR DESCRIPTION
Makes all options (learning rate, momentum etc) for all optimisers per-parameter specifiable. [PyTorch supports this](https://pytorch.org/docs/stable/optim.html#per-parameter-options) already. It is useful for transfer learning, where you may want to tune different layers at different rates.

The per-parameter options are specified using `IdDict`s, these are in addition to the default option values. If a parameter doesn't have its own value for some option, the default value will be used instead.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
