### PR TITLE
Print channel dimensions of `Dense` like those of `Conv`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ been removed in favour of MLDatasets.jl.
 * `flatten` is not exported anymore due to clash with Iterators.flatten.
 * Remove Juno.jl progress bar support as it is now obsolete.
 * `Dropout` gained improved compatibility with Int and Complex arrays and is now twice-differentiable.
+* Notation `Dense(2 => 3, σ)` for channels matches `Conv`; the equivalent `Dense(2, 3, σ)` still works.
 * Many utily functions and the `DataLoader` are [now provided by MLUtils.jl](https://github.com/FluxML/Flux.jl/pull/1874).
 * The DataLoader is now compatible with generic dataset types implementing `MLUtils.numobs` and `MLUtils.getobs`.
 * Added [truncated normal initialisation](https://github.com/FluxML/Flux.jl/pull/1877) of weights.

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -39,12 +39,12 @@ Note that we convert both the parameters (`W`, `b`) and the data set (`x`, `y`) 
 If you define a structured model, like a `Dense` layer or `Chain`, you just need to convert the internal parameters. Flux provides `fmap`, which allows you to alter all parameters of a model at once.
 
 ```julia
-d = Dense(10, 5, σ)
+d = Dense(10 => 5, σ)
 d = fmap(cu, d)
 d.weight # CuArray
 d(cu(rand(10))) # CuArray output
 
-m = Chain(Dense(10, 5, σ), Dense(5, 2), softmax)
+m = Chain(Dense(10 => 5, σ), Dense(5 => 2), softmax)
 m = fmap(cu, m)
 d(cu(rand(10)))
 ```
@@ -54,8 +54,8 @@ As a convenience, Flux provides the `gpu` function to convert models and data to
 ```julia
 julia> using Flux, CUDA
 
-julia> m = Dense(10,5) |> gpu
-Dense(10, 5)
+julia> m = Dense(10, 5) |> gpu
+Dense(10 => 5)
 
 julia> x = rand(10) |> gpu
 10-element CuArray{Float32,1}:

--- a/docs/src/models/advanced.md
+++ b/docs/src/models/advanced.md
@@ -74,10 +74,10 @@ this using the slicing features `Chain` provides:
 
 ```julia
 m = Chain(
-      Dense(784, 64, relu),
-      Dense(64, 64, relu),
-      Dense(32, 10)
-    )
+      Dense(784 => 64, relu),
+      Dense(64 => 64, relu),
+      Dense(32 => 10)
+    );
 
 ps = Flux.params(m[3:end])
 ```
@@ -142,10 +142,11 @@ Lastly, we can test our new layer. Thanks to the proper abstractions in Julia, o
 ```julia
 model = Chain(
               Join(vcat,
-                   Chain(Dense(1, 5),Dense(5, 1)), # branch 1
-                   Dense(1, 2),                    # branch 2
-                   Dense(1, 1)),                   # branch 3
-              Dense(4, 1)
+                   Chain(Dense(1 => 5, relu), Dense(5 => 1)), # branch 1
+                   Dense(1 => 2),                             # branch 2
+                   Dense(1 => 1)                              # branch 3
+                  ),
+              Dense(4 => 1)
              ) |> gpu
 
 xs = map(gpu, (rand(1), rand(1), rand(1)))
@@ -164,11 +165,11 @@ Join(combine, paths...) = Join(combine, paths)
 # use vararg/tuple version of Parallel forward pass
 model = Chain(
               Join(vcat,
-                   Chain(Dense(1, 5),Dense(5, 1)),
-                   Dense(1, 2),
-                   Dense(1, 1)
+                   Chain(Dense(1 => 5, relu), Dense(5 => 1)),
+                   Dense(1 => 2),
+                   Dense(1 => 1)
                   ),
-              Dense(4, 1)
+              Dense(4 => 1)
              ) |> gpu
 
 xs = map(gpu, (rand(1), rand(1), rand(1)))
@@ -201,8 +202,8 @@ Flux.@functor Split
 Now we can test to see that our `Split` does indeed produce multiple outputs.
 ```julia
 model = Chain(
-              Dense(10, 5),
-              Split(Dense(5, 1),Dense(5, 3),Dense(5, 2))
+              Dense(10 => 5),
+              Split(Dense(5 => 1, tanh), Dense(5 => 3, tanh), Dense(5 => 2))
              ) |> gpu
 
 model(gpu(rand(10)))

--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -158,14 +158,14 @@ a(rand(10)) # => 5-element vector
 
 Congratulations! You just built the `Dense` layer that comes with Flux. Flux has many interesting layers available, but they're all things you could have built yourself very easily.
 
-(There is one small difference with `Dense` – for convenience it also takes an activation function, like `Dense(10, 5, σ)`.)
+(There is one small difference with `Dense` – for convenience it also takes an activation function, like `Dense(10 => 5, σ)`.)
 
 ## Stacking It Up
 
 It's pretty common to write models that look something like:
 
 ```julia
-layer1 = Dense(10, 5, σ)
+layer1 = Dense(10 => 5, σ)
 # ...
 model(x) = layer3(layer2(layer1(x)))
 ```
@@ -175,7 +175,7 @@ For long chains, it might be a bit more intuitive to have a list of layers, like
 ```julia
 using Flux
 
-layers = [Dense(10, 5, σ), Dense(5, 2), softmax]
+layers = [Dense(10 => 5, σ), Dense(5 => 2), softmax]
 
 model(x) = foldl((x, m) -> m(x), layers, init = x)
 
@@ -186,8 +186,8 @@ Handily, this is also provided for in Flux:
 
 ```julia
 model2 = Chain(
-  Dense(10, 5, σ),
-  Dense(5, 2),
+  Dense(10 => 5, σ),
+  Dense(5 => 2),
   softmax)
 
 model2(rand(10)) # => 2-element vector
@@ -198,7 +198,7 @@ This quickly starts to look like a high-level deep learning library; yet you can
 A nice property of this approach is that because "models" are just functions (possibly with trainable parameters), you can also see this as simple function composition.
 
 ```julia
-m = Dense(5, 2) ∘ Dense(10, 5, σ)
+m = Dense(5 => 2) ∘ Dense(10 => 5, σ)
 
 m(rand(10))
 ```

--- a/docs/src/models/overview.md
+++ b/docs/src/models/overview.md
@@ -43,8 +43,8 @@ Normally, your training and test data come from real world observations, but thi
 Now, build a model to make predictions with `1` input and `1` output:
 
 ```julia
-julia> model = Dense(1, 1)
-Dense(1, 1)
+julia> model = Dense(1 => 1)
+Dense(1 => 1)
 
 julia> model.weight
 1×1 Matrix{Float32}:
@@ -58,10 +58,10 @@ julia> model.bias
 Under the hood, a dense layer is a struct with fields `weight` and `bias`. `weight` represents a weights' matrix and `bias` represents a bias vector. There's another way to think about a model. In Flux, *models are conceptually predictive functions*: 
 
 ```julia
-julia> predict = Dense(1, 1)
+julia> predict = Dense(1 => 1)
 ```
 
-`Dense(1, 1)` also implements the function `σ(Wx+b)` where `W` and `b` are the weights and biases. `σ` is an activation function (more on activations later). Our model has one weight and one bias, but typical models will have many more. Think of weights and biases as knobs and levers Flux can use to tune predictions. Activation functions are transformations that tailor models to your needs. 
+`Dense(1 => 1)` also implements the function `σ(Wx+b)` where `W` and `b` are the weights and biases. `σ` is an activation function (more on activations later). Our model has one weight and one bias, but typical models will have many more. Think of weights and biases as knobs and levers Flux can use to tune predictions. Activation functions are transformations that tailor models to your needs. 
 
 This model will already make predictions, though not accurate ones yet:
 
@@ -185,7 +185,7 @@ The predictions are good. Here's how we got there.
 
 First, we gathered real-world data into the variables `x_train`, `y_train`, `x_test`, and `y_test`. The `x_*` data defines inputs, and the `y_*` data defines outputs. The `*_train` data is for training the model, and the `*_test` data is for verifying the model. Our data was based on the function `4x + 2`.
 
-Then, we built a single input, single output predictive model, `predict = Dense(1, 1)`. The initial predictions weren't accurate, because we had not trained the model yet.
+Then, we built a single input, single output predictive model, `predict = Dense(1 => 1)`. The initial predictions weren't accurate, because we had not trained the model yet.
 
 After building the model, we trained it with `train!(loss, parameters, data, opt)`. The loss function is first, followed by the `parameters` holding the weights and biases of the model, the training data, and the `Descent` optimizer provided by Flux. We ran the training step once, and observed that the parameters changed and the loss went down. Then, we ran the `train!` many times to finish the training process.
 

--- a/docs/src/models/recurrence.md
+++ b/docs/src/models/recurrence.md
@@ -74,7 +74,7 @@ Equivalent to the `RNN` stateful constructor, `LSTM` and `GRU` are also availabl
 Using these tools, we can now build the model shown in the above diagram with: 
 
 ```julia
-m = Chain(RNN(2, 5), Dense(5, 1))
+m = Chain(RNN(2, 5), Dense(5 => 1))
 ```
 In this example, each output has only one component.
 

--- a/docs/src/models/regularisation.md
+++ b/docs/src/models/regularisation.md
@@ -9,7 +9,7 @@ For example, say we have a simple regression.
 ```julia
 using Flux
 using Flux.Losses: logitcrossentropy
-m = Dense(10, 5)
+m = Dense(10 => 5)
 loss(x, y) = logitcrossentropy(m(x), y)
 ```
 
@@ -39,9 +39,9 @@ Here's a larger example with a multi-layer perceptron.
 
 ```julia
 m = Chain(
-  Dense(28^2, 128, relu),
-  Dense(128, 32, relu),
-  Dense(32, 10))
+  Dense(28^2 => 128, relu),
+  Dense(128 => 32, relu),
+  Dense(32 => 10))
 
 sqnorm(x) = sum(abs2, x)
 
@@ -55,8 +55,8 @@ One can also easily add per-layer regularisation via the `activations` function:
 ```julia
 julia> using Flux: activations
 
-julia> c = Chain(Dense(10, 5, σ), Dense(5, 2), softmax)
-Chain(Dense(10, 5, σ), Dense(5, 2), softmax)
+julia> c = Chain(Dense(10 => 5, σ), Dense(5 => 2), softmax)
+Chain(Dense(10 => 5, σ), Dense(5 => 2), softmax)
 
 julia> activations(c, rand(10))
 3-element Array{Any,1}:

--- a/docs/src/saving.md
+++ b/docs/src/saving.md
@@ -11,8 +11,8 @@ julia> using Flux
 
 julia> model = Chain(Dense(10, 5, NNlib.relu), Dense(5, 2), NNlib.softmax)
 Chain(
-  Dense(10, 5, relu),                   # 55 parameters
-  Dense(5, 2),                          # 12 parameters
+  Dense(10 => 5, relu),                 # 55 parameters
+  Dense(5 => 2),                        # 12 parameters
   NNlib.softmax,
 )                   # Total: 4 arrays, 67 parameters, 524 bytes.
 
@@ -32,8 +32,8 @@ julia> @load "mymodel.bson" model
 
 julia> model
 Chain(
-  Dense(10, 5, relu),                   # 55 parameters
-  Dense(5, 2),                          # 12 parameters
+  Dense(10 => 5, relu),                 # 55 parameters
+  Dense(5 => 2),                        # 12 parameters
   NNlib.softmax,
 )                   # Total: 4 arrays, 67 parameters, 524 bytes.
 
@@ -59,7 +59,7 @@ model parameters.
 ```Julia
 julia> using Flux
 
-julia> model = Chain(Dense(10,5,relu),Dense(5,2),softmax)
+julia> model = Chain(Dense(10 => 5,relu),Dense(5 => 2),softmax)
 Chain(Dense(10, 5, NNlib.relu), Dense(5, 2), NNlib.softmax)
 
 julia> weights = Flux.params(model);
@@ -74,7 +74,7 @@ You can easily load parameters back into a model with `Flux.loadparams!`.
 ```julia
 julia> using Flux
 
-julia> model = Chain(Dense(10,5,relu),Dense(5,2),softmax)
+julia> model = Chain(Dense(10 => 5,relu),Dense(5 => 2),softmax)
 Chain(Dense(10, 5, NNlib.relu), Dense(5, 2), NNlib.softmax)
 
 julia> using BSON: @load
@@ -94,7 +94,7 @@ In longer training runs it's a good idea to periodically save your model, so tha
 using Flux: throttle
 using BSON: @save
 
-m = Chain(Dense(10,5,relu),Dense(5,2),softmax)
+m = Chain(Dense(10 => 5, relu), Dense(5 => 2), softmax)
 
 evalcb = throttle(30) do
   # Show loss

--- a/docs/src/training/training.md
+++ b/docs/src/training/training.md
@@ -47,8 +47,8 @@ We can also define an objective in terms of some model:
 
 ```julia
 m = Chain(
-  Dense(784, 32, σ),
-  Dense(32, 10), softmax)
+  Dense(784 => 32, σ),
+  Dense(32 => 10), softmax)
 
 loss(x, y) = Flux.Losses.mse(m(x), y)
 ps = Flux.params(m)

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -92,7 +92,7 @@ function make_model(width, height, inchannels, nclasses;
 
   # the input dimension to Dense is programatically calculated from
   #  width, height, and nchannels
-  return Chain(conv_layers..., Dense(prod(conv_outsize), nclasses))
+  return Chain(conv_layers..., Dense(prod(conv_outsize) => nclasses))
 end
 ```
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -16,4 +16,14 @@ ones32(::Type, dims...) = throw(ArgumentError("Flux.ones32 is always Float32, us
 zeros32(::Type, dims...) = throw(ArgumentError("Flux.zeros32 is always Float32, use Base.zeros to specify the element type"))
 
 # v0.13 deprecations
+
 @deprecate frequencies(xs) group_counts(xs)
+
+# Channel notation: Changed to match Conv, but very softly deprecated!
+# Perhaps change to @deprecate for v0.14, but there is no plan to remove these.
+Dense(in::Integer, out::Integer, σ = identity; kw...) =
+  Dense(in => out, σ; kw...)
+Bilinear(in1::Integer, in2::Integer, out::Integer, σ = identity; kw...) =
+  Bilinear((in1, in2) => out, σ; kw...)
+Embedding(in::Integer, out::Integer; kw...) = Embedding(in => out; kw...)
+

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -99,6 +99,7 @@ extraChain(::Tuple{}, x) = ()
 
 """
     Dense(in => out, σ=identity; bias=true, init=glorot_uniform)
+    Dense(in, out, [σ; keywords...])
     Dense(W::AbstractMatrix, [bias, σ])
 
 Create a traditional `Dense` layer, whose forward pass is given by:
@@ -117,7 +118,7 @@ The weight matrix and/or the bias vector (of length `out`) may also be provided 
 
 # Examples
 ```jldoctest
-julia> d = Dense(5, 2)
+julia> d = Dense(5 => 2)
 Dense(5 => 2)       # 12 parameters
 
 julia> d(rand(Float32, 5, 64)) |> size

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -149,8 +149,7 @@ struct Dense{F, M<:AbstractMatrix, B}
 end
 
 function Dense((in, out)::Pair{<:Integer, <:Integer}, σ = identity;
-               initW = nothing, initb = nothing,
-               init = glorot_uniform, bias=true)
+               init = glorot_uniform, bias = true)
   Dense(init(out, in), bias, σ)
 end
 
@@ -525,7 +524,7 @@ Embedding((in, out)::Pair{<:Integer, <:Integer}; init = randn32) = Embedding(ini
 (m::Embedding)(x::AbstractArray) = reshape(m(vec(x)), :, size(x)...)
 
 function (m::Embedding)(x::Union{OneHotVector{T,L}, OneHotMatrix{T,L}}) where {T,L}
-    size(m.weight, 2) == L || throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(m.weight, 2)) != $L"))
+  size(m.weight, 2) == L || throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(m.weight, 2)) != $L"))
   return m(onecold(x))
 end
  

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -98,7 +98,7 @@ extraChain(::Tuple{}, x) = ()
 
 
 """
-    Dense(in, out, σ=identity; bias=true, init=glorot_uniform)
+    Dense(in => out, σ=identity; bias=true, init=glorot_uniform)
     Dense(W::AbstractMatrix, [bias, σ])
 
 Create a traditional `Dense` layer, whose forward pass is given by:
@@ -118,7 +118,7 @@ The weight matrix and/or the bias vector (of length `out`) may also be provided 
 # Examples
 ```jldoctest
 julia> d = Dense(5, 2)
-Dense(5, 2)         # 12 parameters
+Dense(5 => 2)       # 12 parameters
 
 julia> d(rand(Float32, 5, 64)) |> size
 (2, 64)
@@ -127,7 +127,7 @@ julia> d(rand(Float32, 5, 1, 1, 64)) |> size  # treated as three batch dimension
 (2, 1, 1, 64)
 
 julia> d1 = Dense(ones(2, 5), false, tanh)  # using provided weight matrix
-Dense(5, 2, tanh; bias=false)  # 10 parameters
+Dense(5 => 2, tanh; bias=false)  # 10 parameters
 
 julia> d1(ones(5))
 2-element Vector{Float64}:
@@ -148,9 +148,11 @@ struct Dense{F, M<:AbstractMatrix, B}
   end
 end
 
-function Dense(in::Integer, out::Integer, σ = identity;
-               init = glorot_uniform, bias=true)
+Dense(in::Integer, out::Integer, σ = identity; kw...) = Dense(in => out, σ; kw...)
 
+function Dense((in, out)::Pair{<:Integer, <:Integer}, σ = identity;
+               initW = nothing, initb = nothing,
+               init = glorot_uniform, bias=true)
   Dense(init(out, in), bias, σ)
 end
 
@@ -166,7 +168,7 @@ end
   reshape(a(reshape(x, size(x,1), :)), :, size(x)[2:end]...)
 
 function Base.show(io::IO, l::Dense)
-  print(io, "Dense(", size(l.weight, 2), ", ", size(l.weight, 1))
+  print(io, "Dense(", size(l.weight, 2), " => ", size(l.weight, 1))
   l.σ == identity || print(io, ", ", l.σ)
   l.bias == Zeros() && print(io, "; bias=false")
   print(io, ")")
@@ -410,9 +412,9 @@ and [`Maxout`](@ref) which reduces by broadcasting `max`.
 # Examples
 
 ```jldoctest
-julia> model = Chain(Dense(3, 5),
-                     Parallel(vcat, Dense(5, 4), Chain(Dense(5, 7), Dense(7, 4))),
-                     Dense(8, 17));
+julia> model = Chain(Dense(3 => 5),
+                     Parallel(vcat, Dense(5 => 4), Chain(Dense(5 => 7), Dense(7 => 4))),
+                     Dense(8 => 17));
 
 julia> model(rand(3)) |> size
 (17,)
@@ -420,8 +422,8 @@ julia> model(rand(3)) |> size
 julia> model2 = Parallel(+; α = Dense(10, 2, tanh), β = Dense(5, 2))
 Parallel(
   +,
-  α = Dense(10, 2, tanh),               # 22 parameters
-  β = Dense(5, 2),                      # 12 parameters
+  α = Dense(10 => 2, tanh),             # 22 parameters
+  β = Dense(5 => 2),                    # 12 parameters
 )                   # Total: 4 arrays, 34 parameters, 392 bytes.
 
 julia> model2(rand(10), rand(5)) |> size

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -360,8 +360,11 @@ end
 
 @functor Bilinear
 
-Bilinear(((in1, in2), out)::Pair{<:Tuple, <:Integer}, σ = identity; kw...) = Bilinear(in1, in2, out, σ; kw...)
-Bilinear((in12, out)::Pair{<:Integer, <:Integer}, σ = identity; kw...) = Bilinear(in12, in12, out, σ; kw...)
+function Bilinear(((in1, in2), out)::Pair{<:Tuple, <:Integer}, σ = identity;
+                  bias = true, init = glorot_uniform)
+  Bilinear(init(out, in1, in2), bias, σ)
+end
+Bilinear((in12, out)::Pair{<:Integer, <:Integer}, σ = identity; kw...) = Bilinear((in12, in12) => out, σ; kw...)
 
 function (a::Bilinear)(x::AbstractMatrix, y::AbstractMatrix)
   W, b, σ = a.weight, a.bias, a.σ

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -14,15 +14,15 @@ julia> m = Chain(x -> x^2, x -> x+1);
 julia> m(5) == 26
 true
 
-julia> m = Chain(Dense(10, 5, tanh), Dense(5, 2));
+julia> m = Chain(Dense(10 => 5, tanh), Dense(5 => 2));
 
 julia> x = rand(10, 32);
 
 julia> m(x) == m[2](m[1](x))
 true
 
-julia> m2 = Chain(enc = Chain(Flux.flatten, Dense(10, 5, tanh)), 
-                  dec = Dense(5, 2));
+julia> m2 = Chain(enc = Chain(Flux.flatten, Dense(10 => 5, tanh)), 
+                  dec = Dense(5 => 2));
 
 julia> m2(x) == (m2[:dec] ∘ m2[:enc])(x)
 true
@@ -339,7 +339,7 @@ julia> B(x,y) == B((x,y))  # two inputs, may be given as a tuple
 true
 
 julia> sc = SkipConnection(
-                Chain(Dense(5 => 20, tanh), Dense(20, 9, tanh)),
+                Chain(Dense(5 => 20, tanh), Dense(20 => 9, tanh)),
                 Flux.Bilinear((9, 5) => 3, bias=false),
             );  # used as the recombinator, with skip as the second input
 

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -265,9 +265,9 @@ Use [`testmode!`](@ref) during inference.
 # Examples
 ```julia
 m = Chain(
-  Dense(28^2, 64),
+  Dense(28^2 => 64),
   BatchNorm(64, relu),
-  Dense(64, 10),
+  Dense(64 => 10),
   BatchNorm(10),
   softmax)
 ```

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -55,7 +55,7 @@ _show_children(m::Maxout) = m.layers
 _show_children(p::Parallel) = (p.connection, p.layers...)
 
 for T in [
-    :Conv, :ConvTranspose, :CrossCor, :DepthwiseConv, :Dense,
+    :Conv, :ConvTranspose, :CrossCor, :DepthwiseConv, :Dense, :Bilinear,
     :BatchNorm, :LayerNorm, :InstanceNorm, :GroupNorm,
   ]
   @eval function Base.show(io::IO, m::MIME"text/plain", x::$T)

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -55,7 +55,7 @@ _show_children(m::Maxout) = m.layers
 _show_children(p::Parallel) = (p.connection, p.layers...)
 
 for T in [
-    :Conv, :ConvTranspose, :CrossCor, :DepthwiseConv, :Dense, :Bilinear,
+    :Conv, :ConvTranspose, :CrossCor, :DepthwiseConv, :Dense, :Bilinear, :Embedding,
     :BatchNorm, :LayerNorm, :InstanceNorm, :GroupNorm,
   ]
   @eval function Base.show(io::IO, m::MIME"text/plain", x::$T)

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -13,7 +13,7 @@ julia> rand(3,4,5) |> Flux.flatten |> size
 
 julia> xs = rand(Float32, 10,10,3,7);
 
-julia> m = Chain(Conv((3,3), 3=>4, pad=1), Flux.flatten, Dense(400,33));
+julia> m = Chain(Conv((3,3), 3 => 4, pad=1), Flux.flatten, Dense(400 => 33));
 
 julia> xs |> m[1] |> size
 (10, 10, 4, 7)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -587,7 +587,7 @@ Chain(
 julia> Flux.modules(m2)
 7-element Vector{Any}:
  Chain(Chain(Dense(784 => 64), BatchNorm(64, relu)), Dense(64 => 10))  # 51_018 parameters, plus 128 non-trainable
- (Chain(Dense(784 => 64), BatchNorm(64, relu)), Dense(64, 10))
+ (Chain(Dense(784 => 64), BatchNorm(64, relu)), Dense(64 => 10))
  Chain(Dense(784 => 64), BatchNorm(64, relu))  # 50_368 parameters, plus 128 non-trainable
  (Dense(784 => 64), BatchNorm(64, relu))
  Dense(784 => 64)    # 50_240 parameters

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -577,22 +577,22 @@ julia> m1 = Chain(Dense(28^2, 64), BatchNorm(64, relu));
 julia> m2 = Chain(m1, Dense(64, 10))
 Chain(
   Chain(
-    Dense(784, 64),                     # 50_240 parameters
+    Dense(784 => 64),                   # 50_240 parameters
     BatchNorm(64, relu),                # 128 parameters, plus 128
   ),
-  Dense(64, 10),                        # 650 parameters
+  Dense(64 => 10),                      # 650 parameters
 )         # Total: 6 trainable arrays, 51_018 parameters,
           # plus 2 non-trainable, 128 parameters, summarysize 200.312 KiB.
 
 julia> Flux.modules(m2)
 7-element Vector{Any}:
- Chain(Chain(Dense(784, 64), BatchNorm(64, relu)), Dense(64, 10))  # 51_018 parameters, plus 128 non-trainable
- (Chain(Dense(784, 64), BatchNorm(64, relu)), Dense(64, 10))
- Chain(Dense(784, 64), BatchNorm(64, relu))  # 50_368 parameters, plus 128 non-trainable
- (Dense(784, 64), BatchNorm(64, relu))
- Dense(784, 64)      # 50_240 parameters
+ Chain(Chain(Dense(784 => 64), BatchNorm(64, relu)), Dense(64 => 10))  # 51_018 parameters, plus 128 non-trainable
+ (Chain(Dense(784 => 64), BatchNorm(64, relu)), Dense(64, 10))
+ Chain(Dense(784 => 64), BatchNorm(64, relu))  # 50_368 parameters, plus 128 non-trainable
+ (Dense(784 => 64), BatchNorm(64, relu))
+ Dense(784 => 64)    # 50_240 parameters
  BatchNorm(64, relu)  # 128 parameters, plus 128 non-trainable
- Dense(64, 10)       # 650 parameters
+ Dense(64 => 10)     # 650 parameters
 
 julia> L2(m) = sum(sum(abs2, l.weight) for l in Flux.modules(m) if l isa Dense)
 L2 (generic function with 1 method)

--- a/test/layers/show.jl
+++ b/test/layers/show.jl
@@ -1,67 +1,67 @@
 
 @testset "layer printing" begin # 2-arg show, defined with layes
 
-  @test repr(Dense(2,3)) == "Dense(2, 3)"
-  @test repr(Chain(Dense(2,3))) == "Chain(Dense(2, 3))"
-  @test repr(Chain(lay=Dense(2,3))) == "Chain(lay = Dense(2, 3))"
+  @test repr(Dense(2,3)) == "Dense(2 => 3)"
+  @test repr(Chain(Dense(2,3))) == "Chain(Dense(2 => 3))"
+  @test repr(Chain(lay=Dense(2,3))) == "Chain(lay = Dense(2 => 3))"
 
 end
 @testset "nested model printing" begin # 3-arg show, defined in show.jl
 
-  # Dense -- has parameter count, but not inside a matrix
+  # Dense -- has parameter count, but not when inside a matrix:
 
   toplevel_dense = repr("text/plain", Dense(2,3))
-  @test occursin("Dense(2, 3)", toplevel_dense)
+  @test occursin("Dense(2 => 3)", toplevel_dense)
   @test occursin("# 9 parameters", toplevel_dense)
 
   @test Meta.isexpr(Meta.parse(toplevel_dense), :call)  # comment is ignored
 
   vector_dense = repr("text/plain", [Dense(2,3), Dense(2,3)])
-  @test occursin("Dense(2, 3)", vector_dense)
+  @test occursin("Dense(2 => 3)", vector_dense)
   @test occursin("# 9 parameters", vector_dense)
 
   matrix_dense = repr("text/plain", fill(Dense(2,3), 3, 3))
-  @test occursin("Dense(2, 3)", matrix_dense)
+  @test occursin("Dense(2 => 3)", matrix_dense)
   @test !occursin("# 9 parameters", matrix_dense)
 
   tuple_dense = repr("text/plain", tuple(Dense(2,3)))
-  @test occursin("Dense(2, 3)", tuple_dense)
+  @test occursin("Dense(2 => 3)", tuple_dense)
   @test !occursin("# 9 parameters", tuple_dense)
 
   # Chain -- gets split over lines at top level only
 
   toplevel_chain = repr("text/plain", Chain(Dense(2,3)))
-  @test occursin("Chain(\n  Dense(2, 3)", toplevel_chain)
+  @test occursin("Chain(\n  Dense(2 => 3)", toplevel_chain)
   @test occursin("# 9 parameters", toplevel_chain)
   @test !occursin("# Total:", toplevel_chain)
 
   vector_chain = repr("text/plain", [Chain(Dense(2,3)), Chain(Dense(2,3))])
-  @test occursin("Chain(Dense(2, 3))", vector_chain)
+  @test occursin("Chain(Dense(2 => 3))", vector_chain)
   @test occursin("# 9 parameters", vector_chain)
   @test !occursin("# Total:", vector_chain)
 
   matrix_chain = repr("text/plain", fill(Chain(Dense(2,3)), 3,3))
-  @test occursin("Chain(Dense(2, 3))", matrix_chain)
+  @test occursin("Chain(Dense(2 => 3))", matrix_chain)
   @test !occursin("# 9 parameters", matrix_chain)
   @test !occursin("# Total:", matrix_chain)
 
-  # ... and only long enough chains get 
+  # ... and only long enough chains get a total at the end:
 
-  longchain = Chain(Dense(2, 3), Dense(3, 4), Dense(4, 5), softmax)
+  longchain = Chain(Dense(2 => 3), Dense(3 => 4), Dense(4 => 5), softmax)
 
   toplevel_longchain = repr("text/plain", longchain)
-  @test occursin("Chain(\n  Dense(2, 3)", toplevel_longchain)
+  @test occursin("Chain(\n  Dense(2 => 3)", toplevel_longchain)
   @test occursin("# 9 parameters", toplevel_longchain)
   @test occursin("# Total: 6 arrays, 50 parameters", toplevel_longchain)
 
   vector_longchain = repr("text/plain", [longchain, longchain]) # pretty ugly in reality
-  @test occursin("Chain(Dense(2, 3)", vector_longchain)
+  @test occursin("Chain(Dense(2 => 3)", vector_longchain)
   @test occursin("# 50 parameters", vector_longchain)
   @test !occursin("# 9 parameters", vector_longchain)
   @test !occursin("# Total:", vector_longchain)
 
   matrix_longchain = repr("text/plain", fill(longchain, 3,3))
-  @test occursin("Chain(Dense(2, 3)", matrix_longchain)
+  @test occursin("Chain(Dense(2 => 3)", matrix_longchain)
   @test !occursin("# 9 parameters", matrix_longchain)
   @test !occursin("# Total:", matrix_longchain)
 


### PR DESCRIPTION
This makes it print `Dense(5 => 2)` to match e.g. `Conv((3,3), 5 => 2)`, and accept this as input. Then we consistently print channel dimensions one way, and it's a little less confusing that this is `Dense(randn(2, 5))`. 

It does not make `Dense(5, 2)` into a depwarn, because that feels like more of an imposition, to make everyone change everything. It doesn't seem too confusing to just quietly accept both. 

Since the pretty-printing of `Chain` etc. will already break people's doctests, doing this in the same release is the least annoying time to do it.