### PR TITLE
Implementation of Focal loss

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## v0.12.0
 
+* Added [Focal Loss function](https://github.com/FluxML/Flux.jl/pull/1489) to Losses module
 * The Dense layer now supports inputs with [multiple batch dimensions](https://github.com/FluxML/Flux.jl/pull/1405).
 * Dense and Conv layers no longer perform  [implicit type conversion](https://github.com/FluxML/Flux.jl/pull/1394).
 * Excise datasets in favour of other providers in the julia ecosystem.

--- a/docs/src/models/losses.md
+++ b/docs/src/models/losses.md
@@ -39,4 +39,6 @@ Flux.Losses.hinge_loss
 Flux.Losses.squared_hinge_loss
 Flux.Losses.dice_coeff_loss
 Flux.Losses.tversky_loss
+Flux.Losses.binary_focal_loss
+Flux.Losses.focal_loss
 ```

--- a/src/losses/Losses.jl
+++ b/src/losses/Losses.jl
@@ -19,8 +19,7 @@ export mse, mae, msle,
     poisson_loss,
     hinge_loss, squared_hinge_loss,
     ctc_loss,
-    binary_focal_loss,
-    categorical_focal_loss
+    binary_focal_loss, focal_loss
 
 include("utils.jl")
 include("functions.jl")

--- a/src/losses/Losses.jl
+++ b/src/losses/Losses.jl
@@ -19,7 +19,8 @@ export mse, mae, msle,
     poisson_loss,
     hinge_loss, squared_hinge_loss,
     ctc_loss,
-    focal_loss
+    binary_focal_loss,
+    categorical_focal_loss
 
 include("utils.jl")
 include("functions.jl")

--- a/src/losses/Losses.jl
+++ b/src/losses/Losses.jl
@@ -18,7 +18,8 @@ export mse, mae, msle,
     dice_coeff_loss,
     poisson_loss,
     hinge_loss, squared_hinge_loss,
-    ctc_loss
+    ctc_loss,
+    focal_loss
 
 include("utils.jl")
 include("functions.jl")

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -430,16 +430,17 @@ function tversky_loss(ŷ, y; β = ofeltype(ŷ, 0.7))
 end
 
 """
-    binary_focal_loss(ŷ, y; dims=1, agg=mean, γ=2.0, ϵ=epseltype(ŷ))
+    binary_focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
 
 Return the [binary_focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
-Can be used in classification tasks in the presence of highly imbalanced classes. 
+which can be used in classification tasks with highly imbalanced classes.
 It down-weights well-classified examples and focuses on hard examples.
+The input, 'ŷ', is expected to be unnormalized.
 
-γ(default=2.0) is a number called modulating factor. 
-For γ=0, the loss is mathematically equivalent to binarycrossentropy(ŷ, y)
+The modulating factor, `γ`, controls the down-weighting strength.
+For `γ == 0`, the loss is mathematically equivalent to [`Losses.binarycrossentropy`](@ref).
 
-See also: ['focal_loss'](@ref)
+See also: [`Losses.focal_loss`](@ref) for multi-class setting
 
 """
 function binary_focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
@@ -452,12 +453,17 @@ function binary_focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=e
 end
 
 """
-    focal_loss(ŷ, y; dims=1, agg=mean, γ=2.0, ϵ=epseltype(ŷ))
+    focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
 
 Return the [focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
-For γ=0, the loss is mathematically equivalent to crossentropy(ŷ, y)
+which can be used in classification tasks with highly imbalanced classes.
+It down-weights well-classified examples and focuses on hard examples.
+The input, `ŷ`, is expected to be unnormalized.
 
-See also: [`binary_focal_loss`](@ref)
+The modulating factor, `γ`, controls the down-weighting strength.
+For `γ == 0`, the loss is mathematically equivalent to [`Losses.crossentropy`](@ref).
+
+See also: [`Losses.binary_focal_loss`](@ref) for binary (not one-hot) labels
 
 """
 function focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -430,7 +430,7 @@ function tversky_loss(ŷ, y; β = ofeltype(ŷ, 0.7))
 end
 
 """
-    binary_focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
+    binary_focal_loss(ŷ, y; agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
 
 Return the [binary_focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
 which can be used in classification tasks with highly imbalanced classes.

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -430,20 +430,17 @@ function tversky_loss(ŷ, y; β = ofeltype(ŷ, 0.7))
 end
 
 """
-    binary_focal_loss(ŷ, y; agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
+    binary_focal_loss(ŷ, y; agg=mean, γ=2, ϵ=epseltype(ŷ))
 
 Return the [binary_focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
-which can be used in classification tasks with highly imbalanced classes.
-It down-weights well-classified examples and focuses on hard examples.
 The input, 'ŷ', is expected to be normalized (i.e. [`softmax`](@ref) output).
 
-The modulating factor, `γ`, controls the down-weighting strength.
 For `γ == 0`, the loss is mathematically equivalent to [`Losses.binarycrossentropy`](@ref).
 
 See also: [`Losses.focal_loss`](@ref) for multi-class setting
 
 """
-function binary_focal_loss(ŷ, y; agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
+function binary_focal_loss(ŷ, y; agg=mean, γ=2, ϵ=epseltype(ŷ))
     ŷ = ŷ .+ ϵ
     p_t = y .* ŷ  + (1 .- y) .* (1 .- ŷ)
     ce = -log.(p_t)
@@ -453,7 +450,7 @@ function binary_focal_loss(ŷ, y; agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype
 end
 
 """
-    focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
+    focal_loss(ŷ, y; dims=1, agg=mean, γ=2, ϵ=epseltype(ŷ))
 
 Return the [focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
 which can be used in classification tasks with highly imbalanced classes.
@@ -466,7 +463,7 @@ For `γ == 0`, the loss is mathematically equivalent to [`Losses.crossentropy`](
 See also: [`Losses.binary_focal_loss`](@ref) for binary (not one-hot) labels
 
 """
-function focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
+function focal_loss(ŷ, y; dims=1, agg=mean, γ=2, ϵ=epseltype(ŷ))
     ŷ = ŷ .+ ϵ
     agg(sum(@. -y * (1 - ŷ)^γ * log(ŷ); dims=dims))
 end

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -458,7 +458,7 @@ true
 See also: [`Losses.focal_loss`](@ref) for multi-class setting
 
 """
-function binary_focal_loss(ŷ, y; agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
+function binary_focal_loss(ŷ, y; agg=mean, γ=2, ϵ=epseltype(ŷ))
     ŷ = ŷ .+ ϵ
     p_t = y .* ŷ  + (1 .- y) .* (1 .- ŷ)
     ce = -log.(p_t)
@@ -501,11 +501,10 @@ true
 See also: [`Losses.binary_focal_loss`](@ref) for binary (not one-hot) labels
 
 """
-function focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
+function focal_loss(ŷ, y; dims=1, agg=mean, γ=2, ϵ=epseltype(ŷ))
     ŷ = ŷ .+ ϵ
     agg(sum(@. -y * (1 - ŷ)^γ * log(ŷ); dims=dims))
 end
 ```@meta
 DocTestFilters = nothing
 ```
-

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -458,7 +458,7 @@ true
 See also: [`Losses.focal_loss`](@ref) for multi-class setting
 
 """
-function binary_focal_loss(ŷ, y; agg=mean, γ=2, ϵ=epseltype(ŷ))
+function binary_focal_loss(ŷ, y; agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
     ŷ = ŷ .+ ϵ
     p_t = y .* ŷ  + (1 .- y) .* (1 .- ŷ)
     ce = -log.(p_t)
@@ -501,7 +501,7 @@ true
 See also: [`Losses.binary_focal_loss`](@ref) for binary (not one-hot) labels
 
 """
-function focal_loss(ŷ, y; dims=1, agg=mean, γ=2, ϵ=epseltype(ŷ))
+function focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
     ŷ = ŷ .+ ϵ
     agg(sum(@. -y * (1 - ŷ)^γ * log(ŷ); dims=dims))
 end

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -430,23 +430,34 @@ function tversky_loss(ŷ, y; β = ofeltype(ŷ, 0.7))
 end
 
 """
-    focal_loss(yhat, y; dims=1, agg=mean, gamma=2.0, eps = eps(eltype(yhat))
+    binary_focal_loss(ŷ, y; dims=1, agg=mean, γ=2.0, eps = epseltype(ŷ))
 
-         𝛄: modulating factor.
+    γ: modulating factor.
 
-Return the [focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
-Extremely useful for classification when you have highly imbalanced classes. It down-weights
-well-classified examples and focuses on hard examples. Loss is much high for misclassified points as compared to well-classified points. Used in single-shot detectors.
 """
-function focal_loss(ŷ, y; dims=1, agg=mean, 𝛄=2.0, eps = eps(eltype(ŷ)))
+function binary_focal_loss(ŷ, y; dims=1, agg=mean, γ=2.0, eps = epseltype(ŷ))
     ŷ = ŷ .+ eps
-    p_t = [y==1 ? ŷ : 1-ŷ for (ŷ, y) in zip(ŷ, y)]
+    p_t = y .*ŷ  + (1 .- y) .* (1 .- ŷ)
     ce = -log.(p_t)
-    weight = (1 .- p_t) .^ 𝛄
+    weight = (1 .- p_t) .^ γ
     loss = weight .* ce
     agg(sum(loss, dims=dims))
 end
 
+"""
+    categorical_focal_loss(ŷ, y; dims=1, agg=mean, γ=2.0, eps = epseltype(ŷ))
+    Softmax version of Focal Loss
+    γ: modulating factor.
+
+"""
+function categorical_focal_loss(ŷ, y; dims=1, agg=mean, γ=2.0, eps = epseltype(ŷ))
+    ŷ = softmax(ŷ; dims=dims)
+    ŷ = ŷ .+ eps
+    ce = -y .* log.(ŷ)
+    weight = (1 .- ŷ) .^ γ
+    loss = weight .* ce
+    agg(sum(loss, dims=dims))
+end
 ```@meta
 DocTestFilters = nothing
 ```

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -430,12 +430,30 @@ function tversky_loss(ŷ, y; β = ofeltype(ŷ, 0.7))
 end
 
 """
-    binary_focal_loss(ŷ, y; agg=mean, γ=2, ϵ=epseltype(ŷ))
+    binary_focal_loss(ŷ, y; agg=mean, γ=2, ϵ=eps(ŷ))
 
 Return the [binary_focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
 The input, 'ŷ', is expected to be normalized (i.e. [`softmax`](@ref) output).
 
 For `γ == 0`, the loss is mathematically equivalent to [`Losses.binarycrossentropy`](@ref).
+
+# Example
+```jldoctest
+julia> y = [0  1  0
+            1  0  1]
+2×3 Array{Int64,2}:
+ 0  1  0
+ 1  0  1
+
+julia> ŷ = [0.268941  0.5  0.268941
+            0.731059  0.5  0.731059]
+2×3 Array{Float64,2}:
+ 0.268941  0.5  0.268941
+ 0.731059  0.5  0.731059
+
+julia> Flux.binary_focal_loss(ŷ, y) ≈ 0.0728675615927385
+true
+```
 
 See also: [`Losses.focal_loss`](@ref) for multi-class setting
 
@@ -450,7 +468,7 @@ function binary_focal_loss(ŷ, y; agg=mean, γ=2, ϵ=epseltype(ŷ))
 end
 
 """
-    focal_loss(ŷ, y; dims=1, agg=mean, γ=2, ϵ=epseltype(ŷ))
+    focal_loss(ŷ, y; dims=1, agg=mean, γ=2, ϵ=eps(ŷ))
 
 Return the [focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
 which can be used in classification tasks with highly imbalanced classes.
@@ -459,6 +477,26 @@ The input, 'ŷ', is expected to be normalized (i.e. [`softmax`](@ref) output).
 
 The modulating factor, `γ`, controls the down-weighting strength.
 For `γ == 0`, the loss is mathematically equivalent to [`Losses.crossentropy`](@ref).
+
+# Example
+```jldoctest
+julia> y = [1  0  0  0  1
+            0  1  0  1  0
+            0  0  1  0  0]
+3×5 Array{Int64,2}:
+ 1  0  0  0  1
+ 0  1  0  1  0
+ 0  0  1  0  0
+
+julia> ŷ = softmax(reshape(-7:7, 3, 5) .* 1f0)
+3×5 Array{Float32,2}:
+ 0.0900306  0.0900306  0.0900306  0.0900306  0.0900306
+ 0.244728   0.244728   0.244728   0.244728   0.244728
+ 0.665241   0.665241   0.665241   0.665241   0.665241
+
+julia> Flux.focal_loss(ŷ, y) ≈ 1.1277571935622628
+true
+```
 
 See also: [`Losses.binary_focal_loss`](@ref) for binary (not one-hot) labels
 
@@ -470,3 +508,4 @@ end
 ```@meta
 DocTestFilters = nothing
 ```
+

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -429,6 +429,23 @@ function tversky_loss(ŷ, y; β = ofeltype(ŷ, 0.7))
     1 - num / den
 end
 
+"""
+    focal_loss(yhat, y; dims=1, agg=mean, gamma=2.0, eps = eps(eltype(yhat))
+
+         𝛄: modulating factor.
+
+Return the [focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
+Extremely useful for classification when you have highly imbalanced classes. It down-weights
+well-classified examples and focuses on hard examples. Loss is much high for misclassified points as compared to well-classified points. Used in single-shot detectors.
+"""
+function focal_loss(ŷ, y; dims=1, agg=mean, 𝛄=2.0, eps = eps(eltype(ŷ)))
+    ŷ = ŷ .+ eps
+    p_t = [y==1 ? ŷ : 1-ŷ for (ŷ, y) in zip(ŷ, y)]
+    ce = -log.(p_t)
+    weight = (1 .- p_t) .^ 𝛄
+    loss = weight .* ce
+    agg(sum(loss, dims=dims))
+end
 
 ```@meta
 DocTestFilters = nothing

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -435,7 +435,7 @@ end
 Return the [binary_focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
 which can be used in classification tasks with highly imbalanced classes.
 It down-weights well-classified examples and focuses on hard examples.
-The input, 'ŷ', is expected to be unnormalized.
+The input, 'ŷ', is expected to be normalized (i.e. [`softmax`](@ref) output).
 
 The modulating factor, `γ`, controls the down-weighting strength.
 For `γ == 0`, the loss is mathematically equivalent to [`Losses.binarycrossentropy`](@ref).
@@ -443,7 +443,7 @@ For `γ == 0`, the loss is mathematically equivalent to [`Losses.binarycrossentr
 See also: [`Losses.focal_loss`](@ref) for multi-class setting
 
 """
-function binary_focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
+function binary_focal_loss(ŷ, y; agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
     ŷ = ŷ .+ ϵ
     p_t = y .* ŷ  + (1 .- y) .* (1 .- ŷ)
     ce = -log.(p_t)
@@ -458,7 +458,7 @@ end
 Return the [focal_loss](https://arxiv.org/pdf/1708.02002.pdf)
 which can be used in classification tasks with highly imbalanced classes.
 It down-weights well-classified examples and focuses on hard examples.
-The input, `ŷ`, is expected to be unnormalized.
+The input, 'ŷ', is expected to be normalized (i.e. [`softmax`](@ref) output).
 
 The modulating factor, `γ`, controls the down-weighting strength.
 For `γ == 0`, the loss is mathematically equivalent to [`Losses.crossentropy`](@ref).
@@ -468,7 +468,7 @@ See also: [`Losses.binary_focal_loss`](@ref) for binary (not one-hot) labels
 """
 function focal_loss(ŷ, y; dims=1, agg=mean, γ=ofeltype(ŷ, 2.0), ϵ=epseltype(ŷ))
     ŷ = ŷ .+ ϵ
-    agg(sum(@. -y * (1 - ŷ)^γ * log(ŷ); dims=1))
+    agg(sum(@. -y * (1 - ŷ)^γ * log(ŷ); dims=dims))
 end
 ```@meta
 DocTestFilters = nothing

--- a/test/cuda/losses.jl
+++ b/test/cuda/losses.jl
@@ -1,4 +1,4 @@
-using Flux.Losses: crossentropy, binarycrossentropy, logitbinarycrossentropy
+using Flux.Losses: crossentropy, binarycrossentropy, logitbinarycrossentropy, binary_focal_loss, focal_loss
 
 
 @testset "Losses" begin
@@ -14,6 +14,17 @@ y = [1, 1, 0.]
 @test binarycrossentropy(σ.(x), y) ≈ binarycrossentropy(gpu(σ.(x)), gpu(y))
 @test logitbinarycrossentropy(x, y) ≈ logitbinarycrossentropy(gpu(x), gpu(y))
 
+x = [0.268941  0.5  0.268941
+     0.731059  0.5  0.731059]
+y = [0  1  0
+     1  0  1]
+@test binary_focal_loss(x, y) ≈ binary_focal_loss(gpu(x), gpu(y))
+
+x = softmax(reshape(-7:7, 3, 5) .* 1f0)
+y = [1  0  0  0  1
+     0  1  0  1  0
+     0  0  1  0  0]
+@test focal_loss(x, y) ≈ focal_loss(gpu(x), gpu(y))
 
 @testset "GPU grad tests" begin
   x = rand(Float32, 3,3)

--- a/test/losses.jl
+++ b/test/losses.jl
@@ -174,3 +174,16 @@ end
     end
   end
 end
+
+y = [0 1 1]
+ŷ = [0.1 0.7 0.9]
+y1 = [1 0
+      0 0
+      0 1]
+ŷ1 = [0.6 0.3
+      0.3 0.1
+      0.1 0.6]
+@testset "focal_loss" begin
+    @test Flux.focal_loss(ŷ, y) ≈ 0.011402651755880793
+    @test Flux.focal_loss(ŷ1, y1) ≈ 0.11488644991362265
+end

--- a/test/losses.jl
+++ b/test/losses.jl
@@ -205,5 +205,3 @@ end
     @test Flux.categorical_focal_loss(ŷ, y) ≈ 1.0668209889165343
     @test Flux.categorical_focal_loss(ŷ1, y1) ≈ 0.011366240888043638
 end
-
-

--- a/test/losses.jl
+++ b/test/losses.jl
@@ -176,32 +176,35 @@ end
 end
 
 @testset "binary_focal_loss" begin
-    y = [0 1 1]
-    ŷ = [0.1 0.7 0.9]
+    y = [0  1  0
+         1  0  1]
+    yhat = [0.268941  0.5  0.268941
+            0.731059  0.5  0.731059]
+
     y1 = [1 0
-          0 0
           0 1]
     ŷ1 = [0.6 0.3
-          0.3 0.1
-          0.1 0.6]
-    @test Flux.binary_focal_loss(ŷ, y) ≈ 0.011402651755880793
-    @test Flux.binary_focal_loss(ŷ1, y1) ≈ 0.11488644991362265
+          0.4 0.7]
+    @test Flux.binary_focal_loss(ŷ, y) ≈ 0.0728675615927385
+    @test Flux.binary_focal_loss(ŷ1, y1) ≈ 0.05691642237852222
+    @test Flux.binary_focal_loss(ŷ, y; γ=0.0) == Flux.binarycrossentropy(ŷ, y)
 end
 
-@testset "categorical_focal_loss" begin
-    y = [1  0  0  1  0  1  1
-         0  1  0  0  1  0  0
-         0  0  1  0  0  0  0]
+@testset "focal_loss" begin
+    y = [1  0  0  0  1
+         0  1  0  1  0
+         0  0  1  0  0]
 
-    ŷ = [-9.0  -6.0  -3.0  0.0  2.0  5.0  8.0
-         -8.0  -5.0  -2.0  0.0  3.0  6.0  9.0
-         -7.0  -4.0  -1.0  1.0  4.0  7.0  7.5]
+    ŷ = [0.0900306  0.0900306  0.0900306  0.0900306  0.0900306
+        0.244728   0.244728   0.244728   0.244728   0.244728
+        0.665241   0.665241   0.665241   0.665241   0.665241]
     y1 = [1 0
           0 0
           0 1]
     ŷ1 = [5.0 1.0
           2.3 2.0
           3.8 9.0]
-    @test Flux.categorical_focal_loss(ŷ, y) ≈ 1.0668209889165343
-    @test Flux.categorical_focal_loss(ŷ1, y1) ≈ 0.011366240888043638
+    @test Flux.focal_loss(ŷ, y) ≈ 1.1277571935622628
+    @test Flux.focal_loss(ŷ1, y1) ≈ 0.011366240888043638
+    @test Flux.focal_loss(ŷ, y; γ=0.0) == Flux.crossentropy(ŷ, y)
 end

--- a/test/losses.jl
+++ b/test/losses.jl
@@ -13,7 +13,8 @@ const ALL_LOSSES = [Flux.Losses.mse, Flux.Losses.mae, Flux.Losses.msle,
                     Flux.Losses.tversky_loss,
                     Flux.Losses.dice_coeff_loss,
                     Flux.Losses.poisson_loss,
-                    Flux.Losses.hinge_loss, Flux.Losses.squared_hinge_loss]
+                    Flux.Losses.hinge_loss, Flux.Losses.squared_hinge_loss,
+                    Flux.Losses.binary_focal_loss, Flux.Losses.focal_loss]
 
 
 @testset "xlogx & xlogy" begin
@@ -179,7 +180,7 @@ end
     y = [0  1  0
          1  0  1]
     ŷ = [0.268941  0.5  0.268941
-            0.731059  0.5  0.731059]
+         0.731059  0.5  0.731059]
 
     y1 = [1 0
           0 1]
@@ -194,10 +195,7 @@ end
     y = [1  0  0  0  1
          0  1  0  1  0
          0  0  1  0  0]
-
-    ŷ = [0.0900306  0.0900306  0.0900306  0.0900306  0.0900306
-        0.244728   0.244728   0.244728   0.244728   0.244728
-        0.665241   0.665241   0.665241   0.665241   0.665241]
+    ŷ = softmax(reshape(-7:7, 3, 5) .* 1f0)
     y1 = [1 0
           0 0
           0 1]

--- a/test/losses.jl
+++ b/test/losses.jl
@@ -187,7 +187,7 @@ end
           0.4 0.7]
     @test Flux.binary_focal_loss(ŷ, y) ≈ 0.0728675615927385
     @test Flux.binary_focal_loss(ŷ1, y1) ≈ 0.05691642237852222
-    @test Flux.binary_focal_loss(ŷ, y; γ=0.0) == Flux.binarycrossentropy(ŷ, y)
+    @test Flux.binary_focal_loss(ŷ, y; γ=0.0) ≈ Flux.binarycrossentropy(ŷ, y)
 end
 
 @testset "focal_loss" begin
@@ -206,5 +206,5 @@ end
           0.1 0.3]
     @test Flux.focal_loss(ŷ, y) ≈ 1.1277571935622628
     @test Flux.focal_loss(ŷ1, y1) ≈ 0.45990566879720157
-    @test Flux.focal_loss(ŷ, y; γ=0.0) == Flux.crossentropy(ŷ, y)
+    @test Flux.focal_loss(ŷ, y; γ=0.0) ≈ Flux.crossentropy(ŷ, y)
 end

--- a/test/losses.jl
+++ b/test/losses.jl
@@ -178,7 +178,7 @@ end
 @testset "binary_focal_loss" begin
     y = [0  1  0
          1  0  1]
-    yhat = [0.268941  0.5  0.268941
+    ŷ = [0.268941  0.5  0.268941
             0.731059  0.5  0.731059]
 
     y1 = [1 0
@@ -201,10 +201,10 @@ end
     y1 = [1 0
           0 0
           0 1]
-    ŷ1 = [5.0 1.0
-          2.3 2.0
-          3.8 9.0]
+    ŷ1 = [0.4 0.2
+          0.5 0.5
+          0.1 0.3]
     @test Flux.focal_loss(ŷ, y) ≈ 1.1277571935622628
-    @test Flux.focal_loss(ŷ1, y1) ≈ 0.011366240888043638
+    @test Flux.focal_loss(ŷ1, y1) ≈ 0.45990566879720157
     @test Flux.focal_loss(ŷ, y; γ=0.0) == Flux.crossentropy(ŷ, y)
 end

--- a/test/losses.jl
+++ b/test/losses.jl
@@ -175,15 +175,35 @@ end
   end
 end
 
-y = [0 1 1]
-ŷ = [0.1 0.7 0.9]
-y1 = [1 0
-      0 0
-      0 1]
-ŷ1 = [0.6 0.3
-      0.3 0.1
-      0.1 0.6]
-@testset "focal_loss" begin
-    @test Flux.focal_loss(ŷ, y) ≈ 0.011402651755880793
-    @test Flux.focal_loss(ŷ1, y1) ≈ 0.11488644991362265
+@testset "binary_focal_loss" begin
+    y = [0 1 1]
+    ŷ = [0.1 0.7 0.9]
+    y1 = [1 0
+          0 0
+          0 1]
+    ŷ1 = [0.6 0.3
+          0.3 0.1
+          0.1 0.6]
+    @test Flux.binary_focal_loss(ŷ, y) ≈ 0.011402651755880793
+    @test Flux.binary_focal_loss(ŷ1, y1) ≈ 0.11488644991362265
 end
+
+@testset "categorical_focal_loss" begin
+    y = [1  0  0  1  0  1  1
+         0  1  0  0  1  0  0
+         0  0  1  0  0  0  0]
+
+    ŷ = [-9.0  -6.0  -3.0  0.0  2.0  5.0  8.0
+         -8.0  -5.0  -2.0  0.0  3.0  6.0  9.0
+         -7.0  -4.0  -1.0  1.0  4.0  7.0  7.5]
+    y1 = [1 0
+          0 0
+          0 1]
+    ŷ1 = [5.0 1.0
+          2.3 2.0
+          3.8 9.0]
+    @test Flux.categorical_focal_loss(ŷ, y) ≈ 1.0668209889165343
+    @test Flux.categorical_focal_loss(ŷ1, y1) ≈ 0.011366240888043638
+end
+
+


### PR DESCRIPTION
Focal loss was introduced in the RetinaNet paper (https://arxiv.org/pdf/1708.02002.pdf). 

Focal loss is useful for classification when you we highly imbalanced classes. It down-weights well-classified examples and focuses on hard examples. The loss value is much high for a sample which is misclassified by the classifier as compared to the loss value corresponding to a well-classified example. 

Used in single-shot object detection where the imbalance between the background class and other classes is extremely high.

Here's it's tensorflow implementation (https://github.com/tensorflow/addons/blob/v0.12.0/tensorflow_addons/losses/focal_loss.py#L26-L81)
### PR Checklist

- [x] Tests are added
- [x] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
