### PR TITLE
new onehot implementation

### DIFF
--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -131,6 +131,7 @@ function OneHotArray{K, N, var"N+1"}(xs::AbstractArray{T, N}) where {K, N, var"N
   OneHotArray(K, xs)
 end
 
+const OneHotVector{K} = OneHot{K}
 const OneHotMatrix{K} = OneHotArray{K, 1}
 
 onehotsize(::OneHotArray{K}) where K = Int(K)

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -323,7 +323,7 @@ return [`onehot(unk, labels)`](@ref) ; otherwise the function will raise an erro
 # Examples
 ```jldoctest
 julia> Flux.onehotbatch([:b, :a, :b], [:a, :b, :c])
-3×3 Flux.OneHoArray{3, 2, Array{Flux.OneHot{0x00000003},1}}:
+3×3 Flux.OneHotArray{3, 2, Array{Flux.OneHot{0x00000003},1}}:
  0  1  0
  1  0  1
  0  0  0

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -1,57 +1,246 @@
-import Base: *
+using Base: @_noinline_meta, @_inline_meta
+using Core: is_top_bit_set
+using Core.Intrinsics: bitcast, trunc_int, sext_int, zext_int, sle_int, eq_int, and_int
 
-struct OneHotVector <: AbstractVector{Bool}
-  ix::UInt32
-  of::UInt32
+abstract type AbstractOneHotArray{N} <: AbstractArray{Bool,  N} end
+
+# onehot erorr
+struct OneHotEncodeError <: Exception
+  K
+  val
+  OneHotEncodeError(@nospecialize(K), @nospecialize(val)) = (@_noinline_meta; new(K, val))
 end
 
-Base.size(xs::OneHotVector) = (Int64(xs.of),)
+function Base.showerror(io::IO, e::OneHotEncodeError)
+  print(io, "OneHotEncodeError: cannot encode ")
+  print(io, e.val)
+  print(io, " with OneHot{")
+  print(io, e.K)
+  print(io, '}')
+end
 
-Base.getindex(xs::OneHotVector, i::Integer) = i == xs.ix
+throw_onehotencode_error(K, val) = (@_noinline_meta; throw(OneHotEncodeError(K, val)))
 
-Base.getindex(xs::OneHotVector, ::Colon) = OneHotVector(xs.ix, xs.of)
+# onehot encode
+primitive type OneHot{K} <: AbstractOneHotArray{1} 32 end
 
-function Base.:*(A::AbstractMatrix, b::OneHotVector)
-  if size(A, 2) != b.of
-    throw(DimensionMismatch("Matrix column must correspond with OneHotVector size"))
+OneHot(k) = OneHot{UInt32(k)}
+OneHot{K}(x) where K = convert(OneHot(K), x)
+OneHot(k, x) = OneHot{k}(x)
+
+onehotsize(::OneHot{K}) where K = Int(K)
+
+# array interface
+
+Base.size(o::OneHot) = (onehotsize(o),)
+function Base.getindex(o::OneHot, i::I) where {I<:Integer}
+  @boundscheck checkbounds(o, i)
+  return convert(I, o) == i
+end
+
+Base.getindex(o::OneHot, i::Colon) = o
+
+Base.argmax(o::OneHot) = Int(o)
+
+# printing
+
+function Base.showarg(io::IO, x::OneHot, toplevel)
+  toplevel || print(io, "::")
+  join(io, ["OneHot{", onehotsize(x), '}'])
+end
+
+# convert
+
+Base.UInt32(o::OneHot) = bitcast(UInt32, o)
+Base.UInt64(o::OneHot) = zext_int(UInt64, o)
+Base.Int32(o::OneHot) = bitcast(Int32, o)
+Base.Int64(o::OneHot) = zext_int(Int64, o)
+
+Base.convert(::Type{Any}, o::OneHot) = o
+Base.convert(::Type{OneHot{K}}, o::OneHot{K}) where {K} = o
+Base.convert(::Type{UInt32},  o::OneHot) = UInt32(o)
+Base.convert(::Type{To}, o::OneHot) where {To} = convert(To, convert(UInt32, o))
+
+Base.convert(ot::Type{OneHot{K}}, x::Core.BuiltinInts) where {K} = toOneHot(ot, x)
+
+# zero
+
+Base.zero(o::O) where {O<:OneHot} = toOneHot(O, 0x00000000)
+Base.zero(::Type{<:OneHot{K}}) where K = OneHot(K, 0)
+Base.iszero(o::O) where {O<:OneHot} = iszero(convert(UInt32, o))
+
+# bit-op
+
+function check_onehot_top_bit(::Type{OneHot{K}}, x) where {K}
+  @_inline_meta
+  is_top_bit_set(x) && throw_onehotencode_error(K, x)
+  x
+end
+
+function check_onehot_encode(ot::Type{OneHot{K}}, x) where {K}
+  @_inline_meta
+  sle_int(x, K) || throw_onehotencode_error(K, x)
+  bitcast(ot, x)
+end
+
+function checked_onehot_trunc_sint(ot::Type{OneHot{K}}, x::From) where {K, From}
+  @_inline_meta
+  y = trunc_int(UInt32, x)
+  back = sext_int(From, y)
+  eq_int(x, back) || throw_onehotencode_error(K, x)
+  check_onehot_encode(ot, y)
+end
+
+function checked_onehot_trunc_uint(ot::Type{OneHot{K}}, x::From) where {K, From}
+  @_inline_meta
+  y = trunc_int(UInt32, x)
+  back = zext_int(From, y)
+  eq_int(x, back) || throw_onehotencode_error(K, x)
+  check_onehot_encode(ot, y)
+end
+
+toOneHot(ot::Type{OneHot{K}}, x::Int8) where {K} = check_onehot_encode(ot, sext_int(UInt32, check_onehot_top_bit(ot, x)))
+toOneHot(ot::Type{OneHot{K}}, x::Int16) where {K} = check_onehot_encode(ot, sext_int(UInt32, check_onehot_top_bit(ot, x)))
+toOneHot(ot::Type{OneHot{K}}, x::Int32) where {K} = check_onehot_encode(ot, bitcast(UInt32, check_onehot_top_bit(ot, x)))
+toOneHot(ot::Type{OneHot{K}}, x::Int64) where {K} = checked_onehot_trunc_sint(ot, check_onehot_top_bit(ot, x))
+toOneHot(ot::Type{OneHot{K}}, x::Int128) where {K} = checked_onehot_trunc_sint(ot, check_onehot_top_bit(ot, x))
+toOneHot(ot::Type{OneHot{K}}, x::UInt8) where {K} = check_onehot_encode(ot, zext_int(UInt32, x))
+toOneHot(ot::Type{OneHot{K}}, x::UInt16) where {K} = check_onehot_encode(ot, zext_int(UInt32, x))
+toOneHot(ot::Type{OneHot{K}}, x::UInt32) where {K} = check_onehot_encode(ot, x)
+toOneHot(ot::Type{OneHot{K}}, x::UInt64) where {K} = checked_onehot_trunc_uint(ot, x)
+toOneHot(ot::Type{OneHot{K}}, x::UInt128) where {K} = checked_onehot_trunc_uint(ot, x)
+toOneHot(ot::Type{OneHot{K}}, x::Bool) where {K} = and_int(zext_int(ot, x), toOneHot(ot, 0x1))
+
+# onehot array
+struct OneHotArray{K, N, var"N+1", A<:AbstractArray{OneHot{K}, N}} <: AbstractOneHotArray{var"N+1"}
+  onehots::A
+end
+
+OneHotArray(onehots::A) where {K, A<:AbstractArray{OneHot{K}}} = OneHotArray{K, ndims(onehots), ndims(onehots)+1, A}(onehots)
+OneHotArray{K}(indices::A) where {K, A<:AbstractArray{<:Integer}} = OneHotArray(K, indices)
+OneHotArray(k, xs) = OneHotArray(OneHot(k).(xs))
+
+OneHotArray{K, N}(xs::AbstractArray{T, N}) where {K, N, T} = OneHotArray{K, N, N+1}(xs)
+function OneHotArray{K, N, var"N+1"}(xs::AbstractArray{T, N}) where {K, N, var"N+1", T}
+  @assert N+1 == var"N+1"
+  OneHotArray(K, xs)
+end
+
+const OneHotMatrix{K} = OneHotArray{K, 1}
+
+onehotsize(::OneHotArray{K}) where K = Int(K)
+
+# array interface
+Base.size(oa::OneHotArray{K}) where K = (onehotsize(oa), size(oa.onehots)...)
+
+function Base.getindex(oa::OneHotArray{K, N}, i, is::Vararg{Int, N}) where {K, N}
+  @boundscheck checkbounds(oa, i, is...)
+  oa.onehots[is...][i]
+end
+
+function Base.getindex(oa::OneHotArray{K, N}, i::Colon, is::Vararg{Int, N}) where {K, N}
+  @boundscheck checkbounds(oa, i, is...)
+  oa.onehots[is...]
+end
+
+function Base.getindex(oa::OneHotArray{K}, i::Colon, is...) where {K}
+  @boundscheck checkbounds(oa, i, is...)
+  OneHotArray(oa.onehots[is...])
+end
+
+function Base.getindex(oa::OneHotArray{K}, i::Integer, is::Vararg{Colon, N}) where {K, N}
+  @boundscheck checkbounds(oa, i, is...)
+  map(x->x[i], oa.onehots)
+end
+
+Base.similar(o::OneHotArray, ::Type{T}, dims::Dims{N}) where {T, N} = similar(o.onehots, T, dims)
+
+# printing
+
+function Base.summary(io::IO, oa::OneHotArray)
+  join(io, size(oa), 'x')
+  join(io, [" OneHotArray{", onehotsize(oa), ", ", ndims(oa), ", "])
+  Base.showarg(io, oa.onehots, true)
+  print(io, "}")
+end
+
+# cat
+
+Base.vcat(xss::OneHot{K}...) where K = cat(xss...; dims=Val(1))
+Base.hcat(xss::OneHot{K}...) where K = cat(xss...; dims=Val(2))
+
+function Base.cat(xss::OneHot{K}...; dims) where K
+  isone(::Val{V}) where V = isone(V)
+  isone(v) = Base.isone(v)
+  if isone(dims)
+    @warn "concat OneHot{$K} along dimension 1."
+    Base._cat(Val(1), xss...)
+  else
+    predecessor(::Val{V}) where V = Val(V-1)
+    predecessor(v) = Val(v - 1)
+    yss = reshape(collect(xss), reverse(Base.rdims(predecessor(dims), axes(xss))))
+    OneHotArray(yss)
   end
-  return A[:, b.ix]
 end
 
-struct OneHotMatrix{A<:AbstractVector{OneHotVector}} <: AbstractMatrix{Bool}
-  height::Int
-  data::A
+Base.vcat(xss::OneHotArray{K}...) where K = cat(xss...; dims=Val(1))
+Base.hcat(xss::OneHotArray{K}...) where K = cat(xss...; dims=Val(2))
+
+function Base.cat(xss::OneHotArray{K}...; dims) where K
+  isone(::Val{V}) where V = isone(V)
+  isone(v) = Base.isone(v)
+  if isone(dims)
+    @warn "concat OneHotArray{$K} along dimension 1."
+    Base._cat(Val(1), xss...)
+  else
+    predecessor(::Val{V}) where V = Val(V-1)
+    predecessor(v) = v - 1
+    sdims = predecessor(dims)
+    xidss = map(xs->xs.onehots, xss)
+    ret = cat(xidss...; dims=sdims)
+    OneHotArray(ret)
+  end
 end
 
-Base.size(xs::OneHotMatrix) = (Int64(xs.height),length(xs.data))
+# reshape
 
-Base.getindex(xs::OneHotMatrix, i::Union{Integer, AbstractVector}, j::Integer) = xs.data[j][i]
-Base.getindex(xs::OneHotMatrix, ::Colon, i::Integer) = xs.data[i]
-Base.getindex(xs::OneHotMatrix, ::Colon, i::AbstractArray) = OneHotMatrix(xs.height, xs.data[i])
-Base.getindex(xs::OneHotMatrix, ::Colon, ::Colon) = OneHotMatrix(xs.height, copy(xs.data))
+"reshape the onehots"
+function ohreshape(parent::OneHotArray{K}, dims) where K
+  onehots = parent.onehots
+  OneHotArray(reshape(onehots, dims))
+end
 
-Base.getindex(xs::OneHotMatrix, i::Integer, ::Colon) = map(x -> x[i], xs.data)
+function Base.reshape(parent::OneHotArray{K}, dims::Dims) where K
+  isequal(prod(dims), length(parent)) || throw(DimensionMismatch("new dimensions $(dims) must be consistent with array size $(length(parent))"))
+  return isequal(K, first(dims)) ?
+    ohreshape(parent, Base.tail(dims)) :
+    Base._reshape(parent, dims)
+end
 
-# remove workaround when https://github.com/JuliaGPU/CuArrays.jl/issues/676 is fixed
-A::AbstractMatrix * B::OneHotMatrix = A[:, cpu(map(x->x.ix, B.data))]
+function Base.reshape(parent::OneHotArray{K}, dims::Tuple{Vararg{Union{Colon, Int64}}}) where K
+  rdims = Base._reshape_uncolon(parent, dims)
+  return isequal(K, first(rdims)) ?
+    ohreshape(parent, Base.tail(rdims)) :
+    Base._reshape(parent,
+                  rdims)
+end
 
-Base.hcat(x::OneHotVector, xs::OneHotVector...) = OneHotMatrix(length(x), [x, xs...])
-
-batch(xs::AbstractArray{<:OneHotVector}) = OneHotMatrix(length(first(xs)), xs)
-
+# gpu
 import Adapt: adapt, adapt_structure
+adapt_structure(T, oa::OneHotArray) = OneHotArray(adapt(T, oa.onehots))
 
-adapt_structure(T, xs::OneHotMatrix) = OneHotMatrix(xs.height, adapt(T, xs.data))
+import .CUDA: CuArray, CuArrayStyle
 
-import .CUDA: CuArray, CuArrayStyle, cudaconvert
-import Base.Broadcast: BroadcastStyle, ArrayStyle
-BroadcastStyle(::Type{<:OneHotMatrix{<:CuArray}}) = CuArrayStyle{2}()
-cudaconvert(x::OneHotMatrix{<:CuArray}) = OneHotMatrix(x.height, cudaconvert(x.data))
+Base.BroadcastStyle(::Type{<: OneHotArray{K, N, var"N+1", A}}) where {K, N, var"N+1", A <: CuArray} = CuArrayStyle{var"N+1"}()
+
+# api
+
+batch(xs::AbstractVector{<:OneHot}) = OneHotArray(xs)
 
 """
     onehot(l, labels[, unk])
 
-Return a `OneHotVector` where only first occourence of `l` in `labels` is `1` and
+Return a `OneHot` where only first occourence of `l` in `labels` is `1` and
 all other elements are `0`.
 
 If `l` is not found in labels and  `unk` is present, the function returns
@@ -60,13 +249,13 @@ If `l` is not found in labels and  `unk` is present, the function returns
 # Examples
 ```jldoctest
 julia> Flux.onehot(:b, [:a, :b, :c])
-3-element Flux.OneHotVector:
+3-element Flux.OneHot{3}:
  0
  1
  0
 
 julia> Flux.onehot(:c, [:a, :b, :c])
-3-element Flux.OneHotVector:
+3-element Flux.OneHot{3}:
  0
  0
  1
@@ -75,13 +264,13 @@ julia> Flux.onehot(:c, [:a, :b, :c])
 function onehot(l, labels)
   i = something(findfirst(isequal(l), labels), 0)
   i > 0 || error("Value $l is not in labels")
-  OneHotVector(i, length(labels))
+  OneHot(length(labels), i)
 end
 
 function onehot(l, labels, unk)
   i = something(findfirst(isequal(l), labels), 0)
   i > 0 || return onehot(unk, labels)
-  OneHotVector(i, length(labels))
+  OneHot(length(labels), i)
 end
 
 """
@@ -95,16 +284,14 @@ return [`onehot(unk, labels)`](@ref) ; otherwise the function will raise an erro
 # Examples
 ```jldoctest
 julia> Flux.onehotbatch([:b, :a, :b], [:a, :b, :c])
-3×3 Flux.OneHotMatrix{Array{Flux.OneHotVector,1}}:
+3×3 Flux.OneHoArray{3, 2, Array{Flux.OneHot{0x00000003},1}}:
  0  1  0
  1  0  1
  0  0  0
 ```
 """
 onehotbatch(ls, labels, unk...) =
-  OneHotMatrix(length(labels), [onehot(l, labels, unk...) for l in ls])
-
-Base.argmax(xs::OneHotVector) = xs.ix
+  OneHotMatrix{length(labels)}([onehot(l, labels, unk...) for l in ls])
 
 """
     onecold(y[, labels = 1:length(y)])
@@ -125,6 +312,21 @@ onecold(y::AbstractVector, labels = 1:length(y)) = labels[Base.argmax(y)]
 onecold(y::AbstractMatrix, labels...) =
   dropdims(mapslices(y -> onecold(y, labels...), y, dims=1), dims=1)
 
-onecold(y::OneHotMatrix, labels...) = map(x -> Flux.onecold(x, labels...), y.data)
+function onecold(y::OneHotArray, labels = 1:onehotsize(y))
+  @assert onehotsize(y) == length(labels)
+  x = convert(AbstractArray{Int}, y.onehots)
+  if labels == 1:onehotsize(y)
+    return x
+  else
+    return map(xi -> labels[xi], x)
+  end
+end
 
-@nograd onecold, onehot, onehotbatch
+# AD
+@nograd OneHot, OneHotArray, onecold, onehot, onehotbatch
+
+import Base: *
+function Base.:(*)(A::AbstractMatrix, B::AbstractOneHotArray)
+  size(A, 2) == onehotsize(B) || throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $(onehotsize(B))"))
+  A[:, onecold(B)]
+end

--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -13,7 +13,7 @@ using LinearAlgebra: I, cholesky, Cholesky
 
   x = Flux.onehotbatch([1, 2, 3], 1:3)
   cx = gpu(x)
-  @test cx isa Flux.OneHotMatrix && cx.data isa CuArray
+  @test cx isa Flux.OneHotMatrix && cx.onehots isa CuArray
   @test (cx .+ 1) isa CuArray
 
   m = Chain(Dense(10, 5, tanh), Dense(5, 2), softmax)

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -33,3 +33,94 @@ end
   @test A*b1 == A[:,1]
   @test_throws DimensionMismatch A*b2
 end
+
+@testset "OneHot primitive" begin
+  using Flux: OneHot
+  idx = rand(5:10)
+  ot = OneHot(10)
+  o = OneHot{10}(idx)
+
+  @test Flux.onehotsize(o) == 10
+  @test o == OneHot(10, idx)
+  @test o == ot(idx)
+
+  @test size(o) == (10,)
+  for i = 1:10
+    @test o[i] == (i == idx)
+  end
+  @test_throws BoundsError o[11]
+
+  @test UInt32(o) == UInt32(idx)
+  @test UInt64(o) == UInt64(idx)
+  @test Int32(o) == Int32(idx)
+  @test Int64(o) == Int64(idx)
+
+  @test convert(UInt32, o) == UInt32(idx)
+  @test convert(UInt64, o) == UInt64(idx)
+  @test convert(Int32, o) == Int32(idx)
+  @test convert(Int64, o) == Int64(idx)
+  @test convert(Int8, o) == Int8(idx)
+  @test_throws InexactError convert(Bool, o)
+  @test convert(ot, idx) == o
+  @test convert(ot, UInt8(idx)) == o
+  @test convert(ot, UInt16(idx)) == o
+  @test convert(ot, UInt32(idx)) == o
+  @test convert(ot, UInt64(idx)) == o
+  @test convert(ot, UInt128(idx)) == o
+  @test convert(ot, Int8(idx)) == o
+  @test convert(ot, Int16(idx)) == o
+  @test convert(ot, Int32(idx)) == o
+  @test convert(ot, Int64(idx)) == o
+  @test convert(ot, Int128(idx)) == o
+
+  @test convert(ot, true) == OneHot(10, 1)
+  @test convert(ot, false) == OneHot(10, 0)
+
+  @test convert(OneHot(15), o) == OneHot(15, idx)
+  @test convert(OneHot(idx+1), o) == OneHot(idx+1, idx)
+  @test_throws Flux.OneHotEncodeError convert(OneHot(idx-1), o)
+
+  @test zero(o) == OneHot(10, 0)
+  @test !iszero(o)
+  @test iszero(zero(o))
+
+  @test_throws Flux.OneHotEncodeError convert(ot, -1)
+  @test_throws Flux.OneHotEncodeError convert(ot, 12)
+  @test_throws Flux.OneHotEncodeError convert(ot, typemax(Int64))
+  @test_throws Flux.OneHotEncodeError convert(ot, typemax(UInt64))
+end
+
+@testset "OneHotArray" begin
+  using Flux: OneHotArray
+  idx = rand(5:10)
+  ot = OneHot(10)
+  o = OneHot{10}(idx)
+  ind = rand(1:10, 5, 5)
+  oa = OneHotArray{10}(ind)
+
+  @test Flux.onehotsize(oa) == 10
+  @test OneHotArray(15, oa) |> Flux.onehotsize == 15
+
+  @test size(oa) == (10, 5, 5)
+  @test oa[:, 5, 5] == oa.onehots[5, 5]
+  @test oa[:, 5, :] == OneHotArray(oa.onehots[5, :])
+  @test oa[ind[1], 1, 1]
+
+  @test vcat(o, o) == vcat(collect(o), collect(o))
+  @test hcat(o, o).onehots == [o,o]
+  @test cat(o, o; dims=1) == vcat(collect(o), collect(o))
+  @test cat(o, o; dims=2).onehots == [o,o]
+
+  @test vcat(oa, oa) == vcat(collect(oa), collect(oa))
+  @test hcat(oa, oa).onehots == vcat(oa.onehots, oa.onehots)
+  @test cat(oa, oa; dims=1) == vcat(collect(oa), collect(oa))
+  @test cat(oa, oa; dims=2).onehots == vcat(oa.onehots, oa.onehots)
+  @test cat(oa, oa; dims=3).onehots == cat(oa.onehots, oa.onehots; dims=2)
+
+  @test reshape(oa, 10, 25) isa OneHotArray
+  @test reshape(oa, 10, :) isa OneHotArray
+  @test reshape(oa, :, 25) isa OneHotArray
+  @test reshape(oa, 50, :) isa Base.ReshapedArray{Bool, 2}
+  @test reshape(oa, 5, 10, 5) isa Base.ReshapedArray{Bool, 3}
+
+end

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -21,14 +21,14 @@ end
 
 @testset "onehotbatch indexing" begin
   y = Flux.onehotbatch(ones(3), 1:10)
-  @test y[:,1] isa Flux.OneHotVector
-  @test y[:,:] isa Flux.OneHotMatrix
+  @test y[:,1] isa Flux.OneHot
+  @test y[:,:] isa Flux.OneHotArray
 end
 
 @testset "abstractmatrix onehotvector multiplication" begin
   A = [1 3 5; 2 4 6; 3 6 9]
-  b1 = Flux.OneHotVector(1,3)
-  b2 = Flux.OneHotVector(3,5)
+  b1 = Flux.OneHot(3, 1)
+  b2 = Flux.OneHot(5, 3)
 
   @test A*b1 == A[:,1]
   @test_throws DimensionMismatch A*b2


### PR DESCRIPTION
fix #1445, #1229 
probably also  #864, #556, #189

The new implementation support multi-dimensional onehot representation (#1229, #1445) with the new type `OneHotArray{K}` and `OneHot{K}`. Since the `height` of previous `OneHotMatrix` is now store on the type parameter, we can reduce the memory consumption by almost half of the origin (#1445). Most the operation are now GPU compatible (#864) without scalar operations, potentially solve the performance issues (#189, #556).

The API should be the same as I implemented them with the new type.

Remaining problem:
The backward of "embedding lookup" for GPU still require scalar operation. This can be fix with [the scatter operator](https://github.com/FluxML/NNlib.jl/pull/255).

some performance comparison:
1. #189
```julia
# the old one
julia> x = Flux.onehotbatch(rand(1:100, 50), 1:100);

julia> W = rand(128, 100);

julia> @btime W * x;
  5.021 μs (13 allocations: 50.86 KiB)

julia> cW, cx = cu(W), cu(x);

julia> @btime cW * cx;
  18.942 μs (52 allocations: 2.06 KiB)

# the new one
julia> x = Flux.onehotbatch(rand(1:100, 50), 1:100);

julia> @btime W * x;
  4.588 μs (3 allocations: 50.36 KiB)

julia> cW, cx = cu(W), cu(x);

julia> @btime cW * cx;
  8.007 μs (60 allocations: 1.67 KiB)
```

2. #556
```julia
julia> valY = randn(1000, 128);

# the old one
julia> @btime onecold(valY);
  442.836 μs (998 allocations: 36.08 KiB)

julia> @btime onecold($(gpu(valY)));
┌ Warning: Performing scalar operations on GPU arrays: This is very slow, consider disallowing these operations with `allowscalar(false)`
└ @ GPUArrays ~/.julia/packages/GPUArrays/eVYIC/src/host/indexing.jl:43
  6.372 ms (13804 allocations: 479.33 KiB)

# the new one
julia> @btime onecold(valY);
  552.794 μs (8 allocations: 4.00 KiB)

julia> @btime onecold($(gpu(valY)));
  24.778 μs (169 allocations: 5.56 KiB)
``` 


### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
