### PR TITLE
Fix printing of OneHotArray in REPL when CUDA.allowscalar(false)

### DIFF
--- a/docs/src/data/onehot.md
+++ b/docs/src/data/onehot.md
@@ -6,13 +6,13 @@ It's common to encode categorical variables (like `true`, `false` or `cat`, `dog
 julia> using Flux: onehot, onecold
 
 julia> onehot(:b, [:a, :b, :c])
-3-element Flux.OneHotArray{UInt32,3,0,1,UInt32}:
+3-element Flux.OneHotVector{3,UInt32}:
  0
  1
  0
 
 julia> onehot(:c, [:a, :b, :c])
-3-element Flux.OneHotArray{UInt32,3,0,1,UInt32}:
+3-element Flux.OneHotVector{3,UInt32}:
  0
  0
  1
@@ -44,7 +44,7 @@ Flux.onecold
 julia> using Flux: onehotbatch
 
 julia> onehotbatch([:b, :a, :b], [:a, :b, :c])
-3×3 Flux.OneHotArray{UInt32,3,1,2,Array{UInt32,1}}:
+3×3 Flux.OneHotArray{3,2,Array{UInt32,1}}:
  0  1  0
  1  0  1
  0  0  0

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -106,7 +106,7 @@ of label smoothing to binary distributions encoded in a single number.
 # Example
 ```jldoctest
 julia> y = Flux.onehotbatch([1, 1, 1, 0, 1, 0], 0:1)
-2×6 Flux.OneHotArray{UInt32,2,1,2,Array{UInt32,1}}:
+2×6 Flux.OneHotArray{2,2,Array{UInt32,1}}:
  0  0  0  1  0  1
  1  1  1  0  1  0
 
@@ -171,7 +171,7 @@ See also: [`logitcrossentropy`](@ref), [`binarycrossentropy`](@ref), [`logitbina
 # Example
 ```jldoctest
 julia> y_label = Flux.onehotbatch([0, 1, 2, 1, 0], 0:2)
-3×5 Flux.OneHotArray{UInt32,3,1,2,Array{UInt32,1}}:
+3×5 Flux.OneHotArray{3,2,Array{UInt32,1}}:
  1  0  0  0  1
  0  1  0  1  0
  0  0  1  0  0
@@ -222,7 +222,7 @@ See also: [`binarycrossentropy`](@ref), [`logitbinarycrossentropy`](@ref), [`lab
 # Example
 ```jldoctest
 julia> y_label = Flux.onehotbatch(collect("abcabaa"), 'a':'c')
-3×7 Flux.OneHotArray{UInt32,3,1,2,Array{UInt32,1}}:
+3×7 Flux.OneHotArray{3,2,Array{UInt32,1}}:
  1  0  0  1  0  1  1
  0  1  0  0  1  0  0
  0  0  1  0  0  0  0
@@ -280,7 +280,7 @@ julia> all(p -> 0<p<1, y_prob[2,:])  # else DomainError
 true
 
 julia> y_hot = Flux.onehotbatch(y_bin, 0:1)
-2×3 Flux.OneHotArray{UInt32,2,1,2,Array{UInt32,1}}:
+2×3 Flux.OneHotArray{2,2,Array{UInt32,1}}:
  0  1  0
  1  0  1
 

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -98,13 +98,13 @@ If `l` is not found in labels and  `unk` is present, the function returns
 # Examples
 ```jldoctest
 julia> Flux.onehot(:b, [:a, :b, :c])
-3-element Flux.OneHotArray{UInt32,3,0,1,UInt32}:
+3-element Flux.OneHotVector{3,UInt32}:
  0
  1
  0
 
 julia> Flux.onehot(:c, [:a, :b, :c])
-3-element Flux.OneHotArray{UInt32,3,0,1,UInt32}:
+3-element Flux.OneHotVector{3,UInt32}:
  0
  0
  1
@@ -133,7 +133,7 @@ return [`onehot(unk, labels)`](@ref) ; otherwise the function will raise an erro
 # Examples
 ```jldoctest
 julia> Flux.onehotbatch([:b, :a, :b], [:a, :b, :c])
-3×3 Flux.OneHotArray{UInt32,3,1,2,Array{UInt32,1}}:
+3×3 Flux.OneHotArray{3,2,Array{UInt32,1}}:
  0  1  0
  1  0  1
  0  0  0

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -18,6 +18,28 @@ const OneHotMatrix{T, L, I} = OneHotArray{T, L, 1, 2, I}
 OneHotVector(idx, L) = OneHotArray(idx, L)
 OneHotMatrix(indices, L) = OneHotArray(indices, L)
 
+function _show_elements(x::OneHotArray)
+  xbool = convert(_onehot_bool_type(x), x)
+  xrepr = join(split(repr(MIME("text/plain"), xbool), "\n")[2:end], "\n")
+
+  return xrepr
+end
+
+function Base.show(io::IO, ::MIME"text/plain", x::OneHotArray{T, L, N}) where {T, L, N}
+  join(io, string.(size(x)), "×")
+  print(io, " Flux.OneHotArray{")
+  join(io, string.([T, L, N+1]), ",")
+  println(io, "}")
+  print(io, _show_elements(x))
+end
+function Base.show(io::IO, ::MIME"text/plain", x::OneHotVector{T, L}) where {T, L}
+  print(io, string.(length(x)))
+  print(io, "-element Flux.OneHotVector{")
+  join(io, string.([T, L]), ",")
+  println(io, "}")
+  print(io, _show_elements(x))
+end
+
 # use this type so reshaped arrays hit fast paths
 # e.g. argmax
 const OneHotLike{T, L, N, var"N+1", I} =

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -25,7 +25,7 @@ function _show_elements(x::OneHotArray)
   return xrepr
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::OneHotArray{L, <:Any, N, I}) where {L, N, I}
+function Base.show(io::IO, ::MIME"text/plain", x::OneHotArray{<:Any, L, <:Any, N, I}) where {L, N, I}
   join(io, string.(size(x)), "×")
   print(io, " Flux.OneHotArray{")
   join(io, string.([L, N, I]), ",")

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -29,14 +29,14 @@ function Base.show(io::IO, ::MIME"text/plain", x::OneHotArray{<:Any, L, <:Any, N
   join(io, string.(size(x)), "×")
   print(io, " Flux.OneHotArray{")
   join(io, string.([L, N, I]), ",")
-  println(io, "}")
+  println(io, "}:")
   print(io, _show_elements(x))
 end
 function Base.show(io::IO, ::MIME"text/plain", x::OneHotVector{T, L}) where {T, L}
   print(io, string.(length(x)))
   print(io, "-element Flux.OneHotVector{")
   join(io, string.([L, T]), ",")
-  println(io, "}")
+  println(io, "}:")
   print(io, _show_elements(x))
 end
 

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -19,23 +19,23 @@ OneHotVector(idx, L) = OneHotArray(idx, L)
 OneHotMatrix(indices, L) = OneHotArray(indices, L)
 
 function _show_elements(x::OneHotArray)
-  xbool = convert(Array{Bool}, x)
+  xbool = convert(Array{Bool}, cpu(x))
   xrepr = join(split(repr(MIME("text/plain"), xbool), "\n")[2:end], "\n")
 
   return xrepr
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::OneHotArray{T, L, N}) where {T, L, N}
+function Base.show(io::IO, ::MIME"text/plain", x::OneHotArray{L, <:Any, N, I}) where {L, N, I}
   join(io, string.(size(x)), "×")
   print(io, " Flux.OneHotArray{")
-  join(io, string.([T, L, N+1]), ",")
+  join(io, string.([L, N, I]), ",")
   println(io, "}")
   print(io, _show_elements(x))
 end
 function Base.show(io::IO, ::MIME"text/plain", x::OneHotVector{T, L}) where {T, L}
   print(io, string.(length(x)))
   print(io, "-element Flux.OneHotVector{")
-  join(io, string.([T, L]), ",")
+  join(io, string.([L, T]), ",")
   println(io, "}")
   print(io, _show_elements(x))
 end

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -19,7 +19,7 @@ OneHotVector(idx, L) = OneHotArray(idx, L)
 OneHotMatrix(indices, L) = OneHotArray(indices, L)
 
 function _show_elements(x::OneHotArray)
-  xbool = convert(_onehot_bool_type(x), x)
+  xbool = convert(Array{Bool}, x)
   xrepr = join(split(repr(MIME("text/plain"), xbool), "\n")[2:end], "\n")
 
   return xrepr


### PR DESCRIPTION
Adds `Base.show` for `OneHotArray`. Fixes #1532. This turned out to be harder than I originally thought.

### PR Checklist

- [ ] ~~Tests are added~~
- [ ] ~~Entry in NEWS.md~~
- [ ] ~~Documentation, if applicable~~
- [ ] ~~API changes require approval from a committer (different from the author, if applicable)~~
