### PR TITLE
Printing & docstrings for `onehot` / `onehotbatch`

### DIFF
--- a/docs/src/data/onehot.md
+++ b/docs/src/data/onehot.md
@@ -6,15 +6,15 @@ It's common to encode categorical variables (like `true`, `false` or `cat`, `dog
 julia> using Flux: onehot, onecold
 
 julia> onehot(:b, [:a, :b, :c])
-3-element Flux.OneHotVector{3,UInt32}:
- 0
+3-element OneHotVector(::UInt32) with eltype Bool:
+ ⋅
  1
- 0
+ ⋅
 
 julia> onehot(:c, [:a, :b, :c])
-3-element Flux.OneHotVector{3,UInt32}:
- 0
- 0
+3-element OneHotVector(::UInt32) with eltype Bool:
+ ⋅
+ ⋅
  1
 ```
 
@@ -44,16 +44,16 @@ Flux.onecold
 julia> using Flux: onehotbatch
 
 julia> onehotbatch([:b, :a, :b], [:a, :b, :c])
-3×3 Flux.OneHotArray{3,2,Vector{UInt32}}:
- 0  1  0
- 1  0  1
- 0  0  0
+3×3 OneHotMatrix(::Vector{UInt32}) with eltype Bool:
+ ⋅  1  ⋅
+ 1  ⋅  1
+ ⋅  ⋅  ⋅
 
-julia> onecold(ans, [:a, :b, :c])	
-3-element Vector{Symbol}:	
- :b	
- :a	
- :b   
+julia> onecold(ans, [:a, :b, :c])
+3-element Vector{Symbol}:
+ :b
+ :a
+ :b
 ```
 
 Note that these operations returned `OneHotVector` and `OneHotMatrix` rather than `Array`s. `OneHotVector`s behave like normal vectors but avoid any unnecessary cost compared to using an integer index directly. For example, multiplying a matrix with a one-hot vector simply slices out the relevant row of the matrix under the hood.

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -106,9 +106,9 @@ of label smoothing to binary distributions encoded in a single number.
 # Example
 ```jldoctest
 julia> y = Flux.onehotbatch([1, 1, 1, 0, 1, 0], 0:1)
-2×6 Flux.OneHotArray{2,2,Vector{UInt32}}:
- 0  0  0  1  0  1
- 1  1  1  0  1  0
+2×6 OneHotMatrix(::Vector{UInt32}) with eltype Bool:
+ ⋅  ⋅  ⋅  1  ⋅  1
+ 1  1  1  ⋅  1  ⋅
 
 julia> y_smoothed = Flux.label_smoothing(y, 0.2f0)
 2×6 Matrix{Float32}:
@@ -171,10 +171,10 @@ See also: [`logitcrossentropy`](@ref), [`binarycrossentropy`](@ref), [`logitbina
 # Example
 ```jldoctest
 julia> y_label = Flux.onehotbatch([0, 1, 2, 1, 0], 0:2)
-3×5 Flux.OneHotArray{3,2,Vector{UInt32}}:
- 1  0  0  0  1
- 0  1  0  1  0
- 0  0  1  0  0
+3×5 OneHotMatrix(::Vector{UInt32}) with eltype Bool:
+ 1  ⋅  ⋅  ⋅  1
+ ⋅  1  ⋅  1  ⋅
+ ⋅  ⋅  1  ⋅  ⋅
 
 julia> y_model = softmax(reshape(-7:7, 3, 5) .* 1f0)
 3×5 Matrix{Float32}:
@@ -222,10 +222,10 @@ See also: [`binarycrossentropy`](@ref), [`logitbinarycrossentropy`](@ref), [`lab
 # Example
 ```jldoctest
 julia> y_label = Flux.onehotbatch(collect("abcabaa"), 'a':'c')
-3×7 Flux.OneHotArray{3,2,Vector{UInt32}}:
- 1  0  0  1  0  1  1
- 0  1  0  0  1  0  0
- 0  0  1  0  0  0  0
+3×7 OneHotMatrix(::Vector{UInt32}) with eltype Bool:
+ 1  ⋅  ⋅  1  ⋅  1  1
+ ⋅  1  ⋅  ⋅  1  ⋅  ⋅
+ ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅
 
 julia> y_model = reshape(vcat(-9:0, 0:9, 7.5f0), 3, 7)
 3×7 Matrix{Float32}:
@@ -280,9 +280,9 @@ julia> all(p -> 0 < p < 1, y_prob[2,:])  # else DomainError
 true
 
 julia> y_hot = Flux.onehotbatch(y_bin, 0:1)
-2×3 Flux.OneHotArray{2,2,Vector{UInt32}}:
- 0  1  0
- 1  0  1
+2×3 OneHotMatrix(::Vector{UInt32}) with eltype Bool:
+ ⋅  1  ⋅
+ 1  ⋅  1
 
 julia> Flux.crossentropy(y_prob, y_hot)
 0.43989f0

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -57,16 +57,15 @@ end
 
 # this is from /LinearAlgebra/src/diagonal.jl, official way to print the dots:
 function Base.replace_in_print_matrix(x::OneHotLike, i::Integer, j::Integer, s::AbstractString)
-    # CUDA.@allowscalar(x[i,j]) ? s : _isonehot(x) ? Base.replace_with_centered_mark(s) : s
     x[i,j] ? s : _isonehot(x) ? Base.replace_with_centered_mark(s) : s
 end
 function Base.replace_in_print_matrix(x::LinearAlgebra.AdjOrTrans{Bool, <:OneHotLike}, i::Integer, j::Integer, s::AbstractString)
-    CUDA.@allowscalar(x[i,j]) ? s : _isonehot(parent(x)) ? Base.replace_with_centered_mark(s) : s
+    x[i,j] ? s : _isonehot(parent(x)) ? Base.replace_with_centered_mark(s) : s
 end
 
-# Base.show(io::IO, x::OneHotLike) = show(io, convert(Array{Bool}, cpu(x))) # helps string(cu(y))
-
 Base.print_array(io::IO, X::OneHotLike{T, L, N, var"N+1", <:CuArray}) where {T, L, N, var"N+1"} = 
+  Base.print_array(io, cpu(X))
+Base.print_array(io::IO, X::LinearAlgebra.AdjOrTrans{Bool, <:OneHotLike{T, L, N, var"N+1", <:CuArray}}) where {T, L, N, var"N+1"} = 
   Base.print_array(io, cpu(X))
 
 _onehot_bool_type(x::OneHotLike{<:Any, <:Any, <:Any, N, <:Union{Integer, AbstractArray}}) where N = Array{Bool, N}

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -104,7 +104,7 @@ Base.argmax(x::OneHotLike; dims = Colon()) =
 
 Return a `OneHotVector` which is roughly a sparse representation of `x .== labels`.
 
-Instead of storing say `Vector{Bool}`, it stores the index of the first occourence 
+Instead of storing say `Vector{Bool}`, it stores the index of the first occurrence 
 of `x` in `labels`. If `x` is not found in labels, then it either returns `onehot(default, labels)`,
 or gives an error if no default is given.
 
@@ -145,13 +145,14 @@ end
     onehotbatch(xs, labels, [default])
 
 Returns a `OneHotMatrix` where `k`th column of the matrix is [`onehot(xs[k], labels)`](@ref onehot).
-This is a sparse matrix, which stores just a `Vector{UInt32}` containing the indices.
+This is a sparse matrix, which stores just a `Vector{UInt32}` containing the indices of the
+nonzero elements.
 
 If one of the inputs in `xs` is not found in `labels`, that column is `onehot(default, labels)`
 if `default` is given, else an error.
 
 If `xs` has more dimensions, `M = ndims(xs) > 1`, then the result is an 
-`AbstractArray{Bool, N+1}` which is one-hot along the first dimension, 
+`AbstractArray{Bool, M+1}` which is one-hot along the first dimension, 
 i.e. `result[:, k...] == onehot(xs[k...], labels)`.
 
 # Examples
@@ -176,11 +177,12 @@ onehotbatch(ls, labels, default...) = batch([onehot(l, labels, default...) for l
 """
     onecold(y, [labels])
 
-Roughly the inverse operation of [`onehot`](@ref): Finds the index of
-the largest element of `y`, or each column of `y`, and looks them up in `labels`.
+Roughly the inverse operation of [`onehot`](@ref) or [`onehotbatch`](@ref): 
+This finds the index of the largest element of `y`, or each column of `y`, 
+and looks them up in `labels`.
 
 If `labels` are not specified, the default is integers `1:size(y,1)` --
-the same as `argmax(y, dims=1)` but a different return type.
+the same operation as `argmax(y, dims=1)` but sometimes a different return type.
 
 # Examples
 ```jldoctest

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -18,26 +18,20 @@ const OneHotMatrix{T, L, I} = OneHotArray{T, L, 1, 2, I}
 OneHotVector(idx, L) = OneHotArray(idx, L)
 OneHotMatrix(indices, L) = OneHotArray(indices, L)
 
-function _show_elements(x::OneHotArray)
-  xbool = convert(Array{Bool}, cpu(x))
-  xrepr = join(split(repr(MIME("text/plain"), xbool; context= :limit => true), "\n")[2:end], "\n")
-
-  return xrepr
+function Base.showarg(io::IO, x::OneHotArray, toplevel)
+    print(io, ndims(x) == 1 ? "onehot(" : "onehotbatch(")
+    Base.showarg(io, x.indices, false)
+    print(io, ')')
+    toplevel && print(io, " with eltype Bool")
+    return nothing
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::OneHotArray{<:Any, L, <:Any, N, I}) where {L, N, I}
-  join(io, string.(size(x)), "×")
-  print(io, " Flux.OneHotArray{")
-  join(io, string.([L, N, I]), ",")
-  println(io, "}:")
-  print(io, _show_elements(x))
+# this is from /LinearAlgebra/src/diagonal.jl, official way to print the dots:
+function Base.replace_in_print_matrix(x::OneHotArray, i::Integer, j::Integer, s::AbstractString)
+    x[i,j] ? s : Base.replace_with_centered_mark(s)
 end
-function Base.show(io::IO, ::MIME"text/plain", x::OneHotVector{T, L}) where {T, L}
-  print(io, string.(length(x)))
-  print(io, "-element Flux.OneHotVector{")
-  join(io, string.([L, T]), ",")
-  println(io, "}:")
-  print(io, _show_elements(x))
+function Base.replace_in_print_matrix(x::Adjoint{Bool, <:OneHotArray}, i::Integer, j::Integer, s::AbstractString)
+    x[i,j] ? s : Base.replace_with_centered_mark(s)
 end
 
 # use this type so reshaped arrays hit fast paths

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -184,7 +184,10 @@ julia> Flux.onecold([ 1  0  0  1  0  1  0  1  0  0  1
 "abeacadabea"
 ```
 """
-onecold(y::AbstractVector, labels = 1:length(y)) = labels[argmax(y)]
+function onecold(y::AbstractVector, labels = 1:length(y))
+  length(labels) == length(y) || throw(DimensionMismatch("expected as many labels as the length of the vector"))
+  labels[argmax(y)]
+end
 function onecold(y::AbstractArray, labels = 1:size(y, 1))
   indices = _fast_argmax(y)
   xs = isbits(labels) ? indices : collect(indices) # non-bit type cannot be handled by CUDA

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -18,22 +18,6 @@ const OneHotMatrix{T, L, I} = OneHotArray{T, L, 1, 2, I}
 OneHotVector(idx, L) = OneHotArray(idx, L)
 OneHotMatrix(indices, L) = OneHotArray(indices, L)
 
-function Base.showarg(io::IO, x::OneHotArray, toplevel)
-    print(io, ndims(x) == 1 ? "OneHotVector(" : ndims(x) == 2 ? "OneHotMatrix(" : "OneHotArray(")
-    Base.showarg(io, x.indices, false)
-    print(io, ')')
-    toplevel && print(io, " with eltype Bool")
-    return nothing
-end
-
-# this is from /LinearAlgebra/src/diagonal.jl, official way to print the dots:
-function Base.replace_in_print_matrix(x::OneHotLike, i::Integer, j::Integer, s::AbstractString)
-    x[i,j] ? s : _isonehot(x) ? Base.replace_with_centered_mark(s) : s
-end
-function Base.replace_in_print_matrix(x::LinearAlgebra.AdjOrTrans{Bool, <:OneHotLike}, i::Integer, j::Integer, s::AbstractString)
-    x[i,j] ? s : _isonehot(parent(x)) ? Base.replace_with_centered_mark(s) : s
-end
-
 # use this type so reshaped arrays hit fast paths
 # e.g. argmax
 const OneHotLike{T, L, N, var"N+1", I} =
@@ -54,6 +38,22 @@ Base.getindex(x::OneHotArray, i::Integer, I...) = _onehotindex.(x.indices[I...],
 Base.getindex(x::OneHotArray{<:Any, L}, ::Colon, I...) where L = OneHotArray(x.indices[I...], L)
 Base.getindex(x::OneHotArray{<:Any, <:Any, <:Any, N}, ::Vararg{Colon, N}) where N = x
 Base.getindex(x::OneHotArray, I::CartesianIndex{N}) where N = x[I[1], Tuple(I)[2:N]...]
+
+function Base.showarg(io::IO, x::OneHotArray, toplevel)
+    print(io, ndims(x) == 1 ? "OneHotVector(" : ndims(x) == 2 ? "OneHotMatrix(" : "OneHotArray(")
+    Base.showarg(io, x.indices, false)
+    print(io, ')')
+    toplevel && print(io, " with eltype Bool")
+    return nothing
+end
+
+# this is from /LinearAlgebra/src/diagonal.jl, official way to print the dots:
+function Base.replace_in_print_matrix(x::OneHotLike, i::Integer, j::Integer, s::AbstractString)
+    x[i,j] ? s : _isonehot(x) ? Base.replace_with_centered_mark(s) : s
+end
+function Base.replace_in_print_matrix(x::LinearAlgebra.AdjOrTrans{Bool, <:OneHotLike}, i::Integer, j::Integer, s::AbstractString)
+    x[i,j] ? s : _isonehot(parent(x)) ? Base.replace_with_centered_mark(s) : s
+end
 
 _onehot_bool_type(x::OneHotLike{<:Any, <:Any, <:Any, N, <:Union{Integer, AbstractArray}}) where N = Array{Bool, N}
 _onehot_bool_type(x::OneHotLike{<:Any, <:Any, <:Any, N, <:CuArray}) where N = CuArray{Bool, N}

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -109,7 +109,7 @@ of `x` in `labels`. If `x` is not found in labels, then it either returns `oneho
 or gives an error if no default is given.
 
 See also [`onehotbatch`](@ref) to apply this to many `x`s, 
-and [`onecold`](@ref) for a `labels`-aware `argmax`.
+and [`onecold`](@ref) to reverse either of these, as well as to generalise `argmax`.
 
 # Examples
 ```jldoctest
@@ -175,7 +175,7 @@ julia> reshape(1:15, 3, 5) * oh  # this matrix multiplication is done efficientl
 onehotbatch(ls, labels, default...) = batch([onehot(l, labels, default...) for l in ls])
 
 """
-    onecold(y, [labels])
+    onecold(y::AbstractArray, labels = 1:size(y,1))
 
 Roughly the inverse operation of [`onehot`](@ref) or [`onehotbatch`](@ref): 
 This finds the index of the largest element of `y`, or each column of `y`, 

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -184,10 +184,7 @@ julia> Flux.onecold([ 1  0  0  1  0  1  0  1  0  0  1
 "abeacadabea"
 ```
 """
-function onecold(y::AbstractVector, labels = 1:length(y))
-  length(labels) == length(y) || throw(DimensionMismatch("expected as many labels as the length of the vector"))
-  labels[argmax(y)]
-end
+onecold(y::AbstractVector, labels = 1:length(y)) = labels[argmax(y)]
 function onecold(y::AbstractArray, labels = 1:size(y, 1))
   indices = _fast_argmax(y)
   xs = isbits(labels) ? indices : collect(indices) # non-bit type cannot be handled by CUDA

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -146,8 +146,8 @@ end
 """
     onehotbatch(xs, labels, [default])
 
-Returns a `OneHotMatrix` where `k`th column of the matrix is [`onehot(ls[k], labels)`](@ref onehot),
-for vector `xs`. This is a sparse matrix, which stores just `Vector{UInt32}` containing the indices.
+Returns a `OneHotMatrix` where `k`th column of the matrix is [`onehot(xs[k], labels)`](@ref onehot).
+This is a sparse matrix, which stores just a `Vector{UInt32}` containing the indices.
 
 If one of the inputs in `xs` is not found in `labels`, that column is `onehot(default, labels)`
 if `default` is given, else an error.


### PR DESCRIPTION
Right now, the printing of OneHotArray lies about its type parameters. That's pretty confusing. The standard way to hide messy details the way `view` and `adjoint` do is via `Base.showarg`, so I did that. Then I also re-used the dots which LinearAlgebra's sparse matrix printing uses: 
```
julia> Flux.onehotbatch(collect("foo"), 'a':'z')  # before
26×3 Flux.OneHotArray{26,2,Vector{UInt32}}:
 0  0  0
 0  0  0
 0  0  0
 0  0  0
 0  0  0
 1  0  0
 0  0  0
 ...
 
julia> typeof(ans)
Flux.OneHotArray{UInt32, 26, 1, 2, Vector{UInt32}}

julia> Flux.onehotbatch(collect("foo"), 'a':'z')  # after
26×3 OneHotMatrix(::Vector{UInt32}) with eltype Bool:
 ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅
 ⋅  ⋅  ⋅
 1  ⋅  ⋅
 ⋅  ⋅  ⋅
```
I've also tried to tidy up things I thought were unclear in the docstrings. E.g. it looked `unk...` was indicating that you could specify multiple defaults, but in fact the splat is just an implementation trick. And following `Base.get` perhaps it's called `default`.

Should have no functional changes at all.