### PR TITLE
Make Dropout docstring clear w.r.t. N-D dropout

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -51,8 +51,8 @@ end
 
 Dropout layer. In the forward pass, apply the [`Flux.dropout`](@ref) function on the input.
 
-For N-D dropout layers (e.g. `Dropout2d` or `Dropout3d` in PyTorch),
-specify the `dims` keyword (i.e. `Dropout(p; dims = 3)` is a 2D dropout layer).
+To apply dropout along an certain dimension (e.g. zeroing out an entire channel's feature map),
+specify the `dims` keyword (i.e. `Dropout(p; dims = 3)` is a 2D dropout layer on WHCN input).
 
 Does nothing to the input once [`Flux.testmode!`](@ref) is `true`.
 """

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -51,6 +51,9 @@ end
 
 Dropout layer. In the forward pass, apply the [`Flux.dropout`](@ref) function on the input.
 
+For N-D dropout layers (e.g. `Dropout2d` or `Dropout3d` in PyTorch),
+specify the `dims` keyword (i.e. `Dropout(p; dims = 2)` is a 2D dropout layer).
+
 Does nothing to the input once [`Flux.testmode!`](@ref) is `true`.
 """
 mutable struct Dropout{F,D}

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -51,8 +51,9 @@ end
 
 Dropout layer. In the forward pass, apply the [`Flux.dropout`](@ref) function on the input.
 
-To apply dropout along an certain dimension (e.g. zeroing out an entire channel's feature map),
-specify the `dims` keyword (i.e. `Dropout(p; dims = 3)` is a 2D dropout layer on WHCN input).
+To apply dropout along certain dimension(s), specify the `dims` keyword.
+e.g. `Dropout(p; dims = 3)` will randomly zero out entire channels on WHCN input
+(also called 2D dropout).
 
 Does nothing to the input once [`Flux.testmode!`](@ref) is `true`.
 """

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -52,7 +52,7 @@ end
 Dropout layer. In the forward pass, apply the [`Flux.dropout`](@ref) function on the input.
 
 For N-D dropout layers (e.g. `Dropout2d` or `Dropout3d` in PyTorch),
-specify the `dims` keyword (i.e. `Dropout(p; dims = 2)` is a 2D dropout layer).
+specify the `dims` keyword (i.e. `Dropout(p; dims = 3)` is a 2D dropout layer).
 
 Does nothing to the input once [`Flux.testmode!`](@ref) is `true`.
 """


### PR DESCRIPTION
Make the docstring specify N-dimensional dropouts more clearly (i.e. so that people don't think we don't have `Dropout3d` etc.).

### PR Checklist

- [x] ~~Tests are added~~
- [x] ~~Entry in NEWS.md~~
- [x] Documentation, if applicable
- [x] ~~Final review from `@dhairyagandhi96` (for API changes).~~
