### PR TITLE
Improve docs for `crossentropy` & friends

### DIFF
--- a/src/losses/Losses.jl
+++ b/src/losses/Losses.jl
@@ -11,7 +11,7 @@ import Base.Broadcast: broadcasted
 export mse, mae, msle,
     label_smoothing,
     crossentropy, logitcrossentropy,
-    # binarycrossentropy, logitbinarycrossentropy # export only after end deprecation
+    binarycrossentropy, logitbinarycrossentropy,
     kldivergence,
     huber_loss,
     tversky_loss,

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -100,22 +100,22 @@ of label smoothing to binary distributions encoded in a single number.
 # Example
 ```jldoctest
 julia> y = Flux.onehotbatch([1, 1, 1, 0, 1, 0], 0:1)
-2×6 Flux.OneHotArray{UInt32, 2, 1, 2, Vector{UInt32}}:
+2×6 Flux.OneHotArray{UInt32,2,1,2,Array{UInt32,1}}:
  0  0  0  1  0  1
  1  1  1  0  1  0
 
 julia> y_smoothed = Flux.label_smoothing(y, 0.2f0)
-2×6 Matrix{Float32}:
+2×6 Array{Float32,2}:
  0.1  0.1  0.1  0.9  0.1  0.9
  0.9  0.9  0.9  0.1  0.9  0.1
 
 julia> y_sim = softmax(y .* log(2f0))
-2×6 Matrix{Float32}:
+2×6 Array{Float32,2}:
  0.333333  0.333333  0.333333  0.666667  0.333333  0.666667
  0.666667  0.666667  0.666667  0.333333  0.666667  0.333333
 
 julia> y_dis = vcat(y_sim[2,:]', y_sim[1,:]')
-2×6 Matrix{Float32}:
+2×6 Array{Float32,2}:
  0.666667  0.666667  0.666667  0.333333  0.666667  0.333333
  0.333333  0.333333  0.333333  0.666667  0.333333  0.666667
 
@@ -165,7 +165,7 @@ See also: [`logitcrossentropy`](@ref), [`binarycrossentropy`](@ref), [`logitbina
 # Example
 ```jldoctest
 julia> y_label = Flux.onehotbatch([0, 1, 2, 1, 0], 0:2)
-3×5 Flux.OneHotArray{UInt32, 3, 1, 2, Vector{UInt32}}:
+3×5 Flux.OneHotArray{UInt32,3,1,2,Array{UInt32,1}}:
  1  0  0  0  1
  0  1  0  1  0
  0  0  1  0  0
@@ -216,7 +216,7 @@ See also: [`binarycrossentropy`](@ref), [`logitbinarycrossentropy`](@ref), [`lab
 # Example
 ```jldoctest
 julia> y_label = Flux.onehotbatch(collect("abcabaa"), 'a':'c')
-3×7 Flux.OneHotArray{UInt32, 3, 1, 2, Vector{UInt32}}:
+3×7 Flux.OneHotArray{UInt32,3,1,2,Array{UInt32,1}}:
  1  0  0  1  0  1  1
  0  1  0  0  1  0  0
  0  0  1  0  0  0  0

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -1,3 +1,8 @@
+# In this file, doctests which differ in the printed Float32 values won't fail
+```@meta
+DocTestFilters = r"[0-9\.]+f0"
+```
+
 """
     mae(ŷ, y; agg=mean)
 
@@ -419,3 +424,8 @@ function tversky_loss(ŷ, y; β=ofeltype(ŷ, 0.7))
     den = sum(y .* ŷ + β*(1 .- y) .* ŷ + (1 - β)*y .* (1 .- ŷ)) + 1
     1 - num / den
 end
+
+
+```@meta
+DocTestFilters = nothing
+```

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -186,15 +186,15 @@ julia> sum(y_model; dims=1)
  1.0  1.0  1.0  1.0  1.0
 
 julia> Flux.crossentropy(y_model, y_label)
-1.6076052f0
+1.6076053f0
 
-julia> Flux.crossentropy(y_model, y_label; agg=sum)
-8.038026f0
+julia> 5 * ans ≈ Flux.crossentropy(y_model, y_label; agg=sum)
+true
 
 julia> y_smooth = Flux.label_smoothing(y_label, 0.15f0)
 3×5 Array{Float32,2}:
- 0.9   0.05  0.05  0.9   0.05
- 0.05  0.9   0.05  0.05  0.9
+ 0.9   0.05  0.05  0.05  0.9
+ 0.05  0.9   0.05  0.9   0.05
  0.05  0.05  0.9   0.05  0.05
 
 julia> Flux.crossentropy(y_model, y_smooth)


### PR DESCRIPTION
Also restores export of binarycrossentropy, logitbinarycrossentropy from Losses module, which was commented out for some long-lost deprecation reason, I think?