### PR TITLE
Add RNG state to shuffling data in DataLoader

### DIFF
--- a/src/data/dataloader.jl
+++ b/src/data/dataloader.jl
@@ -79,8 +79,8 @@ function DataLoader(data; batchsize = 1, shuffle = x -> Random.shuffle!(Random.G
         batchsize = n
     end
     imax = partial ? n : n - batchsize + 1
-    shuffle = if isa(shuffle, Bool)
-      shuffle ? x -> Random.shuffle!(Random.GLOBAL_RNG, x) : identity
+    if isa(shuffle, Bool)
+      shuffle = shuffle ? x -> Random.shuffle!(Random.GLOBAL_RNG, x) : identity
     end
     DataLoader(data, batchsize, n, partial, imax, [1:n;], shuffle)
 end

--- a/src/data/dataloader.jl
+++ b/src/data/dataloader.jl
@@ -21,6 +21,8 @@ Takes as input a single data tensor, or a tuple (or a named tuple) of tensors.
 The last dimension in each tensor is considered to be the observation dimension.
 
 By default, the dataloader shuffles the observations each time iterations are re-started.
+The data is shuffled using the `GLOBAL_RNG`. To pass a different RNG, pass `shuffle` as
+an anonymous function as shown in the API reference.
 To not shuffle the data, pass `shuffle = identity` or shuffle = false.
 
 If `partial = false`, drops the last mini-batch if it is smaller than the batchsize.

--- a/src/data/dataloader.jl
+++ b/src/data/dataloader.jl
@@ -12,7 +12,7 @@ struct DataLoader{D, S}
 end
 
 """
-    DataLoader(data; batchsize = 1, shuffle = x -> Random.shuffle!(Random.GLOBAL_RNG, x), partial = true)
+    DataLoader(data; batchsize = 1, shuffle = false, partial = true)
 
 An object that iterates over mini-batches of `data`, each mini-batch containing `batchsize` observations
 (except possibly the last one).
@@ -70,7 +70,7 @@ Usage example:
         @assert size(datum.labels) == (2,)
     end
 """
-function DataLoader(data; batchsize = 1, shuffle = x -> Random.shuffle!(Random.GLOBAL_RNG, x), partial = true)
+function DataLoader(data; batchsize = 1, shuffle = false, partial = true)
     batchsize > 0 || throw(ArgumentError("Need positive batchsize"))
 
     n = _nobs(data)

--- a/src/data/dataloader.jl
+++ b/src/data/dataloader.jl
@@ -1,4 +1,5 @@
 # Adapted from Knet's src/data.jl (author: Deniz Yuret)
+using Random
 
 struct DataLoader{D}
     data::D


### PR DESCRIPTION
This is similar in spirit to #1501, and allows users to define the RNG they want to use while shuffling, but helps us to not store the RNG in the struct. Removing the type restriction shouldn't hurt performance in this case either, its a simple function.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
