### PR TITLE
Add early stopping utils

### DIFF
--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -102,5 +102,5 @@ Flux.nfan
 Flux.throttle
 Flux.stop
 Flux.skip
-Flux.patience_counter
+Flux.plateau
 ```

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -102,4 +102,5 @@ Flux.nfan
 Flux.throttle
 Flux.stop
 Flux.skip
+Flux.early_stopping
 ```

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -102,5 +102,5 @@ Flux.nfan
 Flux.throttle
 Flux.stop
 Flux.skip
-Flux.early_stopping
+Flux.patience_counter
 ```

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -121,10 +121,10 @@ end
 
 # create an early stopping trigger
 # returns true when the loss increases for two consecutive steps
-es = Flux.early_stopping(loss, 2; init_score=9)
+es = early_stopping(loss, 2; init_score = 9)
 
 # this will stop at the 6th (4 decreasing + 2 increasing calls) epoch
-Flux.@epochs 10 begin
+@epochs 10 begin
   es() && break
 end
 ```
@@ -138,33 +138,33 @@ acc = let v = 0
 end
 
 # create an early stopping trigger for accuracy
-es = Flux.early_stopping(acc, 3; delta = (best_score, score) -> score - best_score)
+es = early_stopping(acc, 3; delta = (best_score, score) -> score - best_score)
 
 # this will iterate until the 10th epoch
-Flux.@epochs 10 begin
+@epochs 10 begin
   es() && break
 end
 ```
 
 `early_stopping` and `plateau` are both built on top of `patience`. You can use `patience` to build your own triggers that use a patient counter. For example, if you want to trigger when the loss is below a threshold for several consecutive iterations:
 ```julia
-threshold(f, thresh, delay) = Flux.patience(delay) do
+threshold(f, thresh, delay) = patience(delay) do
   f() < thresh
 end
 ```
 
 Both `predicate` in `patience` and `f` in `early_stopping` / `plateau` can accept extra arguments. You can pass such extra arguments to `predicate` or `f` through the returned function:
 ```julia
-trigger = Flux.patience((a; b) -> a > b, 3)
+trigger = patience((a; b) -> a > b, 3)
 
 # this will iterate until the 10th epoch
-Flux.@epochs 10 begin
-  trigger(1; b=2) && break
+@epochs 10 begin
+  trigger(1; b = 2) && break
 end
 
 # this will stop at the 3rd epoch
-Flux.@epochs 10 begin
-  trigger(3; b=2) && break
+@epochs 10 begin
+  trigger(3; b = 2) && break
 end
 ```
 

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -106,41 +106,63 @@ Flux.skip
 
 ## Patience Helpers
 
-Flux provide utilities for scheduling your workflow according to some monitored condition and a maximum `patience`. For example, you can use `early_stopping` to stop training when the model is converging or deteriorating, or you can use `plateau` to check if the model is stagnating.
+Flux provides utilities for controlling your training procedure according to some monitored condition and a maximum `patience`. For example, you can use `early_stopping` to stop training when the model is converging or deteriorating, or you can use `plateau` to check if the model is stagnating.
 
-The keyword argument `distance` of `early_stopping` is a function of the form `distance(best_score, score)`. By default `distance` is `-`, which implies that the monitored metric `f` is expected to be decreasing and mimimized. If you use some increasing metric (e.g. accuracy), you can customize the `distance` function: `(best_score, score) -> score - best_score`.
-
+For example, below we create a pseudo-loss function that decreases, bottoms out, then increases. The early stopping trigger will break the loop before the loss increases too much.
 ```julia
-acc = let v = 0
-  () -> v = max(1, v + 0.01)
+# create a pseudo-loss that decreases for 4 calls, then starts increasing
+# we call this like loss()
+loss = let t = 0
+  () -> begin
+    t += 1
+    (t - 4) ^ 2
+  end
 end
 
-es = Flux.early_stopping(acc, 3; delta = (best_score, score) -> score - best_score)
+# create an early stopping trigger
+# returns true when the loss increases for two consecutive steps
+es = Flux.early_stopping(loss, 2; init_score=9)
 
-# This will iterate until the 10th epoch
-Flux.@epochs 10 begin
-  es() && break
-end
-
-es = Flux.early_stopping(acc, 3)
-
-# This will stop at the 3rd epoch
+# this will stop at the 6th (4 decreasing + 2 increasing calls) epoch
 Flux.@epochs 10 begin
   es() && break
 end
 ```
 
-Both `predicate` in `patience` and `f` in `early_stopping` / `plateau` can accept extra arguments. You can pass such extra arguments to `predicate` or `f` through the returned function:
+The keyword argument `distance` of `early_stopping` is a function of the form `distance(best_score, score)`. By default `distance` is `-`, which implies that the monitored metric `f` is expected to be decreasing and mimimized. If you use some increasing metric (e.g. accuracy), you can customize the `distance` function: `(best_score, score) -> score - best_score`.
+```julia
+# create a pseudo-accuracy that increases by 0.01 each time from 0 to 1
+# we call this like acc()
+acc = let v = 0
+  () -> v = max(1, v + 0.01)
+end
 
+# create an early stopping trigger for accuracy
+es = Flux.early_stopping(acc, 3; delta = (best_score, score) -> score - best_score)
+
+# this will iterate until the 10th epoch
+Flux.@epochs 10 begin
+  es() && break
+end
+```
+
+`early_stopping` and `plateau` are both built on top of `patience`. You can use `patience` to build your own triggers that use a patient counter. For example, if you want to trigger when the loss is below a threshold for several consecutive iterations:
+```julia
+threshold(f, thresh, delay) = Flux.patience(delay) do
+  f() < thresh
+end
+```
+
+Both `predicate` in `patience` and `f` in `early_stopping` / `plateau` can accept extra arguments. You can pass such extra arguments to `predicate` or `f` through the returned function:
 ```julia
 trigger = Flux.patience((a; b) -> a > b, 3)
 
-# This will iterate until the 10th epoch
+# this will iterate until the 10th epoch
 Flux.@epochs 10 begin
   trigger(1; b=2) && break
 end
 
-# This will stop at the 3rd epoch
+# this will stop at the 3rd epoch
 Flux.@epochs 10 begin
   trigger(3; b=2) && break
 end

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -102,11 +102,13 @@ Flux.nfan
 Flux.throttle
 Flux.stop
 Flux.skip
-Flux.patience
-Flux.plateau
 ```
 
-The keyword argument `delta` of [`plateau`](@ref) is a function of the form `delta(best_score, current_score)`. By default `delta` is `-`, which implies that the metric `f` is expected to be decreasing and mimimized. If you use some increasing metric (e.g. accuracy), you can customize the `delta` function: `(best_score, score) -> score - best_score`.
+## Patience Helpers
+
+Flux provide utilities for scheduling your workflow according to some monitored condition and a maximum `patience`. For example, you can use `early_stopping` to stop training when the model is converging or deteriorating, or you can use `plateau` to check if the model is stagnating.
+
+The keyword argument `distance` of `early_stopping` is a function of the form `distance(best_score, score)`. By default `distance` is `-`, which implies that the monitored metric `f` is expected to be decreasing and mimimized. If you use some increasing metric (e.g. accuracy), you can customize the `distance` function: `(best_score, score) -> score - best_score`.
 
 ```julia
 acc = let v = 0
@@ -128,7 +130,7 @@ Flux.@epochs 10 begin
 end
 ```
 
-Both `predicate` in [`patience`](@ref) and `f` in [`plateau`](@ref) can accept extra arguments. You can pass such extra arguments to `predicate` or `f` through the returned function:
+Both `predicate` in `patience` and `f` in `early_stopping` / `plateau` can accept extra arguments. You can pass such extra arguments to `predicate` or `f` through the returned function:
 
 ```julia
 trigger = Flux.patience((a; b) -> a > b, 3)
@@ -142,4 +144,10 @@ end
 Flux.@epochs 10 begin
   trigger(3; b=2) && break
 end
+```
+
+```@docs
+Flux.patience
+Flux.early_stopping
+Flux.plateau
 ```

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -102,5 +102,6 @@ Flux.nfan
 Flux.throttle
 Flux.stop
 Flux.skip
+Flux.patience
 Flux.plateau
 ```

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -105,3 +105,41 @@ Flux.skip
 Flux.patience
 Flux.plateau
 ```
+
+The keyword argument `delta` of [`plateau`](@ref) is a function of the form `delta(best_score, current_score)`. By default `delta` is `-`, which implies that the metric `f` is expected to be decreasing and mimimized. If you use some increasing metric (e.g. accuracy), you can customize the `delta` function: `(best_score, score) -> score - best_score`.
+
+```julia
+acc = let v = 0
+  () -> v = max(1, v + 0.01)
+end
+
+es = Flux.early_stopping(acc, 3; delta = (best_score, score) -> score - best_score)
+
+# This will iterate until the 10th epoch
+Flux.@epochs 10 begin
+  es() && break
+end
+
+es = Flux.early_stopping(acc, 3)
+
+# This will stop at the 3rd epoch
+Flux.@epochs 10 begin
+  es() && break
+end
+```
+
+Both `predicate` in [`patience`](@ref) and `f` in [`plateau`](@ref) can accept extra arguments. You can pass such extra arguments to `predicate` or `f` through the returned function:
+
+```julia
+trigger = Flux.patience((a; b) -> a > b, 3)
+
+# This will iterate until the 10th epoch
+Flux.@epochs 10 begin
+  trigger(1; b=2) && break
+end
+
+# This will stop at the 3rd epoch
+Flux.@epochs 10 begin
+  trigger(3; b=2) && break
+end
+```

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -742,3 +742,15 @@ modules(m) = [x for x in Functors.fcollect(m) if !isleaflike(x)]
 isleaflike(x) = Functors.isleaf(x)
 isleaflike(::Tuple{Vararg{<:Number}}) = true
 isleaflike(::Tuple{Vararg{<:AbstractArray{<:Number}}}) = true
+
+function early_stopping(f; min_delta=0, patience=3)
+  min_metric = Inf
+  count = 0
+
+  return function ()
+      metric = f()
+      count = min_metric - metric < min_delta ? count + 1 : 0
+      min_metric = min(min_metric, metric)
+      return count < patience
+  end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -770,7 +770,7 @@ julia> function loss()
        return () -> l += 1
        end; # pseudo loss function that returns increasing values
 
-julia> es = Flux.early_stopping(loss(); patience=3);
+julia> es = Flux.early_stopping(loss(), 3);
 
 julia> Flux.@epochs 10 begin
        es() && break
@@ -780,7 +780,7 @@ julia> Flux.@epochs 10 begin
 [ Info: Epoch 3
 ```
 """
-function patience_counter(f; delta = -, init_score = 0, min_delta = 0, patience = 3)
+function patience_counter(f, patience; delta = -, init_score = 0, min_delta = 0)
   best_score = init_score
   count = 0
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -748,13 +748,14 @@ isleaflike(::Tuple{Vararg{<:AbstractArray{<:Number}}}) = true
 
 Return a function that evaluates the metric `f` and compares its value
 against its value on last invocation. When the difference has been less
-than `min_delta` for at least `patience` times, `true` is returned,
+than `min_delta` at least `patience` times, `true` is returned,
 otherwise `false` is returned.
 
+The difference is measured by keyword argument, `delta`.
 By default, `early_stopping` expects the metric `f` to be minimized.
-However, if you are using some increasing metric, accuracy for example,
-you can change `early_stopping`'s behaviour by customizing the `delta`
-function: `(best_score, score) -> score - best_score`.
+If you are using some increasing metric (e.g. accuracy),
+you can customize the `delta` function:
+`(best_score, score) -> score - best_score` (for increasing metrics).
 
 # Examples
 ```jldoctest
@@ -767,7 +768,7 @@ loss (generic function with 1 method)
 julia> es = Flux.early_stopping(loss(); patience=3);
 
 julia> Flux.@epochs 10 begin
-       es() || break
+       es() && break
        end
 [ Info: Epoch 1
 [ Info: Epoch 2
@@ -783,6 +784,6 @@ function early_stopping(f; delta = -, min_delta = 0, patience = 3)
     Δ = delta(best_score, score)
     count = Δ < min_delta ? count + 1 : 0
     best_score = Δ < 0 ? best_score : score
-    return count < patience
+    return count >= patience
   end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -744,7 +744,7 @@ isleaflike(::Tuple{Vararg{<:Number}}) = true
 isleaflike(::Tuple{Vararg{<:AbstractArray{<:Number}}}) = true
 
 """
-    early_stopping(f; delta=-, min_delta=0, patience=3)
+    patience_counter(f; delta=-, min_delta=0, patience=3)
 
 Return a function that evaluates the metric `f` and compares its value
 against its value on last invocation. When the difference has been less
@@ -757,13 +757,17 @@ If you are using some increasing metric (e.g. accuracy),
 you can customize the `delta` function:
 `(best_score, score) -> score - best_score` (for increasing metrics).
 
+A common use case of `patience_counter` is early stopping. For this,
+we have added `early_stopping` as an alias to `patience_counter`. But
+please note that you can do more generic things with `patience_counter`,
+for example reducing the learning rate when the training loss plateaus.
+
 # Examples
 ```jldoctest
 julia> function loss()
        l = 0
        return () -> l += 1
-       end # pseudo loss function that returns increasing values
-loss (generic function with 1 method)
+       end; # pseudo loss function that returns increasing values
 
 julia> es = Flux.early_stopping(loss(); patience=3);
 
@@ -775,7 +779,7 @@ julia> Flux.@epochs 10 begin
 [ Info: Epoch 3
 ```
 """
-function early_stopping(f; delta = -, min_delta = 0, patience = 3)
+function patience_counter(f; delta = -, min_delta = 0, patience = 3)
   best_score = f()
   count = 0
 
@@ -787,3 +791,5 @@ function early_stopping(f; delta = -, min_delta = 0, patience = 3)
     return count >= patience
   end
 end
+
+early_stopping = patience_counter

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -758,7 +758,7 @@ julia> loss() = rand();
 julia> trigger = Flux.patience(() -> loss() < 1, 3);
 
 julia> Flux.@epochs 10 begin
-       trigger() && break
+         trigger() && break
        end
 [ Info: Epoch 1
 [ Info: Epoch 2
@@ -766,8 +766,8 @@ julia> Flux.@epochs 10 begin
 ```
 """
 function patience(predicate, wait)
-  on_trigger = let count = 0
-    (args...; kwargs...) -> begin
+  let count = 0
+    function on_trigger(args...; kwargs...)
       count = predicate(args...; kwargs...) ? count + 1 : 0
 
       return count >= wait
@@ -788,13 +788,13 @@ The count is reset when `distance(best_score, f(...)) > min_dist`.
 # Examples
 ```jldoctest
 julia> loss = let l = 0
-       () -> l += 1
+         () -> l += 1
        end; # pseudo loss function that returns increasing values
 
 julia> es = Flux.early_stopping(loss, 3);
 
 julia> Flux.@epochs 10 begin
-       es() && break
+         es() && break
        end
 [ Info: Epoch 1
 [ Info: Epoch 2
@@ -828,13 +828,13 @@ The count is reset when `abs(distance(last_score, f(...))) > min_dist`.
 # Examples
 ```jldoctest
 julia> f = let v = 10
-       () -> v = v / abs(v) - v
+         () -> v = v / abs(v) - v
        end; # -9, 8, -7, 6, ...
 
 julia> trigger = Flux.plateau(f, 3; init_score=10, min_dist=18);
 
 julia> Flux.@epochs 10 begin
-       trigger() && break
+         trigger() && break
        end
 [ Info: Epoch 1
 [ Info: Epoch 2

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -744,11 +744,11 @@ isleaflike(::Tuple{Vararg{<:Number}}) = true
 isleaflike(::Tuple{Vararg{<:AbstractArray{<:Number}}}) = true
 
 """
-    patience(predicate, patience)
+    patience(predicate, wait)
 
 Return a function that internally counts by one when
 `predicate(...) == true`, otherwise the count is reset to zero.
-If the count is greater than or equal to `patience`,
+If the count is greater than or equal to `wait`,
 the function returns `true`, otherwise it returns `false`.
 
 # Examples
@@ -765,12 +765,12 @@ julia> Flux.@epochs 10 begin
 [ Info: Epoch 3
 ```
 """
-function patience(predicate, patience)
+function patience(predicate, wait)
   on_trigger = let count = 0
     (args...; kwargs...) -> begin
       count = predicate(args...; kwargs...) ? count + 1 : 0
 
-      return count >= patience
+      return count >= wait
     end
   end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -743,7 +743,7 @@ isleaflike(x) = Functors.isleaf(x)
 isleaflike(::Tuple{Vararg{<:Number}}) = true
 isleaflike(::Tuple{Vararg{<:AbstractArray{<:Number}}}) = true
 
-function early_stopping(f; min_delta=0, patience=3)
+function early_stopping(f; min_delta = 0, patience = 3)
   min_metric = Inf
   count = 0
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -780,7 +780,7 @@ julia> Flux.@epochs 10 begin
 [ Info: Epoch 3
 ```
 """
-function patience_counter(f, patience; delta = -, init_score = 0, min_delta = 0)
+function plateau(f, patience; delta = -, init_score = 0, min_delta = 0)
   best_score = init_score
   count = 0
 
@@ -793,4 +793,4 @@ function patience_counter(f, patience; delta = -, init_score = 0, min_delta = 0)
   end
 end
 
-early_stopping(args...; kwargs...) = patience_counter(args...; kwargs...)
+const early_stopping(args...; kwargs...) = plateau(args...; kwargs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -772,7 +772,6 @@ julia> Flux.@epochs 10 begin
 [ Info: Epoch 1
 [ Info: Epoch 2
 [ Info: Epoch 3
-[ Info: Epoch 4
 ```
 """
 function early_stopping(f; delta = -, min_delta = 0, patience = 3)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -743,6 +743,33 @@ isleaflike(x) = Functors.isleaf(x)
 isleaflike(::Tuple{Vararg{<:Number}}) = true
 isleaflike(::Tuple{Vararg{<:AbstractArray{<:Number}}}) = true
 
+"""
+    early_stopping(f; min_delta=0, patience=3)
+
+Return a function that evaluates the metric `f` and compares its value
+against that of last invokation. When the difference has been less
+than `min_delta` for at least `patience` times, `true` is returned;
+otherwise `false` is returned.
+
+# Examples
+```jldoctest
+julia> function loss()
+       l = 1
+       return () -> l += 1
+       end
+loss (generic function with 1 method)
+
+julia> es = Flux.early_stopping(loss());
+
+julia> Flux.@epochs 10 begin
+       es() || break
+       end
+[ Info: Epoch 1
+[ Info: Epoch 2
+[ Info: Epoch 3
+[ Info: Epoch 4
+```
+"""
 function early_stopping(f; min_delta = 0, patience = 3)
   min_metric = Inf
   count = 0

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -449,6 +449,18 @@ end
     @test n_iter == 99
   end
 
+  @testset "init score" begin
+    es = Flux.patience_counter(metric(); init_score=10)
+
+    n_iter = 0
+    while n_iter < 99
+      es() && break
+      n_iter += 1
+    end
+
+    @test n_iter == 3
+  end
+
   @testset "min delta" begin
     es = Flux.patience_counter(metric(step=-2); min_delta=1)
 
@@ -470,6 +482,6 @@ end
       n_iter += 1
     end
 
-    @test n_iter == 10
+    @test n_iter == 9
   end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -430,7 +430,8 @@ end
 
     n_iter = 0
     while n_iter < 99
-      es() ? break : n_iter += 1
+      es() && break
+      n_iter += 1
     end
 
     @test n_iter == 99
@@ -441,7 +442,8 @@ end
 
     n_iter = 0
     while n_iter < 99
-      es() ? break : n_iter += 1
+      es() && break
+      n_iter += 1
     end
 
     @test n_iter == 99

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -430,7 +430,7 @@ end
 
     n_iter = 0
     while n_iter < 99
-      es() ? n_iter += 1 : break
+      es() ? break : n_iter += 1
     end
 
     @test n_iter == 99
@@ -441,7 +441,7 @@ end
 
     n_iter = 0
     while n_iter < 99
-      es() ? n_iter += 1 : break
+      es() ? break : n_iter += 1
     end
 
     @test n_iter == 99
@@ -452,7 +452,7 @@ end
 
     n_iter = 0
     while n_iter < 99
-      es() ? n_iter += 1 : break
+      es() ? break : n_iter += 1
     end
 
     @test n_iter == 9

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -418,3 +418,32 @@ end
                                 LayerNorm(8)))
   @test length(modules) == 5
 end
+
+@testset "Early stopping" begin
+  function metric(; step = 1)
+    l = 0
+    return () -> l += step
+  end
+
+  @testset "min delta" begin
+    es = Flux.early_stopping(metric(step=-2); min_delta=1)
+
+    n_iter = 0
+    while n_iter < 99
+      es() ? n_iter += 1 : break
+    end
+
+    @test n_iter == 99
+  end
+
+  @testset "patience" begin
+    es = Flux.early_stopping(metric(); patience=10)
+
+    n_iter = 0
+    while true
+      es() ? n_iter += 1 : break
+    end
+
+    @test n_iter == 10
+  end
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -419,13 +419,26 @@ end
   @test length(modules) == 5
 end
 
-@testset "Patience" begin
+@testset "Patience triggers" begin
   @testset "patience" begin
     trigger = Flux.patience(() -> true, 3)
 
     @test trigger() == false
     @test trigger() == false
     @test trigger() == true
+
+    v = [false, true, false, true, true, true]
+    trigger = let v = v
+      Flux.patience(i -> v[i], 3)
+    end
+
+    n_iter = 0
+    for i in 1:length(v)
+      trigger(i) && break
+      n_iter += 1
+    end
+
+    @test n_iter == 5
   end
 
   @testset "early stopping" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -419,14 +419,14 @@ end
   @test length(modules) == 5
 end
 
-@testset "Patience counter" begin
+@testset "Plateau" begin
   function metric(; step = 1)
     l = 0
     return () -> l += step
   end
 
   @testset "args & kwargs" begin
-    es = Flux.patience_counter((x; y = 1) -> x + y, 10; min_delta=2)
+    es = Flux.plateau((x; y = 1) -> x + y, 10; min_delta=2)
 
     n_iter = 0
     while n_iter < 99
@@ -438,7 +438,7 @@ end
   end
 
   @testset "delta" begin
-    es = Flux.patience_counter(metric(), 10; delta=(best_score, score) -> score - best_score)
+    es = Flux.plateau(metric(), 10; delta=(best_score, score) -> score - best_score)
 
     n_iter = 0
     while n_iter < 99
@@ -450,7 +450,7 @@ end
   end
 
   @testset "init score" begin
-    es = Flux.patience_counter(metric(), 10; init_score=10)
+    es = Flux.plateau(metric(), 10; init_score=10)
 
     n_iter = 0
     while n_iter < 99
@@ -462,7 +462,7 @@ end
   end
 
   @testset "min delta" begin
-    es = Flux.patience_counter(metric(step=-2), 10; min_delta=1)
+    es = Flux.plateau(metric(step=-2), 10; min_delta=1)
 
     n_iter = 0
     while n_iter < 99
@@ -474,7 +474,7 @@ end
   end
 
   @testset "patience" begin
-    es = Flux.patience_counter(metric(), 10)
+    es = Flux.plateau(metric(), 10)
 
     n_iter = 0
     while n_iter < 99

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -425,6 +425,17 @@ end
     return () -> l += step
   end
 
+  @testset "delta" begin
+    es = Flux.early_stopping(metric(); delta=(best_score, score) -> score - best_score)
+
+    n_iter = 0
+    while n_iter < 99
+      es() ? n_iter += 1 : break
+    end
+
+    @test n_iter == 99
+  end
+
   @testset "min delta" begin
     es = Flux.early_stopping(metric(step=-2); min_delta=1)
 
@@ -440,10 +451,10 @@ end
     es = Flux.early_stopping(metric(); patience=10)
 
     n_iter = 0
-    while true
+    while n_iter < 99
       es() ? n_iter += 1 : break
     end
 
-    @test n_iter == 10
+    @test n_iter == 9
   end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -425,6 +425,18 @@ end
     return () -> l += step
   end
 
+  @testset "args & kwargs" begin
+    es = Flux.patience_counter((x; y = 1) -> x + y; min_delta=2)
+
+    n_iter = 0
+    while n_iter < 99
+      es(-n_iter; y=-n_iter) && break
+      n_iter += 1
+    end
+
+    @test n_iter == 99
+  end
+
   @testset "delta" begin
     es = Flux.patience_counter(metric(); delta=(best_score, score) -> score - best_score)
 
@@ -458,6 +470,6 @@ end
       n_iter += 1
     end
 
-    @test n_iter == 9
+    @test n_iter == 10
   end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -452,7 +452,8 @@ end
 
     n_iter = 0
     while n_iter < 99
-      es() ? break : n_iter += 1
+      es() && break
+      n_iter += 1
     end
 
     @test n_iter == 9

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -426,7 +426,7 @@ end
   end
 
   @testset "args & kwargs" begin
-    es = Flux.patience_counter((x; y = 1) -> x + y; min_delta=2)
+    es = Flux.patience_counter((x; y = 1) -> x + y, 10; min_delta=2)
 
     n_iter = 0
     while n_iter < 99
@@ -438,7 +438,7 @@ end
   end
 
   @testset "delta" begin
-    es = Flux.patience_counter(metric(); delta=(best_score, score) -> score - best_score)
+    es = Flux.patience_counter(metric(), 10; delta=(best_score, score) -> score - best_score)
 
     n_iter = 0
     while n_iter < 99
@@ -450,7 +450,7 @@ end
   end
 
   @testset "init score" begin
-    es = Flux.patience_counter(metric(); init_score=10)
+    es = Flux.patience_counter(metric(), 10; init_score=10)
 
     n_iter = 0
     while n_iter < 99
@@ -458,11 +458,11 @@ end
       n_iter += 1
     end
 
-    @test n_iter == 3
+    @test n_iter == 10
   end
 
   @testset "min delta" begin
-    es = Flux.patience_counter(metric(step=-2); min_delta=1)
+    es = Flux.patience_counter(metric(step=-2), 10; min_delta=1)
 
     n_iter = 0
     while n_iter < 99
@@ -474,7 +474,7 @@ end
   end
 
   @testset "patience" begin
-    es = Flux.patience_counter(metric(); patience=10)
+    es = Flux.patience_counter(metric(), 10)
 
     n_iter = 0
     while n_iter < 99

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -419,14 +419,14 @@ end
   @test length(modules) == 5
 end
 
-@testset "Early stopping" begin
+@testset "Patience counter" begin
   function metric(; step = 1)
     l = 0
     return () -> l += step
   end
 
   @testset "delta" begin
-    es = Flux.early_stopping(metric(); delta=(best_score, score) -> score - best_score)
+    es = Flux.patience_counter(metric(); delta=(best_score, score) -> score - best_score)
 
     n_iter = 0
     while n_iter < 99
@@ -438,7 +438,7 @@ end
   end
 
   @testset "min delta" begin
-    es = Flux.early_stopping(metric(step=-2); min_delta=1)
+    es = Flux.patience_counter(metric(step=-2); min_delta=1)
 
     n_iter = 0
     while n_iter < 99
@@ -450,7 +450,7 @@ end
   end
 
   @testset "patience" begin
-    es = Flux.early_stopping(metric(); patience=10)
+    es = Flux.patience_counter(metric(); patience=10)
 
     n_iter = 0
     while n_iter < 99


### PR DESCRIPTION
This pull request introduces a utility function `early_stopping(f; min_delta=0, patience=3)` for conveniently implementing early stopping. Its motive was discussed in #227 back in 2018. Also AFAIU, early stopping is widely adopted in training large-scale neural networks nowadays as a mechanism to prevent overfitting. Therefore, I believe a built-in utility function for early stopping would be beneficial for Flux.jl users.

The implementation is heavily based on [tf.keras.callbacks.EarlyStopping](https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/EarlyStopping) and [ignite.handlers.EarlyStopping](https://github.com/pytorch/ignite/blob/master/ignite/handlers/early_stopping.py).

> This is a _draft_ implementation. Documentation and tests are not added yet. As I am new to Flux.jl, I think advice and opinions from maintainers would be helpful before I proceed.

**Example Usage**:
```julia
# test_ea.jl
using Flux

function loss()
    v = 1
    return () -> v += 1
end

ea = Flux.early_stopping(loss(), patience=5)
Flux.@epochs 10 begin
    ea() || break
end
```

**Output**:

```
➜ julia test_ea.jl
 Activating environment at `~/Developer/Flux.jl/Project.toml`
[ Info: Epoch 1
[ Info: Epoch 2
[ Info: Epoch 3
[ Info: Epoch 4
[ Info: Epoch 5
[ Info: Epoch 6
➜
```

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
