### PR TITLE
Add a dropout_mask method for ComplexF64 array types

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -46,6 +46,12 @@ function dropout_mask(x, p; dims=:)
   return y
 end
 
+function dropout_mask(x::Array{Complex{Float64}}, p; dims=:)
+  y = rand!(similar(x, Float64, _dropout_shape(x, dims)))
+  y .= _dropout_kernel.(y, p, 1 - p)
+  return y
+end
+
 """
     Dropout(p; dims=:)
 

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -4,7 +4,7 @@ using Zygote: pullback
 evalwgrad(f, x...) = pullback(f, x...)[1]
 
 @testset "Dropout" begin
-  x = [1.+0im,2.+1im,3.+3im]
+  x = [1.0+0im,2.0+1im,3.0+3im]
   @test x == Dropout(0.1)(x)
   @test x == evalwgrad(Dropout(0), x)
   @test zero(x) == evalwgrad(Dropout(1), x)

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -4,6 +4,11 @@ using Zygote: pullback
 evalwgrad(f, x...) = pullback(f, x...)[1]
 
 @testset "Dropout" begin
+  x = [1.+0im,2.+1im,3.+3im]
+  @test x == Dropout(0.1)(x)
+  @test x == evalwgrad(Dropout(0), x)
+  @test zero(x) == evalwgrad(Dropout(1), x)
+  
   x = [1.,2.,3.]
   @test x == Dropout(0.1)(x)
   @test x == evalwgrad(Dropout(0), x)


### PR DESCRIPTION
Calling _similar_ with a type argument makes dropout work for complex valued networks as well.
Currently using dropout in a complex valued network will fail with the error:

`ERROR: MethodError: no method matching isless(::Float64, ::Complex{Float64})`

This change adds a dropout_mask method for complex arrays with a call to similar with Float64 type.

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
