### PR TITLE
Add struct metadata to cache while de/restructuring

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -369,18 +369,18 @@ end
 
 # Flattening models to weight vectors, and back
 
-function _restructure(m, xs)
+function _restructure(m, xs; cache = IdDict())
   i = 0
   fmap(m) do x
-    x isa AbstractArray || return x
+    x isa AbstractArray || return cache[x]
     x = reshape(xs[i.+(1:length(x))], size(x))
     i += length(x)
     return x
   end
 end
 
-@adjoint function _restructure(m, xs)
-  _restructure(m, xs), dm -> (nothing,destructure(dm)[1])
+@adjoint function _restructure(m, xs; cache = IdDict())
+  _restructure(m, xs, cache = cache), dm -> (nothing,destructure(dm, cache = cache)[1])
 end
 
 """
@@ -404,13 +404,13 @@ modifications to the weight vector (for example, with a hypernetwork).
     julia> re(θ .* 2)
     Chain(Dense(10, 5, σ), Dense(5, 2), softmax)
 """
-function destructure(m)
+function destructure(m; cache = IdDict())
   xs = Zygote.Buffer([])
   fmap(m) do x
-    x isa AbstractArray && push!(xs, x)
+    x isa AbstractArray ? push!(xs, x) : (cache[x] = x)
     return x
   end
-  return vcat(vec.(copy(xs))...), p -> _restructure(m, p)
+  return vcat(vec.(copy(xs))...), p -> _restructure(m, p, cache = cache)
 end
 
 # Other


### PR DESCRIPTION
Needs Tests

Ref https://github.com/SciML/DiffEqFlux.jl/issues/432#issuecomment-707823636

Currently, using `destructure` overwrites state for recurrent layers, which may want to hold on to it. This introduces a cache which behaves exactly like the current system but adds the references to actually restore the state.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
