### PR TITLE
Generalise Parallel forwards pass

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -415,8 +415,8 @@ Parallel(connection, layers...) = Parallel(connection, layers)
 
 @functor Parallel
 
-(m::Parallel)(x::AbstractArray) = mapreduce(f -> f(x), m.connection, m.layers)
-(m::Parallel)(xs::Vararg{<:AbstractArray}) = mapreduce((f, x) -> f(x), m.connection, m.layers, xs)
+(m::Parallel)(x) = mapreduce(f -> f(x), m.connection, m.layers)
+(m::Parallel)(xs...) = mapreduce((f, x) -> f(x), m.connection, m.layers, xs)
 (m::Parallel)(xs::Tuple) = m(xs...)
 
 Base.getindex(m::Parallel, i::Integer) = m.layers[i]

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -190,6 +190,36 @@ import Flux: activations
       inputs = randn(10), randn(5), randn(4)
       @test size(Parallel(+, Dense(10, 2), Dense(5, 2), Dense(4, 2))(inputs)) == (2,)
     end
+    
+    @testset "Input domain" begin
+      struct Input
+        x
+      end
+
+      struct L1
+        x
+      end
+      (l::L1)(x) = l.x * x
+      Flux.@functor L1
+      Base.:*(a::AbstractArray, b::Input) = a * b.x
+
+      par = Parallel(+, L1(rand(Float32, 3,3)), L1(rand(Float32, 3,3)))
+      ip = Input(rand(Float32, 3,3))
+      ip2 = Input(rand(Float32, 3,3))
+
+      @test par(ip) ≈ par.layers[1](ip.x) + par.layers[2](ip.x)
+      @test par(ip, ip2) ≈ par.layers[1](ip.x) + par.layers[2](ip2.x)
+      gs = gradient((par, x...) -> sum(par(x...)), par, ip, ip2)
+      gs_reg = gradient(par, ip, ip2) do par, x, y
+        sum(par.layers[1](x.x) + par.layers[2](y.x))
+      end
+
+      for (a,b) in zip(gs[1].layers, gs_reg[1].layers)
+        @test a.x ≈ b.x
+      end
+      @test gs[2].x ≈ gs_reg[2].x
+      @test gs[3].x ≈ gs_reg[3].x
+    end
   end
 
   @testset "Embedding" begin

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -191,6 +191,7 @@ import Flux: activations
       @test size(Parallel(+, Dense(10, 2), Dense(5, 2), Dense(4, 2))(inputs)) == (2,)
     end
     
+    # Ref https://github.com/FluxML/Flux.jl/issues/1673
     @testset "Input domain" begin
       struct Input
         x


### PR DESCRIPTION
Fix #1673

We should also do a sweep of other layers that may be more restrictive due to excessive typing. By default there should be no typing on the input, or even necessarily on the parameters.

The `(::Parallel)(::Tuple)` case is interesting since the current version assumes that all the elements need to spread out, but  layers may output multiple things as part of their forward pass, and ingest multiple arguments too. This is also the case in the Weave model for example. So we may want to treat tuples as invariant and treat them like a single entity. Currently, the API to pass tuples could be improved since passing tuples to layers would need an extra layer of nesting for example: `p(((x,),))`
