### PR TITLE
Add a few sanity checks

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -54,6 +54,8 @@ function params(m...)
 end
 
 function loadparams!(m, xs)
+  length(params(m)) == length(xs) ||
+    error("Expected $(length(params(m))) parameter arrays, but got $(length(xs))")
   for (p, x) in zip(params(m), xs)
     size(p) == size(x) ||
       error("Expected param size $(size(p)), got $(size(x))")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -391,6 +391,8 @@ function _restructure(m, xs)
     i += length(x)
     return x
   end
+  i == length(xs) || error("Expected a vector of $i parameters, got $(length(xs))")
+  m
 end
 
 @adjoint function _restructure(m, xs)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -273,3 +273,14 @@ end
     end
   end
 end 
+@testset "size checks" begin
+  m = Chain(Dense(5,4), Dense(4,3))
+  p, re = destructure(m)
+  @test_throws BoundsError re(p[1:end-1])
+  @test_throws ErrorException re(vcat(p,1))
+
+  @test_throws ErrorException loadparams!(Chain(Dense(5,4), Dense(4,3), Dense(3,2)), params(m))
+  @test_throws ErrorException loadparams!(Chain(Dense(5,4), Dense(4,3, bias=false)), params(m))
+  @test_throws ErrorException loadparams!(Chain(Dense(5,4, bias=false), Dense(4,3)), params(m))
+  @test_throws ErrorException loadparams!(Chain(Dense(3,4), Dense(4,5)), params(m))
+end


### PR DESCRIPTION
This adds a warning if your `Chain` gets a Float64 gradient, as that's an easy way to get awful performance. Done in a much tidier way than #1031. 

And errors on wrong-length `loadparams!` / `restructure`, closes #1408. 

Has a test for #1393, too, which will fail until that's merged. Or can be moved, but simplest to merge that first.