### PR TITLE
Revert #1557 temporarily

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
This reverts the changes from #1557. I think some of those changes are good, but there were some reservations expressed. Since the changes aren't pressing, let's discuss them instead. We can merge this PR to revert, then open another for the changes from #1557.

### PR Checklist

- [x] ~~Tests are added~~
- [x] ~~Entry in NEWS.md~~
- [x] ~~Documentation, if applicable~~
- [x] ~~API changes require approval from a committer (different from the author, if applicable)~~
