### PR TITLE
Allow user to change the channel axis for BatchNorm function and the likes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # Flux Release Notes
 
 ## v0.12.4
+* Implemented [axis option for normalisation functions](https://github.com/FluxML/Flux.jl/issues/1664).
+
+## v0.12.4
 * Implemented an [`Embedding layer`](https://github.com/FluxML/Flux.jl/pull/1516) 
   based on `NNlib.gather` and `NNlib.scatter`.
 

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -276,7 +276,7 @@ function (BN::BatchNorm)(x)
   @assert size(x, dim) == BN.chs
   reduce_dims = [1:dim-1;dim+1:N]
   affine_shape = ntuple(i -> i == dim ? size(x, dim) : 1, N)
-  return _norm_layer_forward(BN, x; reduce_dims, affine_shape, dim)
+  return _norm_layer_forward(BN, x; reduce_dims, affine_shape, dim=dim)
 end
 
 testmode!(m::BatchNorm, mode=true) =
@@ -353,7 +353,7 @@ function (l::InstanceNorm)(x)
   N = ndims(x)
   reduce_dims = 1:N-2
   affine_shape = ntuple(i -> i == N-1 ? size(x, N-1) : 1, N)
-  return _norm_layer_forward(l, x; reduce_dims, affine_shape, N-1)
+  return _norm_layer_forward(l, x; reduce_dims, affine_shape, dim=N-1)
 end
 
 testmode!(m::InstanceNorm, mode=true) =

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -170,7 +170,7 @@ end
 function _norm_layer_forward(l, x::AbstractArray{T,N}; reduce_dims, affine_shape) where {T, N}
   isnothing(l.dim) ? dim = N-1 : dim = l.dim
   if !_isactive(l) && l.track_stats # testmode with tracked stats
-    stats_shape = ntuple(i -> i == dim ? size(x,dim) : 1, N)
+    stats_shape = ntuple(i -> i == dim ? size(x, dim) : 1, N)
     μ = reshape(l.μ, stats_shape)
     σ² = reshape(l.σ², stats_shape)
   else  # trainmode or testmode without tracked stats
@@ -356,7 +356,7 @@ function (l::InstanceNorm)(x)
   @assert dim < N 
   @assert size(x, dim) == l.chs
   reduce_dims = [1:dim-1;dim+2:N];
-  affine_shape = ntuple(i -> i == dim ? size(x,dim) : 1, N)
+  affine_shape = ntuple(i -> i == dim ? size(x, dim) : 1, N)
   return _norm_layer_forward(l, x; reduce_dims, affine_shape)
 end
 
@@ -442,7 +442,7 @@ function (gn::GroupNorm)(x)
   @assert dim < N 
   @assert size(x, dim) == gn.chs
   sz = size(x)
-  x = reshape(x, sz[1:dim-1]..., sz[dim]÷gn.G, gn.G, sz[N], sz[dim+2:N]...,)
+  x = reshape(x, sz[1:dim-1]..., sz[dim]÷gn.G, gn.G, sz[dim+1:N]...)
   reduce_dims = [1:dim-1;dim+2:N];
   affine_shape = ntuple(i -> i ∈ (dim, dim-1) ? size(x, i) : 1, N)
   x = _norm_layer_forward(gn, x; reduce_dims, affine_shape)


### PR DESCRIPTION
Proposition for issue #1664

This PR allows the user to customize the channel axis for normalisation functions (`BatchNorm`,` GroupNorm` and `InstanceNorm`).

## Example

```Julia
using Flux
channel_size = 3
channel_axis = 1
BN = BatchNorm(channel_size, dim = channel_axis)
x = randn(channel_size, 10, 10)
BN(x)
```