### PR TITLE
Adding GRUv3 support.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Flux Release Notes
 
+## v0.12.7
+* Added support for [`GRUv3`](https://github.com/FluxML/Flux.jl/pull/1675)
+
 ## v0.12.5
 * Added option to configure [`groups`](https://github.com/FluxML/Flux.jl/pull/1531) in `Conv`.
 

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -11,7 +11,7 @@ using Zygote: Params, @adjoint, gradient, pullback, @nograd
 export gradient
 
 export Chain, Dense, Maxout, SkipConnection, Parallel, flatten,
-       RNN, LSTM, GRU,
+       RNN, LSTM, GRU, GRUv3,
        SamePad, Conv, CrossCor, ConvTranspose, DepthwiseConv,
        AdaptiveMaxPool, AdaptiveMeanPool, GlobalMaxPool, GlobalMeanPool, MaxPool, MeanPool,
        Dropout, AlphaDropout, LayerNorm, BatchNorm, InstanceNorm, GroupNorm,

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -213,7 +213,8 @@ Base.show(io::IO, l::GRUCell) =
     GRU(in::Integer, out::Integer)
 
 [Gated Recurrent Unit](https://arxiv.org/abs/1406.1078) layer. Behaves like an
-RNN but generally exhibits a longer memory span over sequences.
+RNN but generally exhibits a longer memory span over sequences. This implements
+the cell proposed in v1 of the above paper.
 
 See [this article](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 for a good overview of the internals.
@@ -268,7 +269,8 @@ Base.show(io::IO, l::GRUv3Cell) =
     GRUv3(in::Integer, out::Integer)
 
 [Gated Recurrent Unit](https://arxiv.org/abs/1406.1078) layer. Behaves like an
-RNN but generally exhibits a longer memory span over sequences.
+RNN but generally exhibits a longer memory span over sequences. This implements
+the version proposed in v3 of the above arxiv paper.
 
 See [this article](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 for a good overview of the internals.

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -270,7 +270,7 @@ Base.show(io::IO, l::GRUv3Cell) =
 
 [Gated Recurrent Unit](https://arxiv.org/abs/1406.1078) layer. Behaves like an
 RNN but generally exhibits a longer memory span over sequences. This implements
-the version proposed in v3 of the above arxiv paper.
+the variant proposed in v3 of the referenced paper.
 
 See [this article](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 for a good overview of the internals.

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -268,7 +268,7 @@ Base.show(io::IO, l::GRUv3Cell) =
 """
     GRUv3(in::Integer, out::Integer)
 
-[Gated Recurrent Unit](https://arxiv.org/abs/1406.1078) layer. Behaves like an
+[Gated Recurrent Unit](https://arxiv.org/abs/1406.1078v3) layer. Behaves like an
 RNN but generally exhibits a longer memory span over sequences. This implements
 the variant proposed in v3 of the referenced paper.
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -184,12 +184,12 @@ end
 # GRU
 
 function _gru_output(Wi, Wh, b, x, h)
-    o = size(h, 1)
-    gx, gh = Wi*x, Wh*h
-    r = σ.(gate(gx, o, 1) .+ gate(gh, o, 1) .+ gate(b, o, 1))
-    z = σ.(gate(gx, o, 2) .+ gate(gh, o, 2) .+ gate(b, o, 2))
+  o = size(h, 1)
+  gx, gh = Wi*x, Wh*h
+  r = σ.(gate(gx, o, 1) .+ gate(gh, o, 1) .+ gate(b, o, 1))
+  z = σ.(gate(gx, o, 2) .+ gate(gh, o, 2) .+ gate(b, o, 2))
 
-    return gx, gh, r, z
+  return gx, gh, r, z
 end
 
 struct GRUCell{A,V,S}
@@ -253,8 +253,8 @@ struct GRUv3Cell{A,V,S}
 end
 
 GRUv3Cell(in, out; init = glorot_uniform, initb = zeros32, init_state = zeros32) =
-    GRUv3Cell(init(out * 3, in), init(out * 2, out), initb(out * 3), 
-              init(out, out), init_state(out,1))
+  GRUv3Cell(init(out * 3, in), init(out * 2, out), initb(out * 3), 
+            init(out, out), init_state(out,1))
 
 function (m::GRUv3Cell{A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {A,V,T}
   b, o = m.b, size(h, 1)

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -183,7 +183,8 @@ end
 
 # GRU
 
-function _gru_output(Wi, Wh, x, h)
+function _gru_output(Wi, Wh, b, x, h)
+    o = size(h, 1)
     gx, gh = Wi*x, Wh*h
     r = σ.(gate(gx, o, 1) .+ gate(gh, o, 1) .+ gate(b, o, 1))
     z = σ.(gate(gx, o, 2) .+ gate(gh, o, 2) .+ gate(b, o, 2))
@@ -203,7 +204,7 @@ GRUCell(in, out; init = glorot_uniform, initb = zeros32, init_state = zeros32) =
 
 function (m::GRUCell{A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {A,V,T}
   b, o = m.b, size(h, 1)
-  gx, gh, r, z = _gru_output(m.Wi, m.Wh, x, h)
+  gx, gh, r, z = _gru_output(m.Wi, m.Wh, b, x, h)
   h̃ = tanh.(gate(gx, o, 3) .+ r .* gate(gh, o, 3) .+ gate(b, o, 3))
   h′ = (1 .- z) .* h̃ .+ z .* h
   sz = size(x)
@@ -257,7 +258,7 @@ GRUv3Cell(in, out; init = glorot_uniform, initb = zeros32, init_state = zeros32)
 
 function (m::GRUv3Cell{A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {A,V,T}
   b, o = m.b, size(h, 1)
-  gx, gh, r, z = _gru_output(m.Wi, m.Wh, x, h)
+  gx, gh, r, z = _gru_output(m.Wi, m.Wh, b, x, h)
   h̃ = tanh.(gate(gx, o, 3) .+ (m.Wh_h̃ * (r .* h)) .+ gate(b, o, 3))
   h′ = (1 .- z) .* h̃ .+ z .* h
   sz = size(x)

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -212,7 +212,7 @@ Base.show(io::IO, l::GRUCell) =
 """
     GRU(in::Integer, out::Integer)
 
-[Gated Recurrent Unit](https://arxiv.org/abs/1406.1078) layer. Behaves like an
+[Gated Recurrent Unit](https://arxiv.org/abs/1406.1078v1) layer. Behaves like an
 RNN but generally exhibits a longer memory span over sequences. This implements
 the cell proposed in v1 of the above paper.
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -214,7 +214,7 @@ Base.show(io::IO, l::GRUCell) =
 
 [Gated Recurrent Unit](https://arxiv.org/abs/1406.1078v1) layer. Behaves like an
 RNN but generally exhibits a longer memory span over sequences. This implements
-the cell proposed in v1 of the above paper.
+the variant proposed in v1 of the referenced paper.
 
 See [this article](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 for a good overview of the internals.

--- a/test/cuda/curnn.jl
+++ b/test/cuda/curnn.jl
@@ -1,6 +1,6 @@
 using Flux, CUDA, Test
 
-@testset for R in [RNN, GRU, LSTM]
+@testset for R in [RNN, GRU, LSTM, GRUv3]
   m = R(10, 5) |> gpu
   x = gpu(rand(10))
   (m̄,) = gradient(m -> sum(m(x)), m)
@@ -12,7 +12,7 @@ using Flux, CUDA, Test
 end
 
 @testset "RNN" begin
-  @testset for R in [RNN, GRU, LSTM], batch_size in (1, 5)
+  @testset for R in [RNN, GRU, LSTM, GRUv3], batch_size in (1, 5)
     rnn = R(10, 5)
     curnn = fmap(gpu, rnn)
 

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -43,7 +43,7 @@ end
 end
 
 @testset "RNN-shapes" begin
-    @testset for R in [RNN, GRU, LSTM]
+    @testset for R in [RNN, GRU, LSTM, GRUv3]
         m1 = R(3, 5)
         m2 = R(3, 5)
         x1 = rand(Float32, 3)
@@ -58,7 +58,7 @@ end
 end
 
 @testset "RNN-input-state-eltypes" begin
-  @testset for R in [RNN, GRU, LSTM]
+  @testset for R in [RNN, GRU, LSTM, GRUv3]
       m = R(3, 5)
       x = rand(Float64, 3, 1)
       Flux.reset!(m)


### PR DESCRIPTION
As per the starting discussion in #1671, we should provide support for variations on the GRU and LSTM cell. 

In this PR, I added support for the GRU found in v3 of the [original GRU paper](https://arxiv.org/abs/1406.1078). Current support in Flux is for v1 only. [Tensorflow](https://www.tensorflow.org/api_docs/python/tf/keras/layers/GRU) supports several variations, with this as one of the variations. 

While the feature is added and usable in this PR, this is only a first pass at a design and could use further iterations. Some questions I have:
- Should we have new types for each variation of these cells? (another possibility is through parametric options)
- Should we have a shared constructor similar to Tensorflow/Pytorch? (it might make sense to rename the current GRU to GRUv1 if we want to do this).

### PR Checklist

- [x] Tests are added
- [x] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
