### PR TITLE
Minimal fix of #1556, remove eltype checks 

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -388,14 +388,10 @@ to the constructor's keyword `bias=bias`.
 function create_bias(weights::AbstractArray, bias::Bool, dims::Integer...)
   bias ? fill!(similar(weights, dims...), 0) : Zeros()
 end
+
 function create_bias(weights::AbstractArray, bias::AbstractArray, dims::Integer...)
   size(bias) == dims || throw(DimensionMismatch("expected bias of size $(dims), got size $(size(bias))"))
-  if eltype(bias) == eltype(weights)
-    return bias
-  else
-    @warn "converting bias to match element type of weights" typeof(weights) typeof(bias) maxlog=3 _id=hash(dims)
-    return broadcast(eltype(weights), bias)
-  end
+  bias
 end
 
 """

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -38,10 +38,10 @@ import Flux: activations
       @test Dense(rand(100,10), false, tanh).σ == tanh
       @test Dense(rand(100,10), rand(100)).σ == identity
       @test Dense(rand(Float16, 100,10), true).bias isa Vector{Float16}  # creates matching type
-      @test Dense(rand(Float16, 100,10), rand(100)).bias isa Vector{Float16}  # converts to match
+      @test_skip Dense(rand(Float16, 100,10), rand(100)).bias isa Vector{Float16}  # converts to match
 
       @test Dense(3,4; init=Base.randn, bias=true).bias isa Vector{Float64}
-      @test Dense(3,4; init=Base.randn, bias=[1,2,3,4]).bias isa Vector{Float64}
+      @test_skip Dense(3,4; init=Base.randn, bias=[1,2,3,4]).bias isa Vector{Float64}
 
       @test_throws MethodError Dense(10, 10.5)
       @test_throws MethodError Dense(10, 10.5, tanh)
@@ -167,7 +167,7 @@ import Flux: activations
       @test size(b3(rand(4), rand(5))) == (3,)
 
       b4 = Flux.Bilinear(3,3,7; bias=1:7, init=Flux.zeros)
-      @test  b4.bias isa Vector{Float32}
+      @test_skip  b4.bias isa Vector{Float32}
 
       @test_throws ArgumentError Flux.Bilinear(rand(3)) # expects a 3-array
       @test_throws ArgumentError Flux.Bilinear(rand(3,4), false, tanh)

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -194,7 +194,7 @@ end
   @test fun(rand(2,3,4,5), false).bias isa Flux.Zeros
   if fun == Conv
     @test fun(rand(2,3,4,5,6), rand(6)).bias isa Vector{Float64}
-    @test fun(rand(2,3,4,5,6), 1:6).bias isa Vector{Float64}
+    @test_skip fun(rand(2,3,4,5,6), 1:6).bias isa Vector{Float64}
   elseif fun == DepthwiseConv
     @test fun(rand(2,3,4,5,6), rand(30)).bias isa Vector{Float64}
   end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -342,7 +342,7 @@ end
   testdense(m, bt) = @testset "Check layer $i" for (i, (l1, l2)) in enumerate(zip(m, dm(bt)))
     @test l1.W == l2.W
     @test l1.b == l2.b
-    @test typeof(l1.b) === typeof(l2.b)
+    @test_skip typeof(l1.b) === typeof(l2.b)
   end
 
   @testset "loadparams!" begin


### PR DESCRIPTION
Fix #1556, closes #1557. 

Tests of this conversion behaviour are left skipped for now, that seems the minimal step. Perhaps friendly warnings if you're about to accidentally promote to Float64 can be combined with not rejecting tracking types. But that need not be designed in a rush. 

The complete solution of #1556 should include tests of gradients through the `re` of `destructure`. At the moment it is (I think) only tested alongside `loadparams!` as an "offline" utility, but clearly it's also useful to map a vector of parameters to a model inside a solver, etc. Perhaps it can be made faster, too. 