### PR TITLE
make bias optional in dense layer

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -92,6 +92,8 @@ Create a traditional `Dense` layer with parameters `W` and `b`.
 The input `x` must be a vector of length `in`, or a batch of vectors represented
 as an `in × N` matrix. The out `y` will be a vector or batch of length `out`.
 
+Setting `initb` to `Flux.Zeros()` would switch `bias` off for the layer.
+
 # Example
 ```
 julia> d = Dense(5, 2)
@@ -103,7 +105,8 @@ julia> d(rand(5))
   0.123119034
 ```
 """
-struct Dense{F,S<:AbstractArray,T<:AbstractArray}
+
+struct Dense{F,S<:AbstractArray,T<: Union{Zeros, AbstractArray}}
   W::S
   b::T
   σ::F
@@ -112,15 +115,15 @@ end
 Dense(W, b) = Dense(W, b, identity)
 
 function Dense(in::Integer, out::Integer, σ = identity;
-               initW = glorot_uniform, initb = zeros)
-  return Dense(initW(out, in), initb(out), σ)
+               initW = glorot_uniform, initb = zeros(out))
+  return Dense(initW(out, in), initb, σ)
 end
 
 @functor Dense
 
 function (a::Dense)(x::AbstractArray)
   W, b, σ = a.W, a.b, a.σ
-  σ.(W*x .+ b)
+  typeof(b) <: Zeros ? σ.(W*x ) : σ.(W*x .+ b)
 end
 
 function Base.show(io::IO, l::Dense)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -106,7 +106,7 @@ julia> d(rand(5))
 ```
 """
 
-struct Dense{F,S<:AbstractArray,T<: Union{Zeros, AbstractArray}}
+struct Dense{F,S<:AbstractArray,T<:AbstractArray}
   W::S
   b::T
   σ::F

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -41,10 +41,10 @@ import Flux: activations
     @test_throws MethodError Dense(10, 5)(1) # avoid broadcasting
     @test_throws MethodError Dense(10, 5).(randn(10)) # avoid broadcasting
 
-    @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(1, 1)
-    @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
-    @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
-    @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
+    @test Dense(10, 1, identity, initW = ones, initb = zeros(1) )(ones(10,1)) == 10*ones(1, 1)
+    @test Dense(10, 1, identity, initW = ones )(ones(10,2)) == 10*ones(1, 2)
+    @test Dense(10, 2, identity, initW = ones, initb = zeros(2) )(ones(10,1)) == 10*ones(2, 1)
+    @test Dense(10, 2, identity, initW = ones)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
   end
 
   @testset "Diagonal" begin


### PR DESCRIPTION
This is to make the bias in dense layer as optional parameters as in the convolution networks by using Flux.Zeros()

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
