### PR TITLE
remove some unused Conv constructors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,13 +4,14 @@
 
 * The Dense layer now supports inputs with [multiple batch dimensions](https://github.com/FluxML/Flux.jl/pull/1405)
 * Excise datasets in favour of other providers in the julia ecosystem.
-* other new features and bug fixes (see GitHub's releases page)
 * Added option to set `bias` to [false](https://github.com/FluxML/Flux.jl/pull/1379) to eliminating `bias` from being trained.
+* Removed kwarg only constructors for [`convolutional layers`](https://github.com/FluxML/Flux.jl/pull/1379)).
+* Other new features and bug fixes (see GitHub releases page)
 
 ## v0.11.2
 
 * Adds the [AdaBelief](https://arxiv.org/abs/2010.07468) optimiser.
-* other new features and bug fixes (see GitHub releases page)
+* Other new features and bug fixes (see GitHub releases page)
 
 ## v0.11
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -4,3 +4,6 @@
 @deprecate BatchNorm(λ, β, γ, μ, σ², ϵ, momentum) BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, nothing)
 @deprecate GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum) GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum, nothing)
 @deprecate outdims(f, inputsize) outputsize(f, inputsize)
+@deprecate Conv(; weight,  bias, activation=identity, kws...) Conv(weight, bias, activation; kws...) 
+@deprecate ConvTranspose(; weight, bias, activation=identity, kws...) ConvTranspose(weight, bias, activation; kws...) 
+@deprecate DepthwiseConv(; weight, bias, activation=identity, kws...) DepthwiseConv(weight, bias, activation; kws...) 

--- a/src/losses/utils.jl
+++ b/src/losses/utils.jl
@@ -4,13 +4,13 @@ xlogx(x)
 Return `x * log(x)` for `x ≥ 0`, handling `x = 0` by taking the downward limit.
 """
 function xlogx(x)
-result = x * log(x)
-ifelse(iszero(x), zero(result), result)
+  result = x * log(x)
+  ifelse(iszero(x), zero(result), result)
 end
 
 CUDA.@cufunc function xlogx(x)
-result = x * log(x)
-ifelse(iszero(x), zero(result), result)
+  result = x * log(x)
+  ifelse(iszero(x), zero(result), result)
 end
 
 """
@@ -19,16 +19,16 @@ xlogy(x, y)
 Return `x * log(y)` for `y > 0` with correct limit at `x = 0`.
 """
 function xlogy(x, y)
-result = x * log(y)
-ifelse(iszero(x), zero(result), result)
+  result = x * log(y)
+  ifelse(iszero(x), zero(result), result)
 end
 
 CUDA.@cufunc function xlogy(x, y)
-result = x * log(y)
-ifelse(iszero(x), zero(result), result)
+  result = x * log(y)
+  ifelse(iszero(x), zero(result), result)
 end
 
 @adjoint function broadcasted(::typeof(xlogy), x::Zygote.Numeric, y::Zygote.Numeric)
-res = xlogy.(x, y)
-res, Δ -> (nothing, Zygote.unbroadcast(x, xlogy.(Δ, y)), Zygote.unbroadcast(y, Δ .* x ./ y))
+  res = xlogy.(x, y)
+  res, Δ -> (nothing, Zygote.unbroadcast(x, xlogy.(Δ, y)), Zygote.unbroadcast(y, Δ .* x ./ y))
 end


### PR DESCRIPTION
I think these constructors can go, I suspect no one is using them and they weren't even tested. 
Docstrings need some love, I won't do it here in order to avoid conflicts with #1391 

As a general rule, we consistently provide `Layer(W, b)` constructors, so no need to also have `Layer(; weight=W, bias=b)` for an arbitrary subset of the layers. 

### PR Checklist

- [ ] Tests are added
- [x] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
