### PR TITLE
added support for reduce(hcat, OneHotMatrix)

### DIFF
--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -76,10 +76,12 @@ Base.hcat(x::OneHotLike, xs::OneHotLike...) = cat(x, xs...; dims = 2)
 Base.vcat(x::OneHotLike, xs::OneHotLike...) = cat(x, xs...; dims = 1)
 
 # optimized concatenation for matrices and vectors of same parameters
-Base.hcat(x::T, xs::T...) where {L, T <: OneHotLike{<:Any, L, <:Any, 2}} =
-  OneHotMatrix(reduce(vcat, _indices.(xs); init = _indices(x)), L)
 Base.hcat(x::T, xs::T...) where {L, T <: OneHotLike{<:Any, L, <:Any, 1}} =
   OneHotMatrix(reduce(vcat, _indices.(xs); init = _indices(x)), L)
+
+function Base.reduce(::typeof(hcat), xs::Vector{TV})  where {T, L, TV<:OneHotLike{T, L}}
+  OneHotMatrix(reduce(vcat, map(_indices, xs)), L)
+end
 
 batch(xs::AbstractArray{<:OneHotVector{<:Any, L}}) where L = OneHotArray(_indices.(xs), L)
 

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -98,6 +98,11 @@ end
     @test cat(oa, oa; dims = 3) isa OneHotArray
     @test cat(oa, oa; dims = 1) == cat(collect(oa), collect(oa); dims = 1)
 
+    # reduce hcat 
+    @test reduce(hcat, [ov, ov]) == OneHotMatrix(vcat(ov.indices, ov.indices), 10)
+    @test reduce(hcat, [om, om]) == OneHotMatrix(vcat(om.indices, om.indices), 10)
+    @test reduce(hcat, [ov, om]) == OneHotMatrix(vcat(ov.indices, om.indices), 10)
+
     # proper error handling of inconsistent sizes
     @test_throws DimensionMismatch hcat(ov, ov2)
     @test_throws DimensionMismatch hcat(om, om2)


### PR DESCRIPTION
[Please delete this text and describe your change here.
For bugfixes, please detail the bug and include a test case which your patch fixes.
If you are adding a new feature, please clearly describe the design, its rationale, the possible alternatives considered.
It is easiest to merge new features when there is clear precedent in other systems; we need to know we're taking
the right direction since it can be hard to change later.]

This fixes a bug
https://github.com/FluxML/Flux.jl/issues/1596
by adding `reduce(::typeof(hcat), Vector{TV}) where {TV<:OneHotLike}`

### PR Checklist

- [x ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
