### PR TITLE
Deprecate `active` field, and `auto` keyword

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -99,7 +99,7 @@ mutable struct AlphaDropout{F}
   # active::Union{Bool, Nothing}
   function AlphaDropout(p, active = nothing)
     @assert 0 ≤ p ≤ 1
-    new{typeof(p)}(p, active)
+    new{typeof(p)}(p)
   end
 end
 
@@ -108,7 +108,7 @@ function (a::AlphaDropout)(x)
   λ = eltype(x)(1.0507009873554804934193349852946)
   α = eltype(x)(1.6732632423543772848170429916717)
   α1 = eltype(x)(-λ*α)
-  noise = randn(eltype(x), size(x))
+  noise = convert(typeof(x), rand!(similar(x, eltype(x))))
   x = @. x*(noise > (1 - a.p)) + α1 * (noise < (1 - a.p))
   A = (a.p + a.p * (1 - a.p) * α1 ^ 2)^0.5
   B = -A * α1 * (1 - a.p)

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -32,7 +32,7 @@ automatically managed using the [`Dropout`](@ref) layer instead of the
 The [`Dropout`](@ref) layer is what you should use in most scenarios.
 """
 function dropout(x, p; dims=:)
-  !istraining() || return x
+  # !istraining() || return x
   y = dropout_mask(x, p, dims=dims)
   return x .* y
 end
@@ -71,7 +71,7 @@ function Dropout(p; dims = :)
 end
 
 function (a::Dropout)(x)
-  _isactive(a) || return x
+  istraining() || return x
   return dropout(x, a.p; dims = a.dims)
 end
 

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -485,29 +485,6 @@ function apply!(o::Optimiser, x, Δ)
   return Δ
 end
 
-mutable struct MultiLR{T,F}
-  opt::T
-  decay::F
-  milestone::AbstractVector
-  current::Int
-end
-
-MultiLR(opt, decay = 1, milestone = []) =
-  MultiLR(opt, decay, sort(milestone), 0)
-
-function apply!(o::MultiLR, x, Δ)
-  if o.curent in o.milestone
-    lr!(o.opt, lr(o.opt) / o.decay)
-  end
-  o.current >= o.milstone[end] || (o.current += 1)
-  apply!(opt.opt, x, Δ)
-end
-
-lr(o) = o.eta
-function lr!(opt, lr)
-  opt.eta = lr
-end
-
 """
     InvDecay(γ = 0.001)
 

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -489,10 +489,17 @@ mutable struct MultiLR{T,F}
   opt::T
   decay::F
   milestone::AbstractVector
+  current::Int
 end
 
+MultiLR(opt, decay = 1, milestone = []) =
+  MultiLR(opt, decay, sort(milestone), 0)
+
 function apply!(o::MultiLR, x, Δ)
-  lr!(o.opt, lr(o.opt) / o.decay)
+  if o.curent in o.milestone
+    lr!(o.opt, lr(o.opt) / o.decay)
+  end
+  o.current >= o.milstone[end] || (o.current += 1)
   apply!(opt.opt, x, Δ)
 end
 

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -485,6 +485,22 @@ function apply!(o::Optimiser, x, Δ)
   return Δ
 end
 
+mutable struct MultiLR{T,F}
+  opt::T
+  decay::F
+  milestone::AbstractVector
+end
+
+function apply!(o::MultiLR, x, Δ)
+  lr!(o.opt, lr(o.opt) / o.decay)
+  apply!(opt.opt, x, Δ)
+end
+
+lr(o) = o.eta
+function lr!(opt, lr)
+  opt.eta = lr
+end
+
 """
     InvDecay(γ = 0.001)
 


### PR DESCRIPTION
The `auto` functionality generally can be implemented without the extra noise that we see with having to define extra methods that can be easily disambiguated during training and during inference, including forcing `dropout`. This currently implements `Dropout` the layer and `dropout` the kernel to behave consistently with how they are expected to be called.

The current system has been a bit difficult to scale and is open to bugs without defining special handlers which may be misinterpreted. We already can support the same features with lesser potential to cause confusion.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
