### PR TITLE
add NamedTuple chain constructor

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -42,6 +42,14 @@ applychain(fs::Union{NamedTuple,Tuple}, x) = applychain(tail(fs), first(fs)(x))
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i]...)
 
+function Base.getproperty(c::Chain, k::Symbol)
+  if k === :layers
+    Base.getfield(c, :layers)
+  else
+    Base.getproperty(Base.getfield(c, :layers), k)
+  end
+end
+
 function Base.show(io::IO, c::Chain)
   print(io, "Chain(")
   join(io, c.layers, ", ")

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -23,9 +23,10 @@ julia> m(x) == m[2](m[1](x))
 true
 ```
 """
-struct Chain{T<:Tuple}
+struct Chain{T}
   layers::T
   Chain(xs...) = new{typeof(xs)}(xs)
+  Chain(xs::NamedTuple) = new{typeof(xs)}(xs) # Chain(xs...)
 end
 
 @forward Chain.layers Base.getindex, Base.length, Base.first, Base.last,
@@ -34,7 +35,8 @@ end
 functor(::Type{<:Chain}, c) = c.layers, ls -> Chain(ls...)
 
 applychain(::Tuple{}, x) = x
-applychain(fs::Tuple, x) = applychain(tail(fs), first(fs)(x))
+applychain(::NamedTuple{(), Tuple{}}, x) = x
+applychain(fs::Union{NamedTuple,Tuple}, x) = applychain(tail(fs), first(fs)(x))
 
 (c::Chain)(x) = applychain(c.layers, x)
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -27,6 +27,7 @@ struct Chain{T}
   layers::T
   Chain(xs...) = new{typeof(xs)}(xs)
   Chain(xs::NamedTuple) = new{typeof(xs)}(xs) # Chain(xs...)
+  Chain(; xs...) = Chain(values(xs))
 end
 
 @forward Chain.layers Base.getindex, Base.length, Base.first, Base.last,

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -26,7 +26,8 @@ true
 struct Chain{T}
   layers::T
   Chain(xs...) = new{typeof(xs)}(xs)
-  Chain(xs::NamedTuple) = new{typeof(xs)}(xs) # Chain(xs...)
+  Chain(xs::NamedTuple) = new{typeof(xs)}(xs)
+  Chain(; xs...) = Chain(values(xs))
 end
 
 @forward Chain.layers Base.getindex, Base.length, Base.first, Base.last,
@@ -41,14 +42,6 @@ applychain(fs::Union{NamedTuple,Tuple}, x) = applychain(tail(fs), first(fs)(x))
 (c::Chain)(x) = applychain(c.layers, x)
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i]...)
-
-function Base.getproperty(c::Chain, k::Symbol)
-  if k === :layers
-    Base.getfield(c, :layers)
-  else
-    Base.getproperty(Base.getfield(c, :layers), k)
-  end
-end
 
 function Base.show(io::IO, c::Chain)
   print(io, "Chain(")
@@ -76,7 +69,7 @@ function extraChain(fs::Tuple, x)
 end
 
 extraChain(::Tuple{}, x) = ()
-
+extraChain(::NamedTuple{(), Tuple{}}, x) = ()
 
 
 """

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -27,7 +27,6 @@ struct Chain{T}
   layers::T
   Chain(xs...) = new{typeof(xs)}(xs)
   Chain(xs::NamedTuple) = new{typeof(xs)}(xs) # Chain(xs...)
-  Chain(; xs...) = Chain(values(xs))
 end
 
 @forward Chain.layers Base.getindex, Base.length, Base.first, Base.last,


### PR DESCRIPTION
Adds the `NamedTuple` constructor for `Chain`. its a much simpler design and respects all the usual expected behaviour.

```Julia
julia> c = Chain((a = Conv((3,3), 3 => 4),
                 b = Conv((3,3), 4 => 3)))
Chain(
  Conv((3, 3), 3 => 4),                 # 112 parameters
  Conv((3, 3), 4 => 3),                 # 111 parameters
)                   # Total: 4 arrays, 223 parameters, 1.574 KiB.

julia> r = rand(Float32, 28, 28, 3, 1);

julia> c(r) |> size
(24, 24, 3, 1)

julia> c[:a](r) |> size
(26, 26, 4, 1)

julia> c[:a](r) == c[1](r)
true
```