### PR TITLE
`Dense` keyword handling, and docstring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Added [Focal Loss function](https://github.com/FluxML/Flux.jl/pull/1489) to Losses module
 * The Dense layer now supports inputs with [multiple batch dimensions](https://github.com/FluxML/Flux.jl/pull/1405).
 * Dense and Conv layers no longer perform  [implicit type conversion](https://github.com/FluxML/Flux.jl/pull/1394).
+* The keyword `initW` is of Dense layers is now `init`, to agree with convolutional layers.
 * Excise datasets in favour of other providers in the julia ecosystem.
 * Added option to set `bias` to [false](https://github.com/FluxML/Flux.jl/pull/1379) to eliminating `bias` from being trained.
 * Add [CTC loss function](https://github.com/FluxML/Flux.jl/pull/1287) to Losses module

--- a/docs/src/models/layers.md
+++ b/docs/src/models/layers.md
@@ -5,7 +5,6 @@ These core layers form the foundation of almost all neural networks.
 ```@docs
 Chain
 Dense
-Flux.Diagonal
 ```
 
 ## Convolution and Pooling Layers
@@ -57,7 +56,8 @@ But in contrast to the layers described in the other sections are not readily gr
 Maxout
 SkipConnection
 Parallel
-Bilinear
+Flux.Bilinear
+Flux.Diagonal
 ```
 
 ## Normalisation & Regularisation

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -7,3 +7,14 @@
 @deprecate Conv(; weight,  bias, activation=identity, kws...) Conv(weight, bias, activation; kws...) 
 @deprecate ConvTranspose(; weight, bias, activation=identity, kws...) ConvTranspose(weight, bias, activation; kws...) 
 @deprecate DepthwiseConv(; weight, bias, activation=identity, kws...) DepthwiseConv(weight, bias, activation; kws...) 
+
+function Base.getproperty(a::Dense, s::Symbol)
+  if s === :W
+    Base.depwarn("field name dense.W is deprecated in favour of dense.weight", :Dense)
+    return getfield(a, :weight)
+  elseif s === :b
+    Base.depwarn("field name dense.b is deprecated in favour of dense.bias", :Dense)
+    return getfield(a, :bias)
+  end
+  return getfield(a, s)
+end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -94,10 +94,10 @@ Dense(5, 2)
 julia> d(rand(Float32, 5, 64)) |> size
 (2, 64)
 
-julia> d(rand(Float32, 5, 1, 1, 64)) |> size
+julia> d(rand(Float32, 5, 1, 1, 64)) |> size  # treated as three batch dimensions
 (2, 1, 1, 64)
 
-julia> d1 = Dense(ones(2, 5), false, tanh)
+julia> d1 = Dense(ones(2, 5), false, tanh)  # using provided weight matrix
 Dense(5, 2, tanh; bias=false)
 
 julia> d1(ones(5))
@@ -284,13 +284,13 @@ end
 
 """
     Bilinear(in1, in2, out, σ=identity; bias=true, init=glorot_uniform)
-    Bilinear(weight::AbstractArray, [bias, σ])
+    Bilinear(W::AbstractArray, [bias, σ])
 
 Creates a Bilinear layer, which operates on two inputs at the same time.
-It has parameters `weight` and `bias`, and its output given vectors `x`, `y` is
-another vector `z` with, for `i ∈ 1:out`:
+It its output, given vectors `x`, `y` is another vector `z` with,
+for all `i ∈ 1:out`:
 
-    z[i] = σ(dot(x' * weight[i,:,:] * y + bias[i])
+    z[i] = σ(x' * W[i,:,:] * y + bias[i])
 
 If `x` and `y` are matrices, then each column of the output `z = B(x, y)` is of this form,
 with `B` a Bilinear layer.
@@ -299,7 +299,9 @@ If `y` is not given, it is taken to be equal to `x`, i.e. `B(x) == B(x, x)`
 The two inputs may also be provided as a tuple, `B((x, y)) == B(x, y)`,
 which is accepted as the input to a `Chain`.
 
-Keywords `init` and `bias` work as for [`Dense`](@ref) layer.
+The initialisation works as for [`Dense`](@ref) layer, with `W = init(out, in1, in2)`.
+By default the bias vector is `zeros(Float32, out)`, option `bias=false` will switch off
+trainable bias. Either of these may be provided explicitly.
 
 # Examples
 
@@ -370,7 +372,7 @@ function Base.show(io::IO, l::Bilinear)
 end
 
 """
-Parallel(connection, layers...)
+    Parallel(connection, layers...)
 
 Create a 'Parallel' layer that passes an input array to each path in
 `layers`, reducing the output with `connection`.

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -107,7 +107,7 @@ struct Dense{F,S<:AbstractArray,T<:Union{Zeros, AbstractVector}}
   σ::F
 end
 
-Dense(W, b) = Dense(W, b, identity)
+Dense(W, bias) = Dense(W, create_bias(bias, zeros, size(W,1)), identity)
 
 function Dense(in::Integer, out::Integer, σ = identity;
                initW = nothing, initb = nothing,
@@ -121,7 +121,7 @@ function Dense(in::Integer, out::Integer, σ = identity;
   end
 
   b = if bias === true && initb !== nothing
-    @warn "keyword initb is deprecated, please simply supply the " maxlog=1 _id=hash(initW)
+    @warn "keyword initb is deprecated, please simply supply the " maxlog=1 _id=hash(initb)
     create_bias(bias, initb, out)
   else
     create_bias(bias, zeros, out)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -143,11 +143,11 @@ end
 @functor Dense
 
 function (a::Dense)(x::AbstractArray)
-  W, b, σ = getfield(a, :weight), getfield(a, :bias), getfield(a, :σ)
+  W, b, σ = a.weight, a.bias, a.σ
   sz = size(x)
-  x = reshape(x, sz[1], :) # reshape to handle dims > 1 as batch dimensions
-  x = σ.(W*x .+ b)
-  return reshape(x, :, sz[2:end]...)
+  y = reshape(x, sz[1], :)  # reshape to handle dims > 1 as batch dimensions
+  z = σ.(W*y .+ b)
+  return reshape(z, :, sz[2:end]...)
 end
 
 function Base.show(io::IO, l::Dense)

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -30,7 +30,7 @@ function calc_padding(lt, ::SamePad, k::NTuple{N,T}, dilation, stride) where {N,
 end
 
 """
-    Conv(filter, in => out, σ=identity; stride=1, pad=0, dilation=1)
+    Conv(filter, in => out, σ=identity; stride=1, pad=0, dilation=1, [bias, init])
 
 Standard convolutional layer. `filter` is a tuple of integers
 specifying the size of the convolutional kernel;
@@ -122,7 +122,7 @@ function Conv(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, �
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(Conv, pad, size(w)[1:N-2], dilation, stride)
-  bias = create_bias(b, zeros, size(w, N))
+  bias = create_bias(w, b, size(w, N))
   return Conv(σ, w, bias, stride, pad, dilation)
 end
 
@@ -166,7 +166,7 @@ end
 
 
 """
-    ConvTranspose(filter, in => out, σ=identity; stride=1, pad=0, dilation=1)
+    ConvTranspose(filter, in => out, σ=identity; stride=1, pad=0, dilation=1, [bias, init])
 
 Standard convolutional transpose layer. `filter` is a tuple of integers
 specifying the size of the convolutional kernel, while
@@ -216,7 +216,7 @@ function ConvTranspose(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVect
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(ConvTranspose, pad, size(w)[1:N-2], dilation, stride)
-  bias = create_bias(b, zeros, size(w, N-1)) 
+  bias = create_bias(w, b, size(w, N-1))
   return ConvTranspose(σ, w, bias, stride, pad, dilation)
 end
 
@@ -266,7 +266,7 @@ function calc_padding(::Type{ConvTranspose}, pad::SamePad, k::NTuple{N,T}, dilat
 end
 
 """
-    DepthwiseConv(filter, in=>out, σ=identity; stride=1, pad=0, dilation=1)
+    DepthwiseConv(filter, in=>out, σ=identity; stride=1, pad=0, dilation=1, [bias, init])
 
 Depthwise convolutional layer. `filter` is a tuple of integers
 specifying the size of the convolutional kernel, while
@@ -313,7 +313,7 @@ function DepthwiseConv(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVect
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(DepthwiseConv, pad, size(w)[1:N-2], dilation, stride)
-  bias = create_bias(b, zeros, prod(size(w)[N-1:end]))
+  bias = create_bias(w, b, prod(size(w)[N-1:end]))
   return DepthwiseConv(σ, w, bias, stride, pad, dilation)
 end
 
@@ -355,7 +355,7 @@ end
 
 
 """
-    CrossCor(filter, in => out, σ=identity; stride=1, pad=0, dilation=1)
+    CrossCor(filter, in => out, σ=identity; stride=1, pad=0, dilation=1, [bias, init])
 
 Standard cross convolutional layer. `filter` is a tuple of integers
 specifying the size of the convolutional kernel;
@@ -401,7 +401,7 @@ function CrossCor(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(CrossCor, pad, size(w)[1:N-2], dilation, stride)
-  bias = create_bias(b, zeros, size(w, N))
+  bias = create_bias(w, b, size(w, N))
   return CrossCor(σ, w, bias, stride, pad, dilation)
 end
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -95,8 +95,8 @@ struct Conv{N,M,F,A,V}
 end
 
 """
-    Conv(weight::AbstractArray, bias, [activation; stride, pad, dilation])
-    
+    Conv(weight::AbstractArray, [bias, activation; stride, pad, dilation])
+
 Constructs a convolutional layer with the given weight and bias.
 Accepts the same keywords (and has the same defaults) as the `Conv((4,4), 3=>7, relu)`
 method.
@@ -117,13 +117,13 @@ julia> params(c1) |> length
 2
 ```
 """
-function Conv(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, σ = identity;
+function Conv(w::AbstractArray{T,N}, bias = true, σ = identity;
               stride = 1, pad = 0, dilation = 1) where {T,N}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(Conv, pad, size(w)[1:N-2], dilation, stride)
-  bias = create_bias(w, b, size(w, N))
-  return Conv(σ, w, bias, stride, pad, dilation)
+  b = create_bias(w, bias, size(w, N))
+  return Conv(σ, w, b, stride, pad, dilation)
 end
 
 function Conv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;
@@ -206,18 +206,18 @@ struct ConvTranspose{N,M,F,A,V}
 end
 
 """
-    ConvTranspose(weight::AbstractArray, bias, [activation; stride, pad, dilation])
-    
+    ConvTranspose(weight::AbstractArray, [bias, activation; stride, pad, dilation])
+
 Constructs a layer with the given weight and bias arrays.
 Accepts the same keywords as the `ConvTranspose((4,4), 3=>7, relu)` method.
 """
-function ConvTranspose(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, σ = identity;
+function ConvTranspose(w::AbstractArray{T,N}, bias = true, σ = identity;
                       stride = 1, pad = 0, dilation = 1) where {T,N}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(ConvTranspose, pad, size(w)[1:N-2], dilation, stride)
-  bias = create_bias(w, b, size(w, N-1))
-  return ConvTranspose(σ, w, bias, stride, pad, dilation)
+  b = create_bias(w, bias, size(w, N-1))
+  return ConvTranspose(σ, w, b, stride, pad, dilation)
 end
 
 function ConvTranspose(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;
@@ -304,17 +304,17 @@ end
 
 """
     DepthwiseConv(weight::AbstractArray, bias, [activation; stride, pad, dilation])
-    
+
 Constructs a layer with the given weight and bias arrays.
 Accepts the same keywords as the `DepthwiseConv((4,4), 3=>6, relu)` method.
 """
-function DepthwiseConv(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, σ = identity;
+function DepthwiseConv(w::AbstractArray{T,N}, bias = true, σ = identity;
                       stride = 1, pad = 0, dilation = 1) where {T,N}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(DepthwiseConv, pad, size(w)[1:N-2], dilation, stride)
-  bias = create_bias(w, b, prod(size(w)[N-1:end]))
-  return DepthwiseConv(σ, w, bias, stride, pad, dilation)
+  b = create_bias(w, bias, prod(size(w)[N-1:end]))
+  return DepthwiseConv(σ, w, b, stride, pad, dilation)
 end
 
 function DepthwiseConv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;
@@ -391,18 +391,18 @@ struct CrossCor{N,M,F,A,V}
 end
 
 """
-    CrossCor(weight::AbstractArray, bias, [activation; stride, pad, dilation])
-    
+    CrossCor(weight::AbstractArray, [bias, activation; stride, pad, dilation])
+
 Constructs a layer with the given weight and bias arrays.
 Accepts the same keywords as the `CrossCor((4,4), 3=>7, relu)` method.
 """
-function CrossCor(w::AbstractArray{T,N}, b::Union{Bool, Zeros, AbstractVector{T}}, σ = identity;
+function CrossCor(w::AbstractArray{T,N}, bias = true, σ = identity;
                   stride = 1, pad = 0, dilation = 1) where {T,N}
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(CrossCor, pad, size(w)[1:N-2], dilation, stride)
-  bias = create_bias(w, b, size(w, N))
-  return CrossCor(σ, w, bias, stride, pad, dilation)
+  b = create_bias(w, bias, size(w, N))
+  return CrossCor(σ, w, b, stride, pad, dilation)
 end
 
 function CrossCor(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity;

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -177,10 +177,10 @@ kaiming_normal(rng::AbstractRNG; init_kwargs...) = (dims...; kwargs...) -> kaimi
 """
     orthogonal([rng=GLOBAL_RNG], dims...; gain = 1)
 
-Return an `Array` of size `dims` which is a (semi) orthogonal matrix, as described in [1]. 
+Return an `Array` of size `dims` which is a (semi) orthogonal matrix, as described in [1].
 
 The input must have at least 2 dimensions.
-For `length(dims) > 2`, a `prod(dims[1:(end - 1)])` by `dims[end]` orthogonal matrix 
+For `length(dims) > 2`, a `prod(dims[1:(end - 1)])` by `dims[end]` orthogonal matrix
 is computed before reshaping it to the original dimensions.
 
 # Examples
@@ -291,18 +291,23 @@ ones(dims...) = Base.ones(Float32, dims...)
 zeros(dims...) = Base.zeros(Float32, dims...)
 
 """
-    create_bias(shallcreate::Bool, iftrue, dims...)
-    create_bias(x, ::Any...)
+    create_bias(weights, bias, length)
 
-Return a bias parameter for a layer.
+Return a bias parameter for a layer, based on the value given
+to the constructor's keyword `bias=bias`.
 
-Essentially handles the allowed input options for the `bias` keyword:
-    If `false`: Return the `Zeros` type which turns bias off.
-    If `true` : Return the result of `iftrue(dims)`.
-    If not a boolean, return self to handle the case of bias=somearray.
+* `bias == true` creates a zero vector, of the same type as weights.
+* `bias == false` returns `Zeros()`, a special struct which exists to encode the absence of bias.
+* `bias::AbstractArray` uses the array provided, provided it has the correct size and eltype. If the type is wrong, it will be converted.
 """
-create_bias(shallcreate::Bool, iftrue, dims...) = shallcreate ? iftrue(dims...) : Zeros()
-create_bias(x, ::Any...) = x
+function create_bias(weights::AbstractArray{T}, bias::Union{Bool, AbstractArray}, dims::Integer...) where {T}
+  bias===true && return fill!(similar(weights, dims...), 0)
+  bias===false && return Zeros()
+  size(bias) == dims || throw(DimensionMismatch("expected bias of size $dims, but got $(size(bias))"))
+  eltype(bias) == T && return bias
+  @warn "converting bias to match element type of weights" typeof(weights) typeof(bias) maxlog=3 _id=hash(dims)
+  return T.(bias)
+end
 
 """
     unsqueeze(xs, dim)

--- a/src/zeros.jl
+++ b/src/zeros.jl
@@ -47,3 +47,6 @@ broadcasted(::typeof(-), a::Zeros, b::AbstractArray) = -b
 @adjoint broadcasted(::typeof(*), a::AbstractArray, b::Zeros) = zero(a), _ -> (nothing, zero(a), nothing)
 @adjoint broadcasted(::typeof(*), a::Zeros, b::AbstractArray) = zero(b), _ -> (nothing, nothing, zero(b))
 @adjoint broadcasted(::typeof(/), a::Zeros, b::AbstractArray) = zero(b), _ -> (nothing, nothing, zero(b))
+
+# Pass-through for layer constructors
+create_bias(weights::AbstractArray, bias::Flux.Zeros, dims::Integer...) = bias

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -46,11 +46,14 @@ import Flux: activations
       @test size(Dense(10, 5)(randn(10,2,3,4))) == (5,2,3,4)
     end
     @testset "zeros" begin
+      # old keywords
       @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(1, 1)
       @test Dense(10, 1, identity, initW = ones, initb = zeros)(ones(10,2)) == 10*ones(1, 2)
       @test Dense(10, 2, identity, initW = ones, initb = zeros)(ones(10,1)) == 10*ones(2, 1)
       @test Dense(10, 2, identity, initW = ones, initb = zeros)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
       @test Dense(10, 2, identity, initW = ones, bias = false)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
+      # new
+      @test Dense(10, 1, identity, init = ones)(ones(10,2)) == 10*ones(1, 2)
     end
   end
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -161,12 +161,17 @@ import Flux: activations
       b2 = Flux.Bilinear(randn(3,4,5), false)
       @test b2.bias == Flux.Zeros()
 
-      b3 = Flux.Bilinear(randn(3,4,5), true, tanh)
+      b3 = Flux.Bilinear(randn(Float16, 3,4,5), true, tanh)
       @test b3.σ == tanh
+      @test b2.bias isa Vector{Float16}
       @test size(b3(rand(4), rand(5))) == (3,)
 
       b4 = Flux.Bilinear(3,3,7; bias=1:7, init=Flux.zeros)
       @test  b4.bias isa Vector{Float32}
+
+      @test_throws ArgumentError Flux.Bilinear(rand(3)) # expects a 3-array
+      @test_throws ArgumentError Flux.Bilinear(rand(3,4), false, tanh)
+      @test_throws DimensionMismatch Flux.Bilinear(rand(3,4,5), rand(6), tanh) # wrong length bias
     end
   end
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -163,7 +163,7 @@ import Flux: activations
 
       b3 = Flux.Bilinear(randn(Float16, 3,4,5), true, tanh)
       @test b3.σ == tanh
-      @test b2.bias isa Vector{Float16}
+      @test b3.bias isa Vector{Float16}
       @test size(b3(rand(4), rand(5))) == (3,)
 
       b4 = Flux.Bilinear(3,3,7; bias=1:7, init=Flux.zeros)

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -188,3 +188,15 @@ end
   # https://github.com/FluxML/Flux.jl/issues/1421
   @test Conv((5, 5), 10 => 20, identity; init = Base.randn).bias isa Vector{Float64}
 end
+
+@testset "constructors: $fun" for fun in [Conv, CrossCor, ConvTranspose, DepthwiseConv]
+  @test fun(rand(2,3,4)).bias isa Vector{Float64}
+  @test fun(rand(2,3,4,5), false).bias isa Flux.Zeros
+  if fun == Conv
+    @test fun(rand(2,3,4,5,6), rand(6)).bias isa Vector{Float64}
+    @test fun(rand(2,3,4,5,6), 1:6).bias isa Vector{Float64}
+  elseif fun == DepthwiseConv
+    @test fun(rand(2,3,4,5,6), rand(30)).bias isa Vector{Float64}
+  end
+  @test_throws DimensionMismatch fun(rand(2,3,4), rand(6))
+end

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -183,3 +183,8 @@ end
   l = ltype(k, pad=SamePad())
   @test size(l(data))[1:end-2] == cld.(size(data)[1:end-2], k)
 end
+
+@testset "bugs fixed" begin
+  # https://github.com/FluxML/Flux.jl/issues/1421
+  @test Conv((5, 5), 10 => 20, identity; init = Base.randn).bias isa Vector{Float64}
+end

--- a/test/outputsize.jl
+++ b/test/outputsize.jl
@@ -25,6 +25,10 @@
   m = Flux.unsqueeze(3)
   @test outputsize(m, (5, 7, 13)) == (5, 7, 1, 13)
 
+  m = Flux.Bilinear(10, 10, 7)
+  @test outputsize(m, (10,)) == (7,)
+  @test outputsize(m, (10, 32)) == (7, 32)
+
   m = Chain(Conv((3, 3), 3 => 16), BatchNorm(16), flatten, Dense(1024, 10))
   @test outputsize(m, (10, 10, 3, 50)) == (10, 50)
   @test outputsize(m, (10, 10, 3, 2)) == (10, 2)


### PR DESCRIPTION
Closes #1422, by killing the `initW` keyword, in favour of `init` as used by the Conv layers. 

Also fixes "in×out weight matrix" which was incorrect. 

And makes `Dense(rand(2,3), bias)` work like `Dense(3,2; bias)`, which again is like the Conv layers.

Edit -- also closes #1421 now, ensuring that the bias vectors of both Conv and Dense layers match the eltype of the weights. 

### PR Checklist

- [x] Tests are added
- [x] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
