### PR TITLE
Fix some issues with Zeros option 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# v0.11.3
+* Added option to set `bias` to [false](https://github.com/FluxML/Flux.jl/pull/1379) to eliminating `bias` from being trained. 
+
 # v0.11.2
 
 * Adds the [AdaBelief](https://arxiv.org/abs/2010.07468) optimiser.

--- a/docs/src/models/layers.md
+++ b/docs/src/models/layers.md
@@ -24,7 +24,6 @@ ConvTranspose
 CrossCor
 SamePad
 flatten
-Flux.Zeros
 Flux.convfilter
 Flux.depthwiseconvfilter
 ```

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -83,7 +83,7 @@ extraChain(::Tuple{}, x) = ()
 
 
 """
-    Dense(in::Integer, out::Integer, σ = identity)
+    Dense(in::Integer, out::Integer, σ = identity; bias=true)
 
 Create a traditional `Dense` layer with parameters `W` and `b`.
 
@@ -91,6 +91,8 @@ Create a traditional `Dense` layer with parameters `W` and `b`.
 
 The input `x` must be a vector of length `in`, or a batch of vectors represented
 as an `in × N` matrix. The out `y` will be a vector or batch of length `out`.
+
+Setting `bias` to `false` will switch bias off for the layer.
 
 # Example
 ```
@@ -101,6 +103,9 @@ julia> d(rand(5))
 2-element Array{Float32,1}:
  -0.16210233
   0.123119034
+
+julia> d = Dense(5, 2; bias=false)
+Dense(5, 2)
 ```
 """
 struct Dense{F,S<:AbstractArray,T<:Union{Zeros, AbstractVector}}
@@ -112,8 +117,8 @@ end
 Dense(W, b) = Dense(W, b, identity)
 
 function Dense(in::Integer, out::Integer, σ = identity;
-               initW = glorot_uniform, initb = zeros)
-  return Dense(initW(out, in), initb(out), σ)
+               initW = glorot_uniform, initb = zeros, bias=true)
+  return Dense(initW(out, in), create_bias(bias, initb, out), σ)
 end
 
 @functor Dense

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -103,7 +103,7 @@ julia> d(rand(5))
   0.123119034
 ```
 """
-struct Dense{F,S<:AbstractArray,T<:AbstractArray}
+struct Dense{F,S<:AbstractArray,T<:Union{Zeros, AbstractVector}}
   W::S
   b::T
   σ::F

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -46,7 +46,7 @@ In other words, a 100×100 RGB image would be a `100×100×3×1` array,
 and a batch of 50 would be a `100×100×3×50` array.
 
 Accepts keyword arguments `weight` and `bias` to set the corresponding fields.
-Setting `bias` to `Flux.Zeros()` will switch bias off for the layer.
+Setting `bias` to `false` will switch bias off for the layer.
 
 Takes the keyword arguments `pad`, `stride` and `dilation`.
 For input dimension N,
@@ -82,7 +82,7 @@ end
 
 Constructs the convolutional layer with user defined weight and bias arrays.
 
-Setting `bias` to `Flux.Zeros()` would switch `bias` off for the layer.
+Setting `bias` to `false` would switch `bias` off for the layer.
 
 Takes the keyword arguments `pad`, `stride` and `dilation`.
 For input dimension N,
@@ -102,15 +102,16 @@ Conv(weight = weight,
     σ = sigmoid)
 ```
 """
-function Conv(w::AbstractArray{T,N}, b::Union{Zeros, AbstractVector{T}}, σ = identity;
+function Conv(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, σ = identity;
               stride = 1, pad = 0, dilation = 1) where {T,N}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(Conv, pad, size(w)[1:N-2], dilation, stride)
-  return Conv(σ, w, b, stride, pad, dilation)
+  bias = create_bias(b, zeros, size(w, N)) 
+  return Conv(σ, w, bias, stride, pad, dilation)
 end
 
-function Conv(;weight::AbstractArray{T,N}, bias::Union{Zeros, AbstractVector{T}},
+function Conv(;weight::AbstractArray{T,N}, bias::Union{Bool, Zeros, AbstractVector{T}},
               activation = identity, stride = 1, pad = 0, dilation = 1) where {T,N}
   Conv(weight, bias, activation, stride = stride, pad = pad, dilation = dilation)
 end
@@ -131,7 +132,7 @@ convfilter(filter::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer};
 
 function Conv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;
             init = glorot_uniform,  stride = 1, pad = 0, dilation = 1,
-            weight = convfilter(k, ch, init = init), bias = zeros(ch[2])) where N
+            weight = convfilter(k, ch, init = init), bias = true) where N
 
   Conv(weight, bias, σ,
       stride = stride, pad = pad, dilation = dilation)
@@ -189,7 +190,7 @@ In other words, a 100×100 RGB image would be a `100×100×3×1` array,
 and a batch of 50 would be a `100×100×3×50` array.
 
 Accepts keyword arguments `weight` and `bias` to set the corresponding fields.
-Setting `bias` to `Flux.Zeros()` will switch bias off for the layer.
+Setting `bias` to `false` will switch bias off for the layer.
 
 Takes the keyword arguments `pad`, `stride` and `dilation`.
 For input dimension N,
@@ -215,7 +216,7 @@ end
 Constructs the convolutional transpose layer with user defined weight and bias arrays.
 forward pass.
 
-Setting `bias` to `Flux.Zeros()` would switch `bias` off for the layer.
+Setting `bias` to `false` will switch bias off for the layer.
 
 Takes the keyword arguments `pad`, `stride` and `dilation`.
 For input dimension N,
@@ -226,22 +227,23 @@ indicating padding values for each spatial dimension at both the ends.
 
 For keyword-only constuctor, see also [`Conv`](@ref)
 """
-function ConvTranspose(w::AbstractArray{T,N}, b::Union{Zeros, AbstractVector{T}}, σ = identity;
+function ConvTranspose(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, σ = identity;
                       stride = 1, pad = 0, dilation = 1) where {T,N}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(ConvTranspose, pad, size(w)[1:N-2], dilation, stride)
-  return ConvTranspose(σ, w, b, stride, pad, dilation)
+  bias = create_bias(b, zeros, size(w, N)) 
+  return ConvTranspose(σ, w, bias, stride, pad, dilation)
 end
 
-function ConvTranspose(;weight::AbstractArray{T,N}, bias::Union{Zeros, AbstractVector{T}},
+function ConvTranspose(;weight::AbstractArray{T,N}, bias::Union{Bool, Zeros, AbstractVector{T}},
                         activation = identity, stride = 1, pad = 0, dilation = 1) where {T,N}
   ConvTranspose(weight, bias, activation, stride = stride, pad = pad, dilation = dilation)
 end
 
 function ConvTranspose(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;
                       init = glorot_uniform, stride = 1, pad = 0, dilation = 1,
-                      weight = convfilter(k, reverse(ch), init = init), bias = zeros(ch[2])) where N
+                      weight = convfilter(k, reverse(ch), init = init), bias = true) where N
 
   ConvTranspose(weight, bias, σ,
               stride = stride, pad = pad, dilation = dilation)
@@ -307,7 +309,7 @@ In other words, a 100×100 RGB image would be a `100×100×3×1` array,
 and a batch of 50 would be a `100×100×3×50` array.
 
 Accepts keyword arguments `weight` and `bias` to set the corresponding fields.
-Setting `bias` to `Flux.Zeros()` will switch bias off for the layer.
+Setting `bias` to `false` will switch bias off for the layer.
 
 Takes the keyword arguments `pad`, `stride` and `dilation`.
 For input dimension N,
@@ -333,7 +335,7 @@ end
 Constructs the `DepthwiseConv` layer with user defined weight and bias arrays.
 forward pass.
 
-Setting `bias` to `Flux.Zeros()` would switch `bias` off for the layer.
+Setting `bias` to `false` would switch `bias` off for the layer.
 
 Takes the keyword arguments `pad`, `stride` and `dilation`.
 For input dimension N,
@@ -344,15 +346,16 @@ indicating padding values for each spatial dimension at both the ends.
 
 For keyword-only constuctor, see also [`Conv`](@ref)
 """
-function DepthwiseConv(w::AbstractArray{T,N}, b::Union{Zeros, AbstractVector{T}}, σ = identity;
+function DepthwiseConv(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, σ = identity;
                       stride = 1, pad = 0, dilation = 1) where {T,N}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(DepthwiseConv, pad, size(w)[1:N-2], dilation, stride)
-  return DepthwiseConv(σ, w, b, stride, pad, dilation)
+  bias = create_bias(b, zeros, prod(size(w)[N-1:end])) 
+  return DepthwiseConv(σ, w, bias, stride, pad, dilation)
 end
 
-function DepthwiseConv(;weight::AbstractArray{T,N}, bias::Union{Zeros, AbstractVector{T}},
+function DepthwiseConv(;weight::AbstractArray{T,N}, bias::Union{Bool, Zeros, AbstractVector{T}},
                       activation = identity, stride = 1, pad = 0, dilation = 1) where {T,N}
   DepthwiseConv(weight, bias, activation, stride = stride, pad = pad, dilation = dilation)
 end
@@ -373,7 +376,7 @@ depthwiseconvfilter(filter::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer};
 
 function DepthwiseConv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;
                       init = glorot_uniform, stride = 1, pad = 0, dilation = 1,
-                      weight = depthwiseconvfilter(k, ch, init = init), bias = zeros(ch[2])) where N
+                      weight = depthwiseconvfilter(k, ch, init = init), bias = true) where N
   @assert ch[2] % ch[1] == 0 "Output channels must be integer multiple of input channels"
 
   return DepthwiseConv(
@@ -424,7 +427,7 @@ In other words, a 100×100 RGB image would be a `100×100×3×1` array,
 and a batch of 50 would be a `100×100×3×50` array.
 
 Accepts keyword arguments `weight` and `bias` to set the corresponding fields.
-Setting `bias` to `Flux.Zeros()` will switch bias off for the layer.
+Setting `bias` to `false` will switch bias off for the layer.
 
 Takes the keyword arguments `pad`, `stride` and `dilation`.
 For input dimension N,
@@ -461,7 +464,7 @@ end
 Constructs the standard cross convolutional layer with user defined weight and bias
 arrays.
 
-Setting `bias` to `Flux.Zeros()` would switch `bias` off for the layer.
+Setting `bias` to `false` would switch `bias` off for the layer.
 
 Takes the keyword arguments `pad`, `stride` and `dilation`.
 For input dimension N,
@@ -472,22 +475,23 @@ indicating padding values for each spatial dimension at both the ends.
 
 For keyword-only constuctor, see also [`Conv`](@ref)
 """
-function CrossCor(w::AbstractArray{T,N}, b::Union{Zeros, AbstractVector{T}}, σ = identity;
+function CrossCor(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, σ = identity;
                   stride = 1, pad = 0, dilation = 1) where {T,N}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(CrossCor, pad, size(w)[1:N-2], dilation, stride)
-  return CrossCor(σ, w, b, stride, pad, dilation)
+  bias = create_bias(b, zeros, size(w, N)) 
+  return CrossCor(σ, w, bias, stride, pad, dilation)
 end
 
-function CrossCor(;weight::AbstractArray{T,N}, bias::Union{Zeros, AbstractVector{T}},
+function CrossCor(;weight::AbstractArray{T,N}, bias::Union{Bool, Zeros, AbstractVector{T}},
                       activation = identity, stride = 1, pad = 0, dilation = 1) where {T,N}
   CrossCor(weight, bias, activation, stride = stride, pad = pad, dilation = dilation)
 end
 
 function CrossCor(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;
                   init = glorot_uniform, stride = 1, pad = 0, dilation = 1,
-                  weight = convfilter(k, ch, init = init), bias = zeros(ch[2])) where N
+                  weight = convfilter(k, ch, init = init), bias = true) where N
 
   CrossCor(weight, bias, σ,
        stride = stride, pad = pad, dilation = dilation)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -177,6 +177,20 @@ ones(dims...) = Base.ones(Float32, dims...)
 zeros(dims...) = Base.zeros(Float32, dims...)
 
 """
+    create_bias(shallcreate::Bool, iftrue, dims...) 
+    create_bias(x, ::Any...)
+
+Return a bias parameter for a layer.
+
+Essentially handles the allowed input options for the `bias` keyword:
+    If `false`: Return the `Zeros` type which turns bias off.
+    If `true` : Return the result of `iftrue(dims)`.
+    If not a boolean, return self to handle the case of bias=somearray.
+"""
+create_bias(shallcreate::Bool, iftrue, dims...) = shallcreate ? iftrue(dims...) : Zeros()
+create_bias(x, ::Any...) = x  
+
+"""
     unsqueeze(xs, dim)
 
 Return `xs` reshaped into an `Array` one dimensionality higher than `xs`,

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -1,10 +1,7 @@
-import Base: +, -, *, reshape, size
-import Base.Broadcast: broadcasted, Broadcasted, BroadcastStyle
+import Base: +, -, *,/, reshape, broadcasted
 
 """
     Zeros()
-    Zeros(size...)
-    Zeros(Type, size...)
 
 Acts as a stand-in for an array of zeros that can be
 used during training which is ignored by the optimisers.
@@ -13,94 +10,37 @@ Useful to turn bias off for a forward pass of a layer.
 
 ## Examples
 
-```julia
-julia> Flux.Zeros(3,3)
-3×3 Flux.Zeros{Bool,2}:
- false  false  false
- false  false  false
- false  false  false
-
-julia> Flux.Zeros(Float32, 3,3)
-3×3 Flux.Zeros{Float32,2}:
- 0.0  0.0  0.0
- 0.0  0.0  0.0
- 0.0  0.0  0.0
-
-julia> rand(3,3) .+ Flux.Zeros()
-3×3 Array{Float64,2}:
- 0.198739  0.490459  0.785386
- 0.779074  0.39986   0.66383
- 0.854981  0.447292  0.314497
-
+```julia-repl
 julia> bias_less_conv = Conv((2,2), 1=>3, bias = Flux.Zeros())
 Conv((2, 2), 1=>3)
+
+julia> bias_less_dense = Dense(10, 2, initb = Zeros)
+Dense(10, 2)
 ```
 """
-struct Zeros{T,N} <: AbstractArray{T,N}
-  size::Tuple
-end
+struct Zeros end
+# To allow for things like Dense(10, 2, initb = Zeros)
+Zeros(args...) = Zeros()
 
-Zeros(::Type{T}, sz...) where T = Zeros{T,length(sz)}(sz)
-Zeros(sz::Integer...) = Zeros(Bool, sz...)
+Base.reshape(x::Zeros, dims...) = x
 
-Base.size(xs::Zeros) = xs.size
-Base.axes(xs::Zeros) = Base.OneTo.(size(xs))
++(::Zeros, b::AbstractArray) = b
++(a::AbstractArray, ::Zeros) = a
++(a::Zeros, ::Zeros) = a
 
-Base.IndexStyle(::Type{<:Zeros}) = IndexLinear()
-
-Base.getindex(xs::Zeros{T,N}, I::Int) where {T,N} = zero(T)
-Base.getindex(xs::Zeros{T,N}, inds::Union{Base.OneTo, Base.UnitRange}) where {T,N} =
-              Zeros(T, length(inds))
-
-Base.collect(xs::Zeros{T,N}) where {T,N} = fill(zero(T), size(xs))
-
-@adjoint reshape(xs::Zeros{T}, dims...) where T =
-                reshape(xs, dims...), _ -> nothing
-
-# Define basic ops
-for f in (:+, :-)
-  @eval @inline function $f(a::Union{AbstractArray{<:Number}, Zeros}, b::Zeros)
-    @assert size(a) == size(b) throw(DimensionMismatch("dimensions must match"))
-    a
-  end
-end
-
-+(a::Zeros, b::AbstractArray) = b + a
--(a::Zeros, b::AbstractArray) = -b + a
-
-Base.copy(xs::Zeros{T,N}) where {T,N} = xs
-
-# Define broadcasting behaviour
-for op in (:+, :-)
-  @eval function broadcasted(::typeof($op), a::AbstractArray, b::Zeros)
-    bs = Broadcast.broadcast_shape(size(a), size(b))
-    size(a) == bs && return a
-    sz = similar(a, bs)
-    sz .= a
-  end
-end
-
-broadcasted(::typeof(+), a::Zeros, b::AbstractArray) = broadcasted(+, b, a)
-broadcasted(::typeof(-), a::Zeros, b::AbstractArray) = broadcasted(+, -b, a)
-
-function broadcasted(::typeof(*), a::AbstractArray, b::Zeros)
-  Zeros(Broadcast.broadcast_shape(size(a), size(b))...)
-end
-
-broadcasted(::typeof(*), a::Zeros, b::AbstractArray) = broadcasted(*, b, a)
-
-for op in (:+, :-, :*)
-  @eval broadcasted(::typeof($op), a::Zeros, b::Zeros) = Zeros(Broadcast.broadcast_shape(size(a), size(b))...)
-end
+-(::Zeros, b::AbstractArray) = -b
+-(a::AbstractArray, ::Zeros) = a
+-(a::Zeros, ::Zeros) = a
 
 # Some opportunities to avoid scalar indexing, intermediaries
 # Since it replicates a little of what we expect Base to do,
 # it should be possible to remove in the future, but for now,
 # these help with performance.
-broadcasted(::typeof(+), a::AbstractArray, b::Zeros{T,0}) where T = a
-broadcasted(::typeof(+), a::Zeros{T,0}, b::AbstractArray) where T = b
-broadcasted(::typeof(-), a::AbstractArray, b::Zeros{T,0}) where T = a
-broadcasted(::typeof(-), a::Zeros{T,0}, b::AbstractArray) where T = -b
-broadcasted(::typeof(*), a::AbstractArray, b::Zeros{T,0}) where T = zero(a)
-broadcasted(::typeof(*), a::Zeros{T,0}, b::AbstractArray) where T = zero(b)
-broadcasted(::typeof(/), a::Zeros{T,0}, b::AbstractArray) where T = zero(b)
+broadcasted(::typeof(+), a::AbstractArray, b::Zeros) = a
+broadcasted(::typeof(+), a::Zeros, b::AbstractArray) = b
+broadcasted(::typeof(-), a::AbstractArray, b::Zeros) = a
+broadcasted(::typeof(-), a::Zeros, b::AbstractArray) = -b
+# Need adjoints for these or else the gradient w.r.t to the non-Zeros arg will be nothing as well
+@adjoint broadcasted(::typeof(*), a::AbstractArray, b::Zeros) = zero(a), _ -> (nothing, zero(a), nothing)
+@adjoint broadcasted(::typeof(*), a::Zeros, b::AbstractArray) = zero(b), _ -> (nothing, nothing, zero(b))
+@adjoint broadcasted(::typeof(/), a::Zeros, b::AbstractArray) = zero(b), _ -> (nothing, nothing, zero(b))

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -11,11 +11,14 @@ Useful to turn bias off for a forward pass of a layer.
 ## Examples
 
 ```julia-repl
-julia> bias_less_conv = Conv((2,2), 1=>3, bias = Flux.Zeros())
+julia> bias_less_conv = Conv((2,2), 1=>3; bias = false)
 Conv((2, 2), 1=>3)
 
-julia> bias_less_dense = Dense(10, 2, initb = Zeros)
-Dense(10, 2)
+julia> params(bias_less_conv) |> length
+1
+
+julia> bias_less_conv.bias
+Flux.Zeros()
 ```
 """
 struct Zeros end

--- a/test/cuda/layers.jl
+++ b/test/cuda/layers.jl
@@ -46,10 +46,10 @@ end
 # Repeats from Conv, CrossCor
 
 # Just to give testset in gradtest meaningful labels
-ConvNoBias(args...) = Conv(args...; bias=Flux.Zeros())
-ConvTransposeNoBias(args...) = ConvTranspose(args...; bias=Flux.Zeros())
-CrossCorNoBias(args...) = CrossCor(args...; bias=Flux.Zeros())
-DepthwiseConvNoBias(args...) = DepthwiseConv(args...;bias=Flux.Zeros())
+ConvNoBias(args...) = Conv(args...; bias=false)
+ConvTransposeNoBias(args...) = ConvTranspose(args...; bias=false)
+CrossCorNoBias(args...) = CrossCor(args...; bias=false)
+DepthwiseConvNoBias(args...) = DepthwiseConv(args...;bias=false)
 r = rand(Float32, 28, 28, 1, 1)
 conv_layers = [Conv, ConvNoBias, ConvTranspose, ConvTransposeNoBias, CrossCor, CrossCorNoBias, DepthwiseConv, DepthwiseConvNoBias]
 gradtest("Conv", conv_layers, r, (2,2), 1=>3)
@@ -102,7 +102,7 @@ end
 end
 
 @testset "Zeros mapped for $cl" for cl in (Conv, ConvTranspose, CrossCor, DepthwiseConv)
-  l = cl((2,2), 1=>3, bias = Flux.Zeros()) |> gpu
+  l = cl((2,2), 1=>3, bias = false) |> gpu
   ip = zeros(Float32, 28,28,1,1) |> gpu
   if cl in BROKEN_LAYERS
     @test_broken sum(l(ip)) ≈ 0.f0

--- a/test/cuda/layers.jl
+++ b/test/cuda/layers.jl
@@ -45,8 +45,13 @@ end
 
 # Repeats from Conv, CrossCor
 
+# Just to give testset in gradtest meaningful labels
+ConvNoBias(args...) = Conv(args...; bias=Flux.Zeros())
+ConvTransposeNoBias(args...) = ConvTranspose(args...; bias=Flux.Zeros())
+CrossCorNoBias(args...) = CrossCor(args...; bias=Flux.Zeros())
+DepthwiseConvNoBias(args...) = DepthwiseConv(args...;bias=Flux.Zeros())
 r = rand(Float32, 28, 28, 1, 1)
-conv_layers = [Conv, ConvTranspose, CrossCor, DepthwiseConv]
+conv_layers = [Conv, ConvNoBias, ConvTranspose, ConvTransposeNoBias, CrossCor, CrossCorNoBias, DepthwiseConv, DepthwiseConvNoBias]
 gradtest("Conv", conv_layers, r, (2,2), 1=>3)
 
 pooling_layers = [MaxPool, MeanPool]
@@ -94,4 +99,26 @@ end
   for layer in stateless_layers_broadcasted
     stateless_gradtest_broadcasted(layer, x, y)
   end
+end
+
+@testset "Zeros mapped for $cl" for cl in (Conv, ConvTranspose, CrossCor, DepthwiseConv)
+  l = cl((2,2), 1=>3, bias = Flux.Zeros()) |> gpu
+  ip = zeros(Float32, 28,28,1,1) |> gpu
+  if cl in BROKEN_LAYERS
+    @test_broken sum(l(ip)) ≈ 0.f0
+    @test_broken gradient(() -> sum(l(ip)), Flux.params(l)) isa Flux.Zygote.Grads
+  else
+    @test sum(l(ip)) ≈ 0.f0
+    gs = gradient(() -> sum(l(ip)), Flux.params(l))
+    @test l.bias ∉ gs.params 
+  end
+end
+
+@testset "Dense with Zeros bias" begin
+  l = Dense(ones(Float32, 4,3), Flux.Zeros()) |> gpu
+  ip = zeros(Float32, 3, 7) |> gpu
+
+  @test sum(l(ip)) ≈ 0.f0  
+  gs = gradient(() -> sum(l(ip)), Flux.params(l))
+  @test l.b ∉ gs.params 
 end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -45,6 +45,7 @@ import Flux: activations
     @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
     @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
     @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
+    @test Dense(10, 2, identity, initW = ones, initb = Zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
   end
 
   @testset "Diagonal" begin

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -45,7 +45,7 @@ import Flux: activations
     @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
     @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
     @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
-    @test Dense(10, 2, identity, initW = ones, initb = Zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
+    @test Dense(10, 2, identity, initW = ones, bias = false)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
   end
 
   @testset "Diagonal" begin

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -42,8 +42,8 @@ end
   op = bias(ip)
   @test sum(op) == prod(size(op))
 
-  @testset "Zeros mapped through $lmap" for lmap in (identity, cpu, f32)
-    bias = Conv((2,2), 1=>3, bias = Flux.Zeros()) |> lmap
+  @testset "No bias mapped through $lmap" for lmap in (identity, cpu, f32)
+    bias = Conv((2,2), 1=>3, bias = false) |> lmap
     op = bias(ip)
     @test sum(op) ≈ 0.f0
     gs = gradient(() -> sum(bias(ip)), Flux.params(bias))
@@ -52,7 +52,7 @@ end
 
   # Train w/o bias and make sure no convergence happens
   # when only bias can be converged
-  bias = Conv((2, 2), 1=>3, bias = Flux.Zeros());
+  bias = Conv((2, 2), 1=>3, bias = false);
   ip = zeros(Float32, 28,28,1,1)
   op = zeros(Float32, 27,27,3,1) .+ 2.f0
   opt = Descent()
@@ -87,8 +87,11 @@ end
   m1 = DepthwiseConv((2, 2), 3=>15)
   @test size(m1(r), 3) == 15
 
-  m3 = DepthwiseConv((2, 3), 3=>9)
-  @test size(m3(r), 3) == 9
+  m2 = DepthwiseConv((2, 3), 3=>9)
+  @test size(m2(r), 3) == 9
+
+  m3 = DepthwiseConv((2, 3), 3=>9; bias=false)
+  @test size(m2(r), 3) == 9
 
   # Test that we cannot ask for non-integer multiplication factors
   @test_throws AssertionError DepthwiseConv((2,2), 3=>10)
@@ -97,8 +100,9 @@ end
 @testset "ConvTranspose" begin
   x = zeros(Float32, 28, 28, 1, 1)
   y = Conv((3,3), 1 => 1)(x)
-  x_hat = ConvTranspose((3, 3), 1 => 1)(y)
-  @test size(x_hat) == size(x)
+  x_hat1 = ConvTranspose((3, 3), 1 => 1)(y)
+  x_hat2 = ConvTranspose((3, 3), 1 => 1, bias=false)(y)
+  @test size(x_hat1) == size(x_hat2) == size(x)
 
   m = ConvTranspose((3,3), 1=>1)
   # Test that the gradient call does not throw: #900
@@ -116,7 +120,7 @@ end
   m = Chain(
     CrossCor((2, 2), 1=>16, relu),
     MaxPool((2,2)),
-    CrossCor((2, 2), 16=>8, relu),
+    CrossCor((2, 2), 16=>8, relu; bias=false),
     MaxPool((2,2)),
     x -> reshape(x, :, size(x, 4)),
     Dense(288, 10), softmax)

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -42,11 +42,13 @@ end
   op = bias(ip)
   @test sum(op) == prod(size(op))
 
-  bias = Conv((2,2), 1=>3, bias = Flux.Zeros())
-  op = bias(ip)
-  @test sum(op) ≈ 0.f0
-  gs = gradient(() -> sum(bias(ip)), Flux.params(bias))
-  @test gs[bias.bias] == nothing
+  @testset "Zeros mapped through $lmap" for lmap in (identity, cpu, f32)
+    bias = Conv((2,2), 1=>3, bias = Flux.Zeros()) |> lmap
+    op = bias(ip)
+    @test sum(op) ≈ 0.f0
+    gs = gradient(() -> sum(bias(ip)), Flux.params(bias))
+    @test bias.bias ∉ gs.params
+  end
 
   # Train w/o bias and make sure no convergence happens
   # when only bias can be converged

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -14,9 +14,10 @@ using Random
                        Nesterov(), RMSProp(), Momentum()]
     Random.seed!(42)
     w′ = randn(10, 10)
-    loss(x) = Flux.Losses.mse(w*x, w′*x)
+    b = Flux.Zeros()
+    loss(x) = Flux.Losses.mse(w*x, w′*x .+ b)
     for t = 1: 10^5
-      θ = Params([w′])
+      θ = params([w′, b])
       x = rand(10)
       θ̄ = gradient(() -> loss(x), θ)
       Optimise.update!(opt, θ, θ̄)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -130,7 +130,7 @@ end
 end
 
 @testset "Zeros" begin
-  m = Dense(randn(2,3), Zeros())
+  m = Dense(3,2; bias=false)
   @test f64(m).b === m.b === Zeros()
   @test f32(m).b === m.b === Zeros()
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,5 @@
 using Flux
-using Flux: throttle, nfan, glorot_uniform, glorot_normal, kaiming_normal, kaiming_uniform, stack, unstack
+using Flux: throttle, nfan, glorot_uniform, glorot_normal, kaiming_normal, kaiming_uniform, stack, unstack, Zeros
 using StatsBase: var, std
 using Random
 using Test
@@ -129,6 +129,92 @@ end
   @test eltype(f32(f64(m))[1].W) == Float32
 end
 
+@testset "Zeros" begin
+  m = Dense(randn(2,3), Zeros())
+  @test f64(m).b === m.b === Zeros()
+  @test f32(m).b === m.b === Zeros()
+
+  @testset "Gradients for broadcasted $op with sizes $s" for op in (+,-,*), s in ((1,), (2,3))
+    o = ones(s)
+    z = zeros(s)
+    Z = Zeros()
+
+    @testset "Explicit" begin
+      gfun(args...) = gradient((x, y) -> sum(op.(x,y)), args...)
+      g = gfun(o, z) 
+      @test gfun(o, Z) == (g[1], nothing)
+
+      g = gfun(z, o) 
+      @test gfun(Z, o) == (nothing, g[2])
+    end
+
+    @testset "Implicit" begin
+      gfun(args...) = gradient(() -> sum(op.(args...)), params(collect(args)))
+      g = gfun(o, z) 
+
+      gres = gfun(o, Z)
+      @test gres[o] == g[o]
+      @test Z ∉ gres.params
+
+      g = gfun(z, o) 
+      gres = gfun(Z, o)
+      @test gres[o] == g[o]
+      @test Z ∉ gres.params
+    end
+  end
+
+  @testset "Gradients for broadcasted / with sizes $s" for s in ((1,), (2,3))
+    o = ones(s)
+    z = zeros(s)
+    Z = Zeros() # Only defined for 0-dim
+
+    @testset "Explicit" begin
+      gfun(args...) = gradient((x, y) -> sum(x ./ y), args...)
+      g = gfun(z, o) 
+      @test gfun(Z, o) == (nothing, g[2])
+    end
+
+    @testset "Implicit" begin
+      gfun(x,y) = gradient(() -> sum(x ./ y), params([x,y]))
+
+      g = gfun(z, o) 
+      gres = gfun(Z, o)
+      @test gres[o] == g[o]
+      @test Z ∉ gres.params
+    end
+  end
+
+  @testset "Gradients for $op with sizes $s" for op in (+,-), s in (tuple(), (1,), (2,3))
+    o = ones(s)
+    z = zeros(s)
+    Z = Zeros()
+
+
+    @testset "Explicit" begin
+      gfun(args...) = gradient((x, y) -> sum(op(x,y)), args...)
+
+      g = gfun(o, z) 
+      @test gfun(o, Z) == (g[1], nothing)
+
+      g = gfun(z, o) 
+      @test gfun(Z, o) == (nothing, g[2])
+    end
+
+    @testset "Implicit" begin
+      gfun(args...) = gradient(() -> sum(op(args...)), params(collect(args)))
+      g = gfun(o, z) 
+      gres = gfun(o, Z)
+      @test gres[o] == g[o]
+      @test Z ∉ gres.params
+
+      g = gfun(z, o) 
+      gres = gfun(Z, o)
+      @test gres[o] == g[o]
+      @test Z ∉ gres.params
+    end
+  end
+end
+
 @testset "Stacking" begin
   stacked_array=[ 8 9 3 5; 9 6 6 9; 9 1 7 2; 7 4 10 6 ]
   unstacked_array=[[8, 9, 9, 7], [9, 6, 1, 4], [3, 6, 7, 10], [5, 9, 2, 6]]
@@ -136,3 +222,54 @@ end
   @test stack(unstacked_array, 2) == stacked_array
   @test stack(unstack(stacked_array, 1), 1) == stacked_array
 end
+
+@testset "Param remapping" begin
+  ls(dims...) = reshape(collect(Float32, 1:prod(dims)), dims...)
+  dl(nin, nout, bias) = Dense(ls(nin, nout), bias(nout)) 
+  dm(bias) = Chain(
+    dl(3, 5, bias),
+    dl(5, 4, bias),
+    dl(4, 3, bias)
+  )
+
+  nobias(n) = Zeros()
+  testdense(m, bt) = @testset "Check layer $i" for (i, (l1, l2)) in enumerate(zip(m, dm(bt)))
+    @test l1.W == l2.W
+    @test l1.b == l2.b
+    @test typeof(l1.b) === typeof(l2.b)
+  end
+
+  @testset "loadparams!" begin 
+    import Flux: loadparams!
+    pars(w, b::Zeros) = [w, zeros(size(w,2))]
+    pars(w, b) = [w, b] 
+    pars(l) = pars(l.W, l.b)
+    pararray(m) = mapreduce(pars, vcat, m)
+    weights(m) = mapreduce(l -> [l.W], vcat, m)
+    @testset "Bias type $bt" for bt in (zeros, nobias)
+      m = dm(bt)
+      loadparams!(m, params(m))
+      testdense(m, bt)
+    end
+
+    @testset "$b1 to $b2" for (b1, b2, be) in (
+      (zeros, ones, ones),           # Load ones as bias to a model with zeros as bias -> model gets ones as bias
+      (ones, nobias, zeros),         # Load Zeros as bias to a model with ones as bias-> model gets zeros as bias
+      (nobias, ones, nobias),        # Load ones as bias to a model with Zeros as bias-> model bias does not change
+    )
+      m1 = dm(b1)
+      m2 = dm(b2)
+      loadparams!(m1, b1 == nobias ? weights(m2) : pararray(m2))
+      testdense(m1, be)
+    end
+  end
+
+  @testset "destructure" begin
+    import Flux: destructure
+    @testset "Bias type $bt" for bt in (zeros, nobias)
+      m = dm(bt)
+      p, re = destructure(m)
+      testdense(re(p), bt)
+    end
+  end
+end 


### PR DESCRIPTION
Fixes #1332, #1277

This is take two on fixing the above issues and is intended to be mutually exclusive to #1374.

In this version Zeros is no longer an AbstractArray and is thus more like a there-is-no-such-parameter marker instead of this-parameter-is-an-immutable-array-of-zeros type. 

I made the change so that the advertised way of disabling bias is through `bias=false` rather than `bias=Zeros()`. 

`Zeros` itself is alot less capable here compared to the previous attempt, but that also keeps the number of moving parts down, i.e no need to test that both the 0-dim version and the full size version works the same. All in all there are fewer specializations compared to #1374. 

I think that a rename could definitely be in place. Better names I can think of are `bias=Off`, `bias=None` or as suggested by @mcabbott `bias=False()`. 

The best argument against renaming I can think of is to be a little bit less breaking.

### PR Checklist

- [X] Tests are added
- [X] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
