### PR TITLE
Fix rand(::Type{Nil}) errors

### DIFF
--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -41,7 +41,7 @@ Base.typemax(::Type{Nil}) = nil
 
 Base.promote_rule(x::Type{Nil}, y::Type{<:Number}) = Nil
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Nil}) = Nil
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Nil}) = nil
 
 end  # module
 

--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -1,6 +1,7 @@
 module NilNumber
 
 using NNlib
+import Random
 
 """
     Nil <: Number
@@ -39,6 +40,8 @@ Base.typemin(::Type{Nil}) = nil
 Base.typemax(::Type{Nil}) = nil
 
 Base.promote_rule(x::Type{Nil}, y::Type{<:Number}) = Nil
+
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Nil}) = Nil
 
 end  # module
 


### PR DESCRIPTION
Fixes failing CI in #1452 by defining [the proper Random interface](https://docs.julialang.org/en/v1/stdlib/Random/#Generating-values-from-a-type) for the `Nil` type.
