### PR TITLE
placeholder adjoint for params

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.12.7"
+version = "0.12.8"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -56,7 +56,7 @@ end
 
 @adjoint function params(m...)
   params_pullback(Δ::Nothing) = nothing
-  params_pullback(Δ) = (println(Δ); error("derivations through params not supported yet"))
+  params_pullback(Δ) = (println(Δ); error("derivation through `params` not supported yet"))
   params(m...), params_pullback
 end
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -54,6 +54,12 @@ function params(m...)
   return ps
 end
 
+@adjoint function params(m...)
+  params_pullback(Δ::Nothing) = nothing
+  params_pullback(Δ) = (println(Δ); error("derivations through params not supported yet"))
+  params(m...), params_pullback
+end
+
 function loadparams!(m, xs)
   for (p, x) in zip(params(m), xs)
     size(p) == size(x) ||

--- a/test/functor.jl
+++ b/test/functor.jl
@@ -1,0 +1,8 @@
+@testset "use params in gradient context"
+    m = Chain(Dense(3,2), Dense(2,2))
+    ps = Flux.params()
+    gs = gradient(() -> sum(sum(p) for p in Flux.params(m)), ps)
+    for p in ps
+        @test gs[p] ≈ ones(size(p))
+    end    
+begin

--- a/test/functor.jl
+++ b/test/functor.jl
@@ -20,4 +20,4 @@
 
     gs = gradient(() -> sum(params(m)[1]), params(m))
     @test_broken gs[params(m)[1]] !== nothing
-begin
+end

--- a/test/functor.jl
+++ b/test/functor.jl
@@ -1,4 +1,4 @@
-@testset "use params in gradient context"
+@testset "use params in gradient context" begin
     m = Chain(Dense(3,2), Dense(2,2))
     ps = Flux.params()
     gs = gradient(() -> sum(sum(p) for p in Flux.params(m)), ps)

--- a/test/functor.jl
+++ b/test/functor.jl
@@ -5,4 +5,19 @@
     for p in ps
         @test gs[p] ≈ ones(size(p))
     end    
+
+    w1, w2 =  rand(2), rand(2)
+    ps = Flux.params(w1, w2)
+    gs = gradient(() -> sum(sum(p) for p in Flux.params(w1, w2)), ps)
+    for p in ps
+        @test gs[p] ≈ ones(size(p))
+    end
+
+    # BROKEN TESTS
+    m = Chain(Dense(3,2), Dense(2,2))
+    @test_broken gradient(m -> sum(params(m)[1]), m) != (nothing, )
+    @test_broken gradient(m -> sum(params(m)[1]), m) != (nothing, )
+
+    gs = gradient(() -> sum(params(m)[1]), params(m))
+    @test_broken gs[params(m)[1]] !== nothing
 begin

--- a/test/functor.jl
+++ b/test/functor.jl
@@ -1,6 +1,6 @@
 @testset "use params in gradient context" begin
     m = Chain(Dense(3,2), Dense(2,2))
-    ps = Flux.params()
+    ps = Flux.params(m)
     gs = gradient(() -> sum(sum(p) for p in Flux.params(m)), ps)
     for p in ps
         @test gs[p] ≈ ones(size(p))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,10 @@ end
   include("outputsize.jl")
 end
 
+@testset "functor" begin
+  include("functor.jl")
+end
+
 @testset "CUDA" begin
   if CUDA.functional()
     include("cuda/runtests.jl")


### PR DESCRIPTION
Fix #1588, Fix https://github.com/FluxML/Zygote.jl/issues/941

Conservative version of #1590, which throws an error when the pullback receives a not-nothing sensitivity. 
This is strictly better than what we currently have, fixes a relevant issue without introducing any regression. 

Unfortunately, there are some corner cases, marked as `broken_tests` that this does not address. I could not manage to trigger the `params_pullback` branch throwing the error: the pullback always receives `nothing` which seems a little odd to me. 
