### PR TITLE
minor documentation change regarding throttle 

### DIFF
--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -118,7 +118,7 @@ A more typical callback might look like this:
 test_x, test_y = # ... create single batch of test data ...
 evalcb() = @show(loss(test_x, test_y))
 throttled_cb = throttle(evalcb,5)
-Flux.train!(objective, ps, data, opt,
+@epochs 20 Flux.train!(objective, ps, data, opt,
             cb = throttled_cb)
 ```
 

--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -118,8 +118,7 @@ A more typical callback might look like this:
 test_x, test_y = # ... create single batch of test data ...
 evalcb() = @show(loss(test_x, test_y))
 throttled_cb = throttle(evalcb,5)
-@epochs 20 Flux.train!(objective, ps, data, opt,
-            cb = throttled_cb)
+Flux.@epochs 20 Flux.train!(objective, ps, data, opt, cb = throttled_cb)
 ```
 
 Calling `Flux.stop()` in a callback will exit the training loop early.

--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -117,9 +117,9 @@ A more typical callback might look like this:
 ```julia
 test_x, test_y = # ... create single batch of test data ...
 evalcb() = @show(loss(test_x, test_y))
-
+throttled_cb = throttle(evalcb,5)
 Flux.train!(objective, ps, data, opt,
-            cb = throttle(evalcb, 5))
+            cb = throttled_cb)
 ```
 
 Calling `Flux.stop()` in a callback will exit the training loop early.

--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -117,7 +117,7 @@ A more typical callback might look like this:
 ```julia
 test_x, test_y = # ... create single batch of test data ...
 evalcb() = @show(loss(test_x, test_y))
-throttled_cb = throttle(evalcb,5)
+throttled_cb = throttle(evalcb, 5)
 Flux.@epochs 20 Flux.train!(objective, ps, data, opt, cb = throttled_cb)
 ```
 


### PR DESCRIPTION
Minor change in training.md 
throttled function is defined prior to the train! function and not defined as an argument of train!
added @epoch to demonstrate typical training loop