### PR TITLE
Expose train loop to user code

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -77,8 +77,6 @@ end
 batchmemaybe(x) = tuple(x)
 batchmemaybe(x::Tuple) = x
 
-train_prehook(args...) = true
-
 """
     train!(loss, params, data, opt; cb)
 
@@ -106,8 +104,8 @@ function train!(loss, ps, data, opt; cb = (x...) -> (), prehooks = (x...) -> tru
         loss(batchmemaybe(d)...)
       end
       gs = back(l)
-      all(train_prehooks(l, ps, gs, d, opt)) && update!(opt, ps, gs)
-      cb(l, ps, gs, d, opt)
+      all(train_prehooks(l, gs, d)) && update!(opt, ps, gs)
+      cb(l, gs, d)
     catch ex
       if ex isa StopException
         break


### PR DESCRIPTION
This is an example of doing something like #1461 where we can now add schedulers as `prehooks` and have the loss etc be available locally to the users to write better more efficient callbacks as well as manage when updates happen via pre hooks. This means pre hooks can throw `SkipException` and not update the params at all, or run arbitrary code in general.

Generally, it exposes the inner objects to be used by custom callbacks rather than pick them up from global scope or run into further hacks that can be bad for performance, which we have seen happen often.

of course, this is just implementing the changes to the loop itself, and the documentation and advertising the `for` loop more stands. This is to understand if that kind of API can be adopted, which seems clean enough and opens helps plug some holes in our training routines.