### PR TITLE
Fix some issues with Zeros

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -1,4 +1,4 @@
-import Adapt: adapt, adapt_storage
+import Adapt: adapt, adapt_storage, adapt_structure
 using  LinearAlgebra: Cholesky
 using Zygote: IdSet
 import Functors: @functor, functor, fmap
@@ -78,7 +78,7 @@ gpu(x) = use_cuda[] ? fmap(CUDA.cu, x) : x
 adapt_storage(T::Type{<:Real}, xs::AbstractArray{<:Real}) = convert.(T, xs)
 
 paramtype(T::Type{<:Real}, m) = fmap(x -> adapt(T, x), m)
-adapt(::Any, x::Zeros) = x # So that we for example don't accidentally end up with layers having a scalar for bias
+adapt_structure(to, x::Flux.Zeros) = x # So that we for example don't accidentally end up with layers having a scalar for bias
 
 f32(m) = paramtype(Float32, m)
 f64(m) = paramtype(Float64, m)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -78,6 +78,7 @@ gpu(x) = use_cuda[] ? fmap(CUDA.cu, x) : x
 adapt_storage(T::Type{<:Real}, xs::AbstractArray{<:Real}) = convert.(T, xs)
 
 paramtype(T::Type{<:Real}, m) = fmap(x -> adapt(T, x), m)
+adapt(::Any, x::Zeros) = x # So that we for example don't accidentally end up with layers having a scalar for bias
 
 f32(m) = paramtype(Float32, m)
 f64(m) = paramtype(Float64, m)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -61,7 +61,7 @@ mapleaves(f, x) = fmap(f, x)
 
 function loadparams!(m, xs)
   for (p, x) in zip(params(m), xs)
-    size(p) == size(x) ||
+    (any(y -> y isa Zeros, (p, x)) || size(p) == size(x)) ||
       error("Expected param size $(size(p)), got $(size(x))")
     copyto!(p, x)
   end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -372,6 +372,7 @@ end
 function _restructure(m, xs)
   i = 0
   fmap(m) do x
+    x isa Zeros && return x
     x isa AbstractArray || return x
     x = reshape(xs[i.+(1:length(x))], size(x))
     i += length(x)
@@ -407,6 +408,7 @@ modifications to the weight vector (for example, with a hypernetwork).
 function destructure(m)
   xs = Zygote.Buffer([])
   fmap(m) do x
+    x isa Zeros && return x # We don't want to include any Zeros as we allow everything returned to be changed
     x isa AbstractArray && push!(xs, x)
     return x
   end

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -54,6 +54,8 @@ Base.getindex(xs::Zeros{T,N}, inds::Union{Base.OneTo, Base.UnitRange}) where {T,
 
 Base.collect(xs::Zeros{T,N}) where {T,N} = fill(zero(T), size(xs))
 
+# Or else they'll turn into a ReshapedArray and all the stuff below is circumvented
+Base.reshape(xs::Zeros{T}, dims::Vararg{Union{Colon, Int64},N}) where {T, N} = Zeros(T, Base._reshape_uncolon(xs, dims)...)
 @adjoint reshape(xs::Zeros{T}, dims...) where T =
                 reshape(xs, dims...), _ -> nothing
 

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -68,8 +68,15 @@ for f in (:+, :-)
   end
 end
 
-+(a::Zeros, b::AbstractArray) = b + a
--(a::Zeros, b::AbstractArray) = -b + a
+# This is a bit of a whack-a-mole with avoiding ambiguity while still making sure we capture all signatures...
+@adjoint +(a::AbstractArray{<:Number}, b::Zeros) = a + b, ā -> (ā, nothing)
+@adjoint +(a::Zeros, b::AbstractArray{<:Number}) = b + a, b̄ -> (nothing, b̄)
+@adjoint +(a::Zeros, b::Zeros) = b + a, _ -> (nothing, nothing)
+
+@adjoint -(a::AbstractArray{<:Number}, b::Zeros) = a - b, ā -> (ā, nothing)
+@adjoint -(a::Zeros, b::AbstractArray{<:Number}) = -b + a, b̄ -> (nothing, -b̄)
+@adjoint -(a::Zeros{<:Number}, b::Zeros{<:Number}) = a - b, _ -> (nothing, nothing)
+
 
 Base.copy(xs::Zeros{T,N}) where {T,N} = xs
 
@@ -87,8 +94,6 @@ for op in (:+, :-)
     return sz
   end
 end
-
-# This is a bit of a whack-a-mole with avoiding ambiguity while still making sure we capture all signatures...
 
 @adjoint broadcasted(::typeof(+), a::AbstractArray{<:Number}, b::Zeros) = broadcasted(+, a, b), ā -> (nothing, unbroadcast(a, ā), nothing)
 @adjoint broadcasted(::typeof(+), a::Zeros, b::AbstractArray{<:Number}) = broadcasted(+, b, a), b̄ -> (nothing, nothing, unbroadcast(b, b̄))

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -73,6 +73,10 @@ end
 
 Base.copy(xs::Zeros{T,N}) where {T,N} = xs
 
+Base.copyto!(dest::AbstractArray, ::Zeros) = copyto!(dest, zeros(size(dest)))
+Base.copyto!(dest::Zeros, ::AbstractArray) = dest
+Base.copyto!(dest::Zeros, ::Zeros) = dest
+
 # Define broadcasting behaviour
 for op in (:+, :-)
   @eval function broadcasted(::typeof($op), a::AbstractArray{<:Number}, b::Zeros)

--- a/test/cuda/layers.jl
+++ b/test/cuda/layers.jl
@@ -45,8 +45,12 @@ end
 
 # Repeats from Conv, CrossCor
 
+ConvZeros(args...) = Conv(args...; bias=Flux.Zeros())
+ConvTransposeZeros(args...) = ConvTranspose(args...; bias=Flux.Zeros())
+CrossCorZeros(args...) = CrossCor(args...; bias=Flux.Zeros())
+DepthwiseConvZeros(args...) = DepthwiseConv(args...;bias=Flux.Zeros())
 r = rand(Float32, 28, 28, 1, 1)
-conv_layers = [Conv, ConvTranspose, CrossCor, DepthwiseConv]
+conv_layers = [Conv, ConvZeros, ConvTranspose, ConvTransposeZeros, CrossCor, CrossCorZeros, DepthwiseConv, DepthwiseConvZeros]
 gradtest("Conv", conv_layers, r, (2,2), 1=>3)
 
 pooling_layers = [MaxPool, MeanPool]

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -45,6 +45,7 @@ import Flux: activations
     @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
     @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
     @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
+    @test Dense(10, 2, identity, initW = ones, initb = Zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
   end
 
   @testset "Diagonal" begin

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -42,11 +42,13 @@ end
   op = bias(ip)
   @test sum(op) == prod(size(op))
 
-  bias = Conv((2,2), 1=>3, bias = Flux.Zeros())
-  op = bias(ip)
-  @test sum(op) ≈ 0.f0
-  gs = gradient(() -> sum(bias(ip)), Flux.params(bias))
-  @test gs[bias.bias] == nothing
+  @testset "Zeros mapped through $lmap" for lmap in (identity, cpu, f32)
+    bias = Conv((2,2), 1=>3, bias = Flux.Zeros())
+    op = bias(ip)
+    @test sum(op) ≈ 0.f0
+    gs = gradient(() -> sum(bias(ip)), Flux.params(bias))
+    @test gs[bias.bias] === nothing
+  end
 
   # Train w/o bias and make sure no convergence happens
   # when only bias can be converged

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -43,7 +43,7 @@ end
   @test sum(op) == prod(size(op))
 
   @testset "Zeros mapped through $lmap" for lmap in (identity, cpu, f32)
-    bias = Conv((2,2), 1=>3, bias = Flux.Zeros())
+    bias = Conv((2,2), 1=>3, bias = Flux.Zeros()) |> lmap
     op = bias(ip)
     @test sum(op) ≈ 0.f0
     gs = gradient(() -> sum(bias(ip)), Flux.params(bias))

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -14,9 +14,10 @@ using Random
                        Nesterov(), RMSProp(), Momentum()]
     Random.seed!(42)
     w′ = randn(10, 10)
-    loss(x) = Flux.Losses.mse(w*x, w′*x)
+    b = Flux.Zeros()
+    loss(x) = Flux.Losses.mse(w*x, w′*x .+ b)
     for t = 1: 10^5
-      θ = Params([w′])
+      θ = Params([w′, b])
       x = rand(10)
       θ̄ = gradient(() -> loss(x), θ)
       Optimise.update!(opt, θ, θ̄)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -131,8 +131,8 @@ end
 
 @testset "Zeros" begin
   m = Dense(randn(2,3), Zeros())
-  @test f64(m).b === m.b
-  @test f32(m).b === m.b
+  @test f64(m).b === m.b === Zeros()
+  @test f32(m).b === m.b === Zeros()
 end
 
 @testset "Stacking" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,5 @@
 using Flux
-using Flux: throttle, nfan, glorot_uniform, glorot_normal, kaiming_normal, kaiming_uniform, stack, unstack
+using Flux: throttle, nfan, glorot_uniform, glorot_normal, kaiming_normal, kaiming_uniform, stack, unstack, Zeros
 using StatsBase: var, std
 using Random
 using Test
@@ -127,6 +127,12 @@ end
   @test eltype(f64(m)(x)) == Float64
   @test eltype(f64(m)[1].W) == Float64
   @test eltype(f32(f64(m))[1].W) == Float32
+end
+
+@testset "Zeros" begin
+  m = Dense(randn(2,3), Zeros())
+  @test f64(m).b === m.b
+  @test f32(m).b === m.b
 end
 
 @testset "Stacking" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -182,6 +182,27 @@ end
     end
   end
 
+  @testset "Gradients for broadcasted / with sizes $s" for s in ((1,), (2,3))
+    o = ones(s)
+    z = zeros(s)
+    Z = Zeros() # Only defined for 0-dim
+
+    @testset "Explicit" begin
+      gfun(args...) = gradient((x, y) -> sum(x ./ y), args...)
+      g = gfun(z, o) 
+      @test gfun(Z, o) == (nothing, g[2])
+    end
+
+    @testset "Implicit" begin
+      gfun(x,y) = gradient(() -> sum(x ./ y), params([x,y]))
+      
+      g = gfun(z, o) 
+      gres = gfun(Z, o)
+      @test gres[o] == g[o]
+      @test gres[Z] === nothing
+    end
+  end
+
   @testset "Gradients for $op with sizes $s" for op in (+,-), s in (tuple(), (1,), (2,3))
     o = ones(s)
     z = zeros(s)


### PR DESCRIPTION
Fixes #1332, #1277 

Two things where causing trouble:
1) `adapt` (used to change type of parameters) turning `Zeros()` into `T`s
2) `reshape` (used in conv-layers) turning `Zeros` into `Base.ReshapedArray`s

Both are adressed by specializations.

I'm not sure what is the right way to overload reshape. Leaving the type out for the second argument leads to ambiguity, so there are still more than a handful ways to reshape Zeros which leads to issue 2). Any packages which does it I can look at? 

I was too lazy to come up with a nice way to check dimensions of parameters when creating a layer.

Furthermore, a number of adjoints are defined to ensure that gradients of any `Zeros` is nothing.

Also fixes a few issues with `loadparams!` and `destructure` in the presence of `Zeros`. 

### PR Checklist

- [X] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
