### PR TITLE
Adding support for folding RNNs over 3d arrays

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -91,7 +91,7 @@ function (m::FoldedRecur)(x::AbstractArray{<:Number, 3})
       push!(h_all, h_out)
   end
   sz = size(x)
-  h_ret = cat(reshape.(h_all[2:end], :, 1, sz[3:end]...)..., dims=2)
+  h_ret = cat(reshape.(h_all, :, 1, sz[3:end]...)..., dims=2)
   return h_ret
 
 end

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -82,7 +82,7 @@ end
 flip(f, xs) = reverse(f.(reverse(xs)))
 
 function (m::Recur)(x::AbstractArray{T, 3}) where T
-  h = [m(x[:, :, i]) for i in 1:size(x, 3)]
+  h = [m(view(x, :, :, i)) for i in 1:size(x, 3)]
   sze = size(h[1])
   reshape(reduce(hcat, h), sze[1], sze[2], length(h))
 end

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -68,8 +68,8 @@ end
 
 flip(f, xs) = reverse(f.(reverse(xs)))
 
-function (m::Recur)(x::AbstractArray{<:Number, 3})
-  h_ret = mapslices(m, x, dims=[1, 3])
+function (m::Recur)(x::AbstractArray{T, 3}) where T
+  h_ret = mapslices(m, x, dims = (1, 3))
   sz = size(x)
   return h_ret
 end

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -69,11 +69,8 @@ end
 flip(f, xs) = reverse(f.(reverse(xs)))
 
 function (m::Recur)(x::AbstractArray{T, 3}) where T
-  h_ret = mapslices(m, x, dims = (1, 3))
-  sz = size(x)
-  return h_ret
+    stack([m(x[:,:,i]) for i in 1:size(x, 3)], 3)
 end
-
 
 # Vanilla RNN
 
@@ -110,7 +107,6 @@ The most basic recurrent layer; essentially acts as a `Dense` layer, but with th
 output fed back into the input each time step.
 """
 RNN(a...; ka...) = Recur(RNNCell(a...; ka...))
-FoldedRNN(args...; kwargs...) = FoldedRecur(Flux.RNNCell(args...; kwargs...))
 Recur(m::RNNCell) = Recur(m, m.state0)
 
 # TODO remove in v0.13
@@ -171,7 +167,6 @@ See [this article](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 for a good overview of the internals.
 """
 LSTM(a...; ka...) = Recur(LSTMCell(a...; ka...))
-FoldedLSTM(args...; kwargs...) = FoldedRecur(Flux.LSTMCell(args...; kwargs...))
 Recur(m::LSTMCell) = Recur(m, m.state0)
 
 # TODO remove in v0.13
@@ -237,7 +232,6 @@ See [this article](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 for a good overview of the internals.
 """
 GRU(a...; ka...) = Recur(GRUCell(a...; ka...))
-FoldedGRU(args...; kwargs...) = FoldedRecur(Flux.GRUCell(args...; kwargs...))
 Recur(m::GRUCell) = Recur(m, m.state0)
 
 # TODO remove in v0.13
@@ -292,7 +286,6 @@ See [this article](https://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 for a good overview of the internals.
 """
 GRUv3(a...; ka...) = Recur(GRUv3Cell(a...; ka...))
-FoldedGRUv3(args...; kwargs...) = FoldedRecur(Flux.GRUv3Cell(args...; kwargs...))
 Recur(m::GRUv3Cell) = Recur(m, m.state0)
 
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -24,6 +24,19 @@ rnn.state   # 5
 rnn.(1:10)  # apply to a sequence
 rnn.state   # 60
 ```
+
+Folding over a 3d Array of dimensions `(features, batch, time)` is also supported:
+
+```julia
+accum(h, x) = (h .+ x, x)
+rnn = Flux.Recur(accum, zeros(Int, 1, 1))
+rnn([2])                    # 2
+rnn([3])                    # 3
+rnn.state                   # 5
+rnn(reshape(1:10, 1, 1, :)) # apply to a sequence of (features, batch, time)
+rnn.state                   # 60
+```
+
 """
 mutable struct Recur{T,S}
   cell::T
@@ -69,9 +82,9 @@ end
 flip(f, xs) = reverse(f.(reverse(xs)))
 
 function (m::Recur)(x::AbstractArray{T, 3}) where T
-    h = [m(x[:, :, i]) for i in 1:size(x, 3)]
-    sze = size(h[1])
-    reshape(reduce(hcat, h), sze[1], sze[2], length(h))
+  h = [m(x[:, :, i]) for i in 1:size(x, 3)]
+  sze = size(h[1])
+  reshape(reduce(hcat, h), sze[1], sze[2], length(h))
 end
 
 # Vanilla RNN

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -73,17 +73,21 @@ flip(f, xs) = reverse(f.(reverse(xs)))
     FoldedRecur
 
 We fold over the second dimension as the time dimension, and return all the new hidden states concatenated on the time dimension.
+
+TODO: Figure out how to use CuDNN for RNN, GRU, LSTM.
+
 """
 struct FoldedRecur{C}
-  cell::C
+    cell::C
 end
 
 Flux.@functor FoldedRecur
 trainable(a::FoldedRecur) = (a.cell,)
 
+# currently RNNs are only usable with 3-d arrays.
 function (m::FoldedRecur)(x::AbstractArray{<:Number, 3})
-  # stride across temporal dimension
 
+  # stride across temporal dimension
   h = m.cell.state0
   h_all = Vector{typeof(h)}(undef, size(x, 2))
   for t in 1:size(x, 2)
@@ -91,7 +95,7 @@ function (m::FoldedRecur)(x::AbstractArray{<:Number, 3})
       push!(h_all, h_out)
   end
   sz = size(x)
-  h_ret = cat(reshape.(h_all, :, 1, sz[3:end]...)..., dims=2)
+  h_ret = cat(reshape.(h_all, :, 1, sz[3])..., dims=2)
   return h_ret
 
 end

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -69,7 +69,9 @@ end
 flip(f, xs) = reverse(f.(reverse(xs)))
 
 function (m::Recur)(x::AbstractArray{T, 3}) where T
-    stack([m(x[:,:,i]) for i in 1:size(x, 3)], 3)
+    h = [m(x[:, :, i]) for i in 1:size(x, 3)]
+    sze = size(h[1])
+    reshape(reduce(hcat, h), sze[1], sze[2], length(h))
 end
 
 # Vanilla RNN

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -95,10 +95,11 @@ function (m::FoldedRecur)(x::AbstractArray{<:Number, 3})
       Vector{typeof(h)}(undef, size(x, 2))
   end
 
-  for t in 1:size(x, 2)
+  for t in axes(x, 2)
       h, h_out = m.cell(h, x[:, t, :])
       h_all[t] = h_out
   end
+
   sz = size(x)
   h_ret = cat(reshape.(h_all, :, 1, sz[3])..., dims=2)
   return h_ret

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -89,10 +89,15 @@ function (m::FoldedRecur)(x::AbstractArray{<:Number, 3})
 
   # stride across temporal dimension
   h = m.cell.state0
-  h_all = Vector{typeof(h)}(undef, size(x, 2))
+  h_all = if h isa Tuple
+      Vector{typeof(h[1])}(undef, size(x, 2))
+  else
+      Vector{typeof(h)}(undef, size(x, 2))
+  end
+
   for t in 1:size(x, 2)
       h, h_out = m.cell(h, x[:, t, :])
-      push!(h_all, h_out)
+      h_all[t] = h_out
   end
   sz = size(x)
   h_ret = cat(reshape.(h_all, :, 1, sz[3])..., dims=2)

--- a/test/cuda/curnn.jl
+++ b/test/cuda/curnn.jl
@@ -63,7 +63,5 @@ end
 
     cufy = (curnn(cufx); curnn(cufx))
     @test fy ≈ collect(cufy)
-
-      
   end
 end

--- a/test/cuda/curnn.jl
+++ b/test/cuda/curnn.jl
@@ -53,6 +53,17 @@ end
     y = (rnn(ohx); rnn(ohx))
 
     cuy = (curnn(cuohx); curnn(cuohx))
-    @test y ≈ collect(cuy)  
+    @test y ≈ collect(cuy)
+
+    Flux.reset!(rnn)
+    Flux.reset!(curnn)
+    fx = rand(Float32, 10, batch_size, 3)
+    cufx = gpu(fx)
+    fy = (rnn(fx); rnn(fx))
+
+    cufy = (curnn(cufx); curnn(cufx))
+    @test fy ≈ collect(cufy)
+
+      
   end
 end

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -69,17 +69,17 @@ end
     m2 = R(3, 5)
     m3 = R(3, 5)
     x1 = rand(Float32, 3)
-    x2 = rand(Float32,3,1)
-    x3 = rand(Float32,3,1,2)
+    x2 = rand(Float32, 3, 1)
+    x3 = rand(Float32, 3, 1, 2)
     Flux.reset!(m1)
     Flux.reset!(m2)
     Flux.reset!(m3)
     @test size(m1(x1)) == (5,)
     @test size(m1(x1)) == (5,) # repeat in case of effect from change in state shape
-    @test size(m2(x2)) == (5,1)
-    @test size(m2(x2)) == (5,1)
-    @test size(m3(x3)) == (5,1,2)
-    @test size(m3(x3)) == (5,1,2)
+    @test size(m2(x2)) == (5, 1)
+    @test size(m2(x2)) == (5, 1)
+    @test size(m3(x3)) == (5, 1, 2)
+    @test size(m3(x3)) == (5, 1, 2)
   end
 end
 

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -42,26 +42,52 @@ end
 end
 end
 
-@testset "RNN-shapes" begin
-    @testset for R in [RNN, GRU, LSTM, GRUv3]
-        m1 = R(3, 5)
-        m2 = R(3, 5)
-        x1 = rand(Float32, 3)
-        x2 = rand(Float32,3,1)
-        Flux.reset!(m1)
-        Flux.reset!(m2)
-        @test size(m1(x1)) == (5,)
-        @test size(m1(x1)) == (5,) # repeat in case of effect from change in state shape
-        @test size(m2(x2)) == (5,1)
-        @test size(m2(x2)) == (5,1)
+@testset "BPTT-3D" begin
+  seq = rand(Float32, (2, 1, 3))
+  for r ∈ [RNN,]
+    rnn = r(2, 3)
+    Flux.reset!(rnn)
+    grads_seq = gradient(Flux.params(rnn)) do
+        sum(rnn(seq)[:, :, 3])
     end
+    Flux.reset!(rnn);
+    bptt = gradient(Wh -> sum(tanh.(rnn.cell.Wi * seq[:, :, 3] + Wh *
+                                  tanh.(rnn.cell.Wi * seq[:, :, 2] + Wh *
+                                        tanh.(rnn.cell.Wi * seq[:, :, 1] +
+                                            Wh * rnn.cell.state0
+                                        + rnn.cell.b)
+                                  + rnn.cell.b)
+                            + rnn.cell.b)),
+                    rnn.cell.Wh)
+    @test grads_seq[rnn.cell.Wh] ≈ bptt[1]
+end
+end
+
+@testset "RNN-shapes" begin
+  @testset for R in [RNN, GRU, LSTM, GRUv3]
+    m1 = R(3, 5)
+    m2 = R(3, 5)
+    m3 = R(3, 5)
+    x1 = rand(Float32, 3)
+    x2 = rand(Float32,3,1)
+    x3 = rand(Float32,3,1,2)
+    Flux.reset!(m1)
+    Flux.reset!(m2)
+    Flux.reset!(m3)
+    @test size(m1(x1)) == (5,)
+    @test size(m1(x1)) == (5,) # repeat in case of effect from change in state shape
+    @test size(m2(x2)) == (5,1)
+    @test size(m2(x2)) == (5,1)
+    @test size(m3(x3)) == (5,1,2)
+    @test size(m3(x3)) == (5,1,2)
+  end
 end
 
 @testset "RNN-input-state-eltypes" begin
   @testset for R in [RNN, GRU, LSTM, GRUv3]
-      m = R(3, 5)
-      x = rand(Float64, 3, 1)
-      Flux.reset!(m)
-      @test_throws MethodError m(x)
+    m = R(3, 5)
+    x = rand(Float64, 3, 1)
+    Flux.reset!(m)
+    @test_throws MethodError m(x)
   end
 end


### PR DESCRIPTION
From #1678, adding a Recur like interface for a folded operation with support for 3-dimensional arrays. This is how many users expect RNNs to work if they are familiar with Pytorch and Tensorflow, and there seems to be some desire for support for this feature as per the discussion in #1671 and @jeremiedb .  This will also make a push to implementing support for the CuDNN versions of RNNs/GRUs/LSTMs more streamlined as this is the data layout that API expects. 

I did a barebones implementation to add support so we can start iterating on API.

There are several questions that I have lingering with this interface:
- ~Should we support different modes where we return all or only the last hidden state? Is there a better way to do the concat of the hidden states?~
- What kind of tests should we have? Just follow what we currently do for RNNs/LSTMs/GRUs?
- ~For the CPU version, does it make sense not to specialize on the different rnn types? We might be able to take more advantage of BLAS if we specialized on say `Folded{GRU}`.~
- ~Do we want to force the temporal dimension to be the 2nd?~
- ~Do we want this to be stateful? (i.e. allow the user to change what the starting hidden state is rather than state0).~

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
