### PR TITLE
One hot vector

### DIFF
--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -3,6 +3,7 @@ import Base: *
 struct OneHotVector <: AbstractVector{Bool}
   ix::UInt32
   of::UInt32
+  OneHotVector(ix, of) = ix > of ? throw(DimensionMismatch("index must be less than OneHotVector size")) : new(ix, of)
 end
 
 Base.size(xs::OneHotVector) = (Int64(xs.of),)
@@ -23,8 +24,9 @@ struct OneHotMatrix{A<:AbstractVector{OneHotVector}} <: AbstractMatrix{Bool}
   data::A
 end
 
-Base.size(xs::OneHotMatrix) = (Int64(xs.height),length(xs.data))
-
+function Base.size(xs::OneHotMatrix)
+    (Int64(xs.height),length(xs.data))
+end
 Base.getindex(xs::OneHotMatrix, i::Union{Integer, AbstractVector}, j::Integer) = xs.data[j][i]
 Base.getindex(xs::OneHotMatrix, ::Colon, i::Integer) = xs.data[i]
 Base.getindex(xs::OneHotMatrix, ::Colon, i::AbstractArray) = OneHotMatrix(xs.height, xs.data[i])

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -24,9 +24,8 @@ struct OneHotMatrix{A<:AbstractVector{OneHotVector}} <: AbstractMatrix{Bool}
   data::A
 end
 
-function Base.size(xs::OneHotMatrix)
-    (Int64(xs.height),length(xs.data))
-end
+Base.size(xs::OneHotMatrix) = (Int64(xs.height),length(xs.data))
+
 Base.getindex(xs::OneHotMatrix, i::Union{Integer, AbstractVector}, j::Integer) = xs.data[j][i]
 Base.getindex(xs::OneHotMatrix, ::Colon, i::Integer) = xs.data[i]
 Base.getindex(xs::OneHotMatrix, ::Colon, i::AbstractArray) = OneHotMatrix(xs.height, xs.data[i])

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -19,6 +19,11 @@ using Test
   @test cold == data
 end
 
+@testset "onehotvector" begin
+  @test Flux.OneHotVector(1,2) == [1; 0]
+  @test_throws DimensionMismatch Flux.OneHotVector(2,1)
+end
+
 @testset "onehotbatch indexing" begin
   y = Flux.onehotbatch(ones(3), 1:10)
   @test y[:,1] isa Flux.OneHotVector


### PR DESCRIPTION
Fixed the OneHotVector generation to return DimensionMismatch error when index is greater than the size of the vector.
OneHotVector will only be created when ix <= of.
Basic tests are included.

### PR Checklist

- [V] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
