### PR TITLE
Update docstring for `Conv` to clarify feature dimensions

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -42,7 +42,7 @@ and a batch of 50 would be a `100×100×3×50` array.
 This has `N=2` spatial dimensions, and needs a kernel size like `(5,5)`,
 a 2-tuple of integers.
 
-To take convolutions along `N` dimensions, this layer expects as input an array
+To take convolutions along `N` feature dimensions, this layer expects as input an array
 with `ndims(x) == N+2`, where `size(x, N+1) == in` is the number of input channels,
 and `size(x, ndims(x))` is (as always) the number of observations in a batch.
 Then:

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -41,7 +41,7 @@ In other words, a 100×100 RGB image would be a `100×100×3×1` array,
 and a batch of 50 would be a `100×100×3×50` array.
 This has `N=2` spatial dimensions, and needs a kernel size like `(5,5)`,
 a 2-tuple of integers. For different `N`, data should be `N_1 x N_2 x ... x N_n x channels x batch`,
-i.e. `spatial/temporal dimensions x channels x batch`.
+i.e. `spatial/temporal dimensions x channels x batch` (notice that the batch is the last dimension).
 
 For `N` spatial dimensions, this layer expects as input an array
 with `ndims(x) == N+2`, where `size(x,N+1) == in` is the number of channels.

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -40,11 +40,11 @@ Image data should be stored in WHCN order (width, height, channels, batch).
 In other words, a 100×100 RGB image would be a `100×100×3×1` array,
 and a batch of 50 would be a `100×100×3×50` array.
 This has `N=2` spatial dimensions, and needs a kernel size like `(5,5)`,
-a 2-tuple of integers. For different `N`, data should be `N_1 x N_2 x ... x N_n x channels x batch`,
-i.e. `spatial/temporal dimensions x channels x batch` (notice that the batch is the last dimension).
+a 2-tuple of integers.
 
-For `N` spatial dimensions, this layer expects as input an array
-with `ndims(x) == N+2`, where `size(x,N+1) == in` is the number of channels.
+For `N` dimensional data, this layer expects as input an array
+with `ndims(x) == N+2`, where `size(x,N+1) == in` is the number of input channels,
+and the last dimension is `size(x,N+2) == batches`.
 Then:
 * `filter` should be a tuple of `N` integers.
 * Keywords `stride` and `dilation` should each be either single integer,

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -43,8 +43,8 @@ This has `N=2` spatial dimensions, and needs a kernel size like `(5,5)`,
 a 2-tuple of integers.
 
 To take convolutions along `N` dimensions, this layer expects as input an array
-with `ndims(x) == N+2`, where `size(x,N+1) == in` is the number of input channels,
-and the last dimension is `size(x,N+2) == batches`.
+with `ndims(x) == N+2`, where `size(x, N+1) == in` is the number of input channels,
+and `size(x, ndims(x))` is (as always) the number of observations in a batch.
 Then:
 * `filter` should be a tuple of `N` integers.
 * Keywords `stride` and `dilation` should each be either single integer,

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -42,7 +42,7 @@ and a batch of 50 would be a `100×100×3×50` array.
 This has `N=2` spatial dimensions, and needs a kernel size like `(5,5)`,
 a 2-tuple of integers.
 
-For `N` dimensional data, this layer expects as input an array
+To take convolutions along `N` dimensions, this layer expects as input an array
 with `ndims(x) == N+2`, where `size(x,N+1) == in` is the number of input channels,
 and the last dimension is `size(x,N+2) == batches`.
 Then:

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -40,7 +40,8 @@ Image data should be stored in WHCN order (width, height, channels, batch).
 In other words, a 100×100 RGB image would be a `100×100×3×1` array,
 and a batch of 50 would be a `100×100×3×50` array.
 This has `N=2` spatial dimensions, and needs a kernel size like `(5,5)`,
-a 2-tuple of integers.
+a 2-tuple of integers. For different `N`, data should be `N_1 x N_2 x ... x N_n x channels x batch`,
+i.e. `spatial/temporal dimensions x channels x batch`.
 
 For `N` spatial dimensions, this layer expects as input an array
 with `ndims(x) == N+2`, where `size(x,N+1) == in` is the number of channels.


### PR DESCRIPTION
Specifying the format of the data given to the convolutional layer, as mentioned in #1465 .