### PR TITLE
Add identity_init

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## v0.12.0
 
+* Add [identity_init](https://github.com/FluxML/Flux.jl/pull/1524).
 * Add [Orthogonal Matrix initialization](https://github.com/FluxML/Flux.jl/pull/1496) as described in [Exact solutions to the nonlinear dynamics of learning in deep linear neural networks](https://arxiv.org/abs/1312.6120).
 * Added [Focal Loss function](https://github.com/FluxML/Flux.jl/pull/1489) to Losses module
 * The Dense layer now supports inputs with [multiple batch dimensions](https://github.com/FluxML/Flux.jl/pull/1405).

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -297,7 +297,7 @@ Some caveats: Not all layers will be identity mapping when used with this init. 
 include recurrent layers, `DepthwiseConv` and normalization layers.
 
 Also note that layers must have `input_size == output_size` for identity mapping to be 
-possible.
+possible. When this is not the case, the "identity array" is padded with zeros.
 
 For convolutional layers, in addition to the above, the kernel sizes must also be odd and 
 padding must be applied so that output feature maps have the same size as input feature maps,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -294,6 +294,7 @@ Often useful in the context of transfer learning, i.e when one wants to add more
 a model but start from the same mapping.
 
 Use `shift` (integer or tuple) to apply circular shift to the output.
+Equivalent to `Base.circshift(identity(dims...), shift)`.
 
 Some caveats: Not all layers will be identity mapping when used with this init. Exceptions
 include recurrent layers, `DepthwiseConv` and normalization layers.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -351,7 +351,7 @@ identity_init(cols;gain=1) = zeros(cols)
 identity_init(rows, cols; gain=1) = Matrix{Float32}(I * gain, rows,cols)
 
 # Assume convolution
-function identity_init(dims...;gain=1)
+function identity_init(dims...; gain=1)
   nin, nout = dims[end-1], dims[end]
   centers = map(d -> cld(d, 2), dims[1:end-2])
   weights = zeros(dims)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -356,7 +356,7 @@ function identity_init(dims...; gain=1)
   centers = map(d -> cld(d, 2), dims[1:end-2])
   weights = zeros(dims)
   for i in 1:min(nin,nout)
-      weights[centers..., i, i] = gain
+    weights[centers..., i, i] = gain
   end
   return weights
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -285,7 +285,7 @@ sparse_init(dims...; kwargs...) = sparse_init(Random.GLOBAL_RNG, dims...; kwargs
 sparse_init(rng::AbstractRNG; init_kwargs...) = (dims...; kwargs...) -> sparse_init(rng, dims...; init_kwargs..., kwargs...)
 
 """
-    identity_init([rng=GLOBAL_RNG], dims...;gain=1)
+    identity_init([rng=GLOBAL_RNG], dims...; gain=1)
 
 Return an `Array` of size `dims` which yields an identity mapping when used as parameters in 
 most Flux layers.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -345,21 +345,21 @@ identity_init(::AbstractRNG, dims...) = identity_init(dims...)
 identity_init(cols) = zeros(cols)
 # Assume matrix multiplication
 function identity_init(rows, cols)
-  rows == cols || @warn "Identity mapping not possible with rows != cols! Got rows=$rows, rows=$cols."
-  return identity_init_nowarn(rows,cols)
+  rows == cols || throw(ArgumentError("Identity mapping not possible with rows != cols! Got rows=$rows, rows=$cols. Use identity_init_nocheck to bypass this check."))
+  return identity_init_nocheck(rows,cols)
 end
-identity_init_nowarn(rows, cols) = Matrix{Float32}(I, rows,cols)
+identity_init_nocheck(rows, cols) = Matrix{Float32}(I, rows,cols)
 # Assume convolution
 function identity_init(dims...)
   nin, nout = dims[end-1], dims[end]
-  nin == nout || @warn "Identity mapping not possible with nin != nout! Got nin=$nin, nout=$nout."
-  all(isodd, dims[1:end-2]) || @warn "Identity mapping requires odd kernel sizes! Got $(dims[1:end-2])."
-  return identity_init_nowarn(dims...)
+  nin == nout || throw(ArgumentError("Identity mapping not possible with nin != nout! Got nin=$nin, nout=$nout. Use identity_init_nocheck to bypass this check."))
+  all(isodd, dims[1:end-2]) || throw(ArgumentError("Identity mapping requires odd kernel sizes! Got $(dims[1:end-2]). Use identity_init_nocheck to bypass this check."))
+  return identity_init_nocheck(dims...)
 end
 
 # This can still be useful if one e.g is creating an inception-like block which as a whole shall be an identity mapping
 # Requires a bit of circshifting but it is fully doable
-function identity_init_nowarn(dims...)
+function identity_init_nocheck(dims...)
   nin, nout = dims[end-1], dims[end]
   centers = map(d -> cld(d, 2), dims[1:end-2])
   weights = zeros(dims)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -284,6 +284,92 @@ end
 sparse_init(dims...; kwargs...) = sparse_init(Random.GLOBAL_RNG, dims...; kwargs...)
 sparse_init(rng::AbstractRNG; init_kwargs...) = (dims...; kwargs...) -> sparse_init(rng, dims...; init_kwargs..., kwargs...)
 
+"""
+    init_identity([rng=GLOBAL_RNG], dims...)
+
+Return an `Array` of size `dims` which yields an identity mapping when used as parameters in most Flux layers.
+
+Often useful in the context of transfer learning, i.e when one wants to add more capacity to a model but start from the same mapping.
+
+Has the following behaviour
+*  1D: A `Vector` of `zeros` (assumes bias)
+*  2D: An identity matrix (assumes matrix multiplication)
+* >2D: A diagnoal matrix of identity kernels (assumes convolution) 
+
+```jldoctest;
+julia> Flux.init_identity(3,3)
+3×3 Matrix{Float32}:
+ 1.0  0.0  0.0
+ 0.0  1.0  0.0
+ 0.0  0.0  1.0
+
+ julia> Flux.init_identity(3,1,1)
+ 3×1×1 Array{Float32, 3}:
+ [:, :, 1] =
+  0.0
+  1.0
+  0.0
+
+  julia> Flux.init_identity(1,3,3,3)
+  1×3×3×3 Array{Float32, 4}:
+  [:, :, 1, 1] =
+   0.0  1.0  0.0
+  
+  [:, :, 2, 1] =
+   0.0  0.0  0.0
+  
+  [:, :, 3, 1] =
+   0.0  0.0  0.0
+  
+  [:, :, 1, 2] =
+   0.0  0.0  0.0
+  
+  [:, :, 2, 2] =
+   0.0  1.0  0.0
+  
+  [:, :, 3, 2] =
+   0.0  0.0  0.0
+  
+  [:, :, 1, 3] =
+   0.0  0.0  0.0
+  
+  [:, :, 2, 3] =
+   0.0  0.0  0.0
+  
+  [:, :, 3, 3] =
+   0.0  1.0  0.0
+```
+"""
+init_identity(::AbstractRNG, dims...) = init_identity(dims...)
+# Assume bias
+init_identity(cols) = zeros(cols)
+# Assume matrix multiplication
+function init_identity(rows, cols)
+  rows == cols || @warn "Identity mapping not possible with rows != cols! Got rows=$rows, rows=$cols."
+  return init_identity_nowarn(rows,cols)
+end
+init_identity_nowarn(rows, cols) = Matrix{Float32}(I, rows,cols)
+# Assume convolution
+function init_identity(dims...)
+  nin, nout = dims[end-1], dims[end]
+  nin == nout || @warn "Identity mapping not possible with nin != nout! Got nin=$nin, nout=$nout."
+  all(isodd, dims[1:end-2]) || @warn "Identity mapping requires odd kernel sizes! Got $(dims[1:end-2])."
+  return init_identity_nowarn(dims...)
+end
+
+# This can still be useful if one e.g is creating an inception-like block which as a whole shall be an identity mapping
+# Requires a bit of circshifting but it is fully doable
+function init_identity_nowarn(dims...)
+  nin, nout = dims[end-1], dims[end]
+  centers = map(d -> cld(d, 2), dims[1:end-2])
+  weights = zeros(dims)
+  for i in 1:min(nin,nout)
+      weights[centers..., i, i] = 1
+  end
+  return weights
+end
+
+
 ones(T::Type, dims...) = Base.ones(T, dims...)
 zeros(T::Type, dims...) = Base.zeros(T, dims...)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -354,7 +354,7 @@ identity_init(rows, cols; gain=1) = Matrix{Float32}(I * gain, rows,cols)
 function identity_init(dims...; gain=1)
   nin, nout = dims[end-1], dims[end]
   centers = map(d -> cld(d, 2), dims[1:end-2])
-  weights = zeros(dims)
+  weights = zeros(Float32, dims)
   for i in 1:min(nin,nout)
     weights[centers..., i, i] = gain
   end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -288,7 +288,7 @@ sparse_init(rng::AbstractRNG; init_kwargs...) = (dims...; kwargs...) -> sparse_i
     identity_init([rng=GLOBAL_RNG], dims...; gain=1, shift=0)
 
 Return an `Array` of size `dims` which yields an identity mapping when used as parameters in 
-most Flux layers. Use `gain` to get other scalings.  
+most Flux layers. Use `gain` to scale the identity by a constant.
 
 Often useful in the context of transfer learning, i.e when one wants to add more capacity to
 a model but start from the same mapping.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -285,7 +285,7 @@ sparse_init(dims...; kwargs...) = sparse_init(Random.GLOBAL_RNG, dims...; kwargs
 sparse_init(rng::AbstractRNG; init_kwargs...) = (dims...; kwargs...) -> sparse_init(rng, dims...; init_kwargs..., kwargs...)
 
 """
-    init_identity([rng=GLOBAL_RNG], dims...)
+    identity_init([rng=GLOBAL_RNG], dims...)
 
 Return an `Array` of size `dims` which yields an identity mapping when used as parameters in most Flux layers.
 
@@ -297,20 +297,20 @@ Has the following behaviour
 *  More than 2D: A diagnoal matrix of identity kernels (assumes convolution) 
 
 ```jldoctest;
-julia> Flux.init_identity(3,3)
+julia> Flux.identity_init(3,3)
 3×3 Matrix{Float32}:
  1.0  0.0  0.0
  0.0  1.0  0.0
  0.0  0.0  1.0
 
- julia> Flux.init_identity(3,1,1)
+ julia> Flux.identity_init(3,1,1)
  3×1×1 Array{Float32, 3}:
  [:, :, 1] =
   0.0
   1.0
   0.0
 
-  julia> Flux.init_identity(1,3,3,3)
+  julia> Flux.identity_init(1,3,3,3)
   1×3×3×3 Array{Float32, 4}:
   [:, :, 1, 1] =
    0.0  1.0  0.0
@@ -340,26 +340,26 @@ julia> Flux.init_identity(3,3)
    0.0  1.0  0.0
 ```
 """
-init_identity(::AbstractRNG, dims...) = init_identity(dims...)
+identity_init(::AbstractRNG, dims...) = identity_init(dims...)
 # Assume bias
-init_identity(cols) = zeros(cols)
+identity_init(cols) = zeros(cols)
 # Assume matrix multiplication
-function init_identity(rows, cols)
+function identity_init(rows, cols)
   rows == cols || @warn "Identity mapping not possible with rows != cols! Got rows=$rows, rows=$cols."
-  return init_identity_nowarn(rows,cols)
+  return identity_init_nowarn(rows,cols)
 end
-init_identity_nowarn(rows, cols) = Matrix{Float32}(I, rows,cols)
+identity_init_nowarn(rows, cols) = Matrix{Float32}(I, rows,cols)
 # Assume convolution
-function init_identity(dims...)
+function identity_init(dims...)
   nin, nout = dims[end-1], dims[end]
   nin == nout || @warn "Identity mapping not possible with nin != nout! Got nin=$nin, nout=$nout."
   all(isodd, dims[1:end-2]) || @warn "Identity mapping requires odd kernel sizes! Got $(dims[1:end-2])."
-  return init_identity_nowarn(dims...)
+  return identity_init_nowarn(dims...)
 end
 
 # This can still be useful if one e.g is creating an inception-like block which as a whole shall be an identity mapping
 # Requires a bit of circshifting but it is fully doable
-function init_identity_nowarn(dims...)
+function identity_init_nowarn(dims...)
   nin, nout = dims[end-1], dims[end]
   centers = map(d -> cld(d, 2), dims[1:end-2])
   weights = zeros(dims)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -348,7 +348,7 @@ julia> Flux.identity_init(3,3,2,2)
 identity_init(cols;gain=1) = zeros(cols)
 
 # Assume matrix multiplication
-identity_init(rows, cols;gain=1) = Matrix{Float32}(I * gain, rows,cols)
+identity_init(rows, cols; gain=1) = Matrix{Float32}(I * gain, rows,cols)
 
 # Assume convolution
 function identity_init(dims...;gain=1)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -292,9 +292,9 @@ Return an `Array` of size `dims` which yields an identity mapping when used as p
 Often useful in the context of transfer learning, i.e when one wants to add more capacity to a model but start from the same mapping.
 
 Has the following behaviour
-*  1D: A `Vector` of `zeros` (assumes bias)
-*  2D: An identity matrix (assumes matrix multiplication)
-*  More than 2D: A diagnoal matrix of identity kernels (assumes convolution) 
+*  1D: A `Vector` of `zeros` (useful for an identity bias)
+*  2D: An identity matrix (useful for an identity matrix multiplication)
+*  More than 2D: A diagnoal matrix of identity kernels (useful for an identity convolution) 
 
 ```jldoctest
 julia> Flux.identity_init(3,3)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -296,7 +296,7 @@ Has the following behaviour
 *  2D: An identity matrix (assumes matrix multiplication)
 *  More than 2D: A diagnoal matrix of identity kernels (assumes convolution) 
 
-```jldoctest;
+```jldoctest
 julia> Flux.identity_init(3,3)
 3×3 Matrix{Float32}:
  1.0  0.0  0.0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -345,7 +345,7 @@ julia> Flux.identity_init(3,3,2,2)
 ```
 """
 # Assume bias
-identity_init(cols;gain=1) = zeros(cols)
+identity_init(cols; gain=1) = zeros(Float32, cols)
 
 # Assume matrix multiplication
 identity_init(rows, cols; gain=1) = Matrix{Float32}(I * gain, rows,cols)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -298,20 +298,20 @@ Has the following behaviour
 
 ```jldoctest
 julia> Flux.identity_init(3,3)
-3×3 Matrix{Float32}:
+3×3 Array{Float32,2}:
  1.0  0.0  0.0
  0.0  1.0  0.0
  0.0  0.0  1.0
 
  julia> Flux.identity_init(3,1,1)
- 3×1×1 Array{Float32, 3}:
+ 3×1×1 Array{Float32,3}:
  [:, :, 1] =
   0.0
   1.0
   0.0
 
   julia> Flux.identity_init(1,3,3,3)
-  1×3×3×3 Array{Float32, 4}:
+  1×3×3×3 Array{Float32,4}:
   [:, :, 1, 1] =
    0.0  1.0  0.0
   

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -294,7 +294,7 @@ Often useful in the context of transfer learning, i.e when one wants to add more
 Has the following behaviour
 *  1D: A `Vector` of `zeros` (assumes bias)
 *  2D: An identity matrix (assumes matrix multiplication)
-* >2D: A diagnoal matrix of identity kernels (assumes convolution) 
+*  More than 2D: A diagnoal matrix of identity kernels (assumes convolution) 
 
 ```jldoctest;
 julia> Flux.init_identity(3,3)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -301,7 +301,7 @@ possible. When this is not the case, the "identity array" is padded with zeros.
 
 For convolutional layers, in addition to the above, the kernel sizes must also be odd and 
 padding must be applied so that output feature maps have the same size as input feature maps,
-e.g by using `SamePad`.
+e.g by using [`SamePad`](@ref).
 
 Has the following behaviour
 *  1D: A `Vector` of `zeros` (useful for an identity bias)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -361,8 +361,8 @@ function identity_init(dims...; gain=1)
   return weights
 end
 
-identity_init(::AbstractRNG, dims...;kwargs...) = identity_init(dims...;kwargs...)
-identity_init(;init_kwargs...) = identity_init(Random.GLOBAL_RNG; init_kwargs...)
+identity_init(::AbstractRNG, dims...; kwargs...) = identity_init(dims...; kwargs...)
+identity_init(; init_kwargs...) = identity_init(Random.GLOBAL_RNG; init_kwargs...)
 identity_init(rng::AbstractRNG; init_kwargs...) = (args...;kwargs...) -> identity_init(rng, args...; init_kwargs..., kwargs...)
 
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -160,23 +160,24 @@ end
     end
 
     @testset "Non-identity sizes" begin
-        @test size(identity_init(2,3)) == (2,3)
-        @test size(identity_init(1,1,3,4)) == (1,1,3,4)
-        @test size(identity_init(2,1,3,3)) == (2,1,3,3)
-        @test size(identity_init(1,2,3,3)) == (1,2,3,3)
+        @test identity_init(2, 3)[:, end] == zeros(Float32, 2)
+        @test identity_init(1, 1, 3, 4)[:, :, :, end] == zeros(Float32, 1, 1, 3)
+        @test identity_init(2, 1, 3, 3)[end, :, :, :] == zeros(Float32, 1, 3, 3)
+        @test identity_init(1, 2, 3, 3)[:, end, :, :] == zeros(Float32, 1, 3, 3)
     end
 
     @testset "Dense ID mapping" begin
         l = Dense(3,3, initW = identity_init)
+
         indata = reshape(collect(Float32, 1:9), 3, 3)
         @test l(indata) == indata
     end
 
     @testset "$layer ID mapping with kernelsize $kernelsize" for layer in (Conv, ConvTranspose, CrossCor), kernelsize in ((1,), (3,), (1,3), (3,5), (3,5,7))   
         nch = 3
-        indata = randn(Float32, kernelsize..., nch, nch)
-
         l = layer(kernelsize, nch=>nch, init=identity_init, pad=SamePad())
+
+        indata = randn(Float32, kernelsize..., nch, nch)
         @test l(indata) == indata
     end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -154,11 +154,19 @@ end
   @testset "identity_init" begin
     import Flux: identity_init
 
-    @testset "Warnings" begin
-      @test @test_logs (:warn, r"Identity mapping not possible with rows != cols!") size(identity_init(2,3)) == (2,3)
-      @test @test_logs (:warn, r"Identity mapping not possible with nin != nout!") size(identity_init(1,1,3,4)) == (1,1,3,4)
-      @test @test_logs (:warn, r"Identity mapping requires odd kernel sizes!") size(identity_init(2,1,3,3)) == (2,1,3,3)
-      @test @test_logs (:warn, r"Identity mapping requires odd kernel sizes!") size(identity_init(1,2,3,3)) == (1,2,3,3)
+    @testset "Checks" begin
+      @test_throws ArgumentError identity_init(2,3)
+      @test_throws ArgumentError identity_init(1,1,3,4)
+      @test_throws ArgumentError identity_init(2,1,3,3)
+      @test_throws ArgumentError identity_init(1,2,3,3)
+    end
+
+    @testset "No check" begin
+      import Flux: identity_init_nocheck
+        @test size(identity_init_nocheck(2,3)) == (2,3)
+        @test size(identity_init_nocheck(1,1,3,4)) == (1,1,3,4)
+        @test size(identity_init_nocheck(2,1,3,3)) == (2,1,3,3)
+        @test size(identity_init_nocheck(1,2,3,3)) == (1,2,3,3)
     end
 
     @testset "Dense ID mapping" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -151,18 +151,18 @@ end
     @test maximum(partial_si(8, 8, sparsity=0)) > 0
   end
 
-  @testset "init_identity" begin
-    import Flux: init_identity
-    
+  @testset "identity_init" begin
+    import Flux: identity_init
+
     @testset "Warnings" begin
-      @test @test_logs (:warn, r"Identity mapping not possible with rows != cols!") size(init_identity(2,3)) == (2,3)
-      @test @test_logs (:warn, r"Identity mapping not possible with nin != nout!") size(init_identity(1,1,3,4)) == (1,1,3,4)
-      @test @test_logs (:warn, r"Identity mapping requires odd kernel sizes!") size(init_identity(2,1,3,3)) == (2,1,3,3)
-      @test @test_logs (:warn, r"Identity mapping requires odd kernel sizes!") size(init_identity(1,2,3,3)) == (1,2,3,3)
+      @test @test_logs (:warn, r"Identity mapping not possible with rows != cols!") size(identity_init(2,3)) == (2,3)
+      @test @test_logs (:warn, r"Identity mapping not possible with nin != nout!") size(identity_init(1,1,3,4)) == (1,1,3,4)
+      @test @test_logs (:warn, r"Identity mapping requires odd kernel sizes!") size(identity_init(2,1,3,3)) == (2,1,3,3)
+      @test @test_logs (:warn, r"Identity mapping requires odd kernel sizes!") size(identity_init(1,2,3,3)) == (1,2,3,3)
     end
 
     @testset "Dense ID mapping" begin
-        l = Dense(3,3, initW = init_identity)
+        l = Dense(3,3, initW = identity_init)
         indata = reshape(collect(Float32, 1:9), 3, 3)
         @test l(indata) == indata
     end
@@ -171,7 +171,7 @@ end
         nch = 3
         indata = randn(Float32, kernelsize..., nch, nch)
 
-        l = layer(kernelsize, nch=>nch, init=init_identity, pad=SamePad())
+        l = layer(kernelsize, nch=>nch, init=identity_init, pad=SamePad())
         @test l(indata) == indata
     end
   end


### PR DESCRIPTION
As discussed in https://github.com/FluxML/Flux.jl/issues/1431#issuecomment-788836031

Since the only information available is the dimensions, it makes the following assumptions:

*  1D: A `Vector` of `zeros` (assumes bias)
*  2D: An identity matrix (assumes matrix multiplication)
*  2+D: A diagnoal matrix of identity kernels (assumes convolution) 

Not sure if there is a better description of the last one (thats just how I envision it).

I don't think it is possible to create identity mappings for all layer types and if it is, then doing so probably requires that weight init gets to know the layer type. The ones which will not have an ID mapping with this weight init are the RNNs, normalization layers (don't need it) and DepthwiseConv.

### PR Checklist

- [X ] Tests are added
- [X ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] Final review from `@dhairyagandhi96` (for API changes).
