### PR TITLE
Update for latest ParameterSchedulers.jl release

### DIFF
--- a/docs/src/training/optimisers.md
+++ b/docs/src/training/optimisers.md
@@ -144,8 +144,9 @@ In practice, it is fairly common to schedule the learning rate of an optimiser t
 First, we import ParameterSchedulers.jl and initalize a cosine annealing schedule to varying the learning rate between `1e-4` and `1e-2` every 10 steps. We also create a new [`Momentum`](@ref) optimiser.
 ```julia
 using ParameterSchedulers
+using ParameterSchedulers: Stateful, next!
 
-schedule = ScheduleIterator(Cos(λ0 = 1e-4, λ1 = 1e-2, period = 10))
+schedule = Stateful(Cos(λ0 = 1e-4, λ1 = 1e-2, period = 10))
 opt = Momentum()
 ```
 
@@ -157,8 +158,9 @@ for epoch in 1:100
 end
 ```
 
-`schedule` can also be indexed (e.g. `schedule[100]`) or iterated like any iterator in Julia:
+`schedule` can also be indexed (e.g. `schedule(100)`) or iterated like any iterator in Julia:
 ```julia
+schedule = Cos(λ0 = 1e-4, λ1 = 1e-2, period = 10)
 for (eta, epoch) in zip(schedule, 1:100)
   opt.eta = eta
   # your training code here

--- a/docs/src/training/optimisers.md
+++ b/docs/src/training/optimisers.md
@@ -144,25 +144,23 @@ In practice, it is fairly common to schedule the learning rate of an optimiser t
 First, we import ParameterSchedulers.jl and initalize a cosine annealing schedule to varying the learning rate between `1e-4` and `1e-2` every 10 steps. We also create a new [`Momentum`](@ref) optimiser.
 ```julia
 using ParameterSchedulers
-using ParameterSchedulers: Stateful, next!
 
-schedule = Stateful(Cos(λ0 = 1e-4, λ1 = 1e-2, period = 10))
 opt = Momentum()
-```
-
-Next, you can use your schedule directly in a `for`-loop:
-```julia
-for epoch in 1:100
-  opt.eta = next!(schedule)
-  # your training code here
-end
-```
-
-`schedule` can also be indexed (e.g. `schedule(100)`) or iterated like any iterator in Julia:
-```julia
 schedule = Cos(λ0 = 1e-4, λ1 = 1e-2, period = 10)
 for (eta, epoch) in zip(schedule, 1:100)
   opt.eta = eta
+  # your training code here
+end
+```
+`schedule` can also be indexed (e.g. `schedule(100)`) or iterated like any iterator in Julia.
+
+ParameterSchedulers.jl schedules are stateless (they don't store their iteration state). If you want a _stateful_ schedule, you can use `ParameterSchedulers.Stateful`:
+```julia
+using ParameterSchedulers: Stateful, next!
+
+schedule = Stateful(Cos(λ0 = 1e-4, λ1 = 1e-2, period = 10))
+for epoch in 1:100
+  opt.eta = next!(schedule)
   # your training code here
 end
 ```


### PR DESCRIPTION
Due to some finagling with #1506 and work on Optimisers.jl, I made some changes to the names/API of ParameterSchedulers.jl. This just updates the docs to reflect those names.

### PR Checklist

- [ ] ~~Tests are added~~
- [ ] ~~Entry in NEWS.md~~
- [x] Documentation, if applicable
- [ ] ~~Final review from `@dhairyagandhi96` (for API changes).~~
