### PR TITLE
Add inference hints to SkipConnection

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -241,7 +241,7 @@ through a user-supplied 2-argument callable. The first argument to the callable
 will be propagated through the given `layer` while the second is the unchanged,
 "skipped" input.
 
-The simplest "ResNet"-type connection is just `SkipConnection(layer, +)`
+The simplest "ResNet"-type connection is just `SkipConnection(layer, +)`.
 Here is a more complicated example:
 ```julia
 m = Conv((3,3), 4=>7, pad=(1,1))

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -241,8 +241,7 @@ through a user-supplied 2-argument callable. The first argument to the callable
 will be propagated through the given `layer` while the second is the unchanged,
 "skipped" input.
 
-The simplest "ResNet"-type connection is just `SkipConnection(layer, +)`,
-and requires the output of the layers to be the same shape as the input.
+The simplest "ResNet"-type connection is just `SkipConnection(layer, +)`
 Here is a more complicated example:
 ```julia
 m = Conv((3,3), 4=>7, pad=(1,1))
@@ -253,9 +252,9 @@ sm = SkipConnection(m, (mx, x) -> cat(mx, x, dims=3))
 size(sm(x)) == (5, 5, 11, 10)
 ```
 """
-struct SkipConnection
-  layers
-  connection  #user can pass arbitrary connections here, such as (a,b) -> a + b
+struct SkipConnection{T,F}
+  layers::T
+  connection::F  #user can pass arbitrary connections here, such as (a,b) -> a + b
 end
 
 @functor SkipConnection


### PR DESCRIPTION
Removed a bit of the docs that was a bit misleading and added inference hints to the type of `SkipConnection`.
