### PR TITLE
Added equality comparison for layers

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -422,3 +422,9 @@ function Base.show(io::IO, m::Parallel)
   join(io, m.layers, ", ")
   print(io, ")")
 end
+
+
+# define equality comparison for the layers
+function Base.:(==)(x::T, y::T) where {T <: Union{Chain, Dense}}
+  params(x) == params(y)
+end

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -706,3 +706,8 @@ function Base.show(io::IO, m::MeanPool)
   m.stride == m.k || print(io, ", stride=", _maybetuple_string(m.stride))
   print(io, ")")
 end
+
+# define equality comparison for the layers
+function Base.:(==)(x::T, y::T) where {T <: Union{Conv, ConvTranspose, DepthwiseConv, CrossCor}}
+  params(x) == params(y)
+end

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -40,6 +40,8 @@ trainable(a::Recur) = (a.cell,)
 
 Base.show(io::IO, m::Recur) = print(io, "Recur(", m.cell, ")")
 
+Base.:(==)(x::Recur, y::Recur) = params(x) == params(y)
+
 """
     reset!(rnn)
 


### PR DESCRIPTION
Fixes #1012 for layers where comparison is usually done. Happy to add the rest of the layers right away if it is required.

```julia
Random.seed!(1)
x = Dense(10,10)
Random.seed!(1)
y = Dense(10,10)
println(x == y) # true

y = Dense(10, 10, relu)
println(x == y) # false
```
### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
