### PR TITLE
Make Parallel Vararg

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -416,7 +416,7 @@ Parallel(connection, layers...) = Parallel(connection, layers)
 @functor Parallel
 
 (m::Parallel)(x::AbstractArray) = mapreduce(f -> f(x), m.connection, m.layers)
-(m::Parallel)(xs::Vararg{<:AbstractArray}) = mapreduce((f, x) -> f(x), m.connection, m.layers, xs)
+(m::Parallel)(xs::AbstractArray...) = m.connection(map((f, x) -> f(x), m.layers, xs)...)
 (m::Parallel)(xs::Tuple) = m(xs...)
 
 Base.getindex(m::Parallel, i::Integer) = m.layers[i]

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -446,7 +446,7 @@ end
 
 (m::Parallel)(x) = m.connection(map(f -> f(x), Tuple(m.layers))...)
 (m::Parallel)(xs...) = m.connection(map((f, x) -> f(x), Tuple(m.layers), xs)...)
-(m::Parallel)(xs::Tuple) = m(xs...)
+# (m::Parallel)(xs::Tuple) = m(xs...)
 
 Base.getindex(m::Parallel, i) = m.layers[i]
 Base.getindex(m::Parallel, i::AbstractVector) = Parallel(m.connection, m.layers[i]...)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -426,7 +426,7 @@ julia> model2[:β] == model2[2]
 true
 ```
 """
-struct Parallel{F, T}
+struct Parallel{F, T<:Union{NamedTuple,Tuple}}
   connection::F
   layers::T
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -446,7 +446,7 @@ end
 
 (m::Parallel)(x) = m.connection(map(f -> f(x), Tuple(m.layers))...)
 (m::Parallel)(xs...) = m.connection(map((f, x) -> f(x), Tuple(m.layers), xs)...)
-# (m::Parallel)(xs::Tuple) = m(xs...)
+(m::Parallel)(xs::Tuple) = m(xs...)
 
 Base.getindex(m::Parallel, i) = m.layers[i]
 Base.getindex(m::Parallel, i::AbstractVector) = Parallel(m.connection, m.layers[i]...)

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -242,6 +242,27 @@ import Flux: activations
       @test gs[2].x ≈ gs_reg[2].x
       @test gs[3].x ≈ gs_reg[3].x
     end
+
+    @testset "Multiple Inputs/ Multiple Outputs" begin
+
+      struct MIMO{T}
+        W::T
+      end
+
+      (m::MIMO)(x, y) = m.W * x, m.W * y, x * y
+      x = (rand(3,3), rand(3,3))
+
+      p = Parallel((x...) -> identity.(x),
+                   MIMO(rand(3,3)),
+                   MIMO(rand(3,3)))
+
+      (m::MIMO)(x::Tuple) = m(x...)
+      mimo_output1 = p(x, x)
+      mimo_ouput2 = p(x) # to check for N layers 1 input case
+      @test mimo_output1 ≈ mimo_output2
+      @test length(mimo_output1) == 2
+      @test all(x -> length(x) == 3, mimo_output1)
+    end
   end
 
   @testset "Embedding" begin

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -258,8 +258,7 @@ import Flux: activations
 
       (m::MIMO)(x::Tuple) = m(x...)
       mimo_output1 = p(x, x)
-      mimo_ouput2 = p(x) # to check for N layers 1 input case
-      @test mimo_output1 ≈ mimo_output2
+      mimo_output2 = p(x) # to check for N layers 1 input case
       @test length(mimo_output1) == 2
       @test all(x -> length(x) == 3, mimo_output1)
     end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -258,7 +258,7 @@ import Flux: activations
 
       (m::MIMO)(x::Tuple) = m(x...)
       mimo_output1 = p(x, x)
-      mimo_output2 = p(x) # to check for N layers 1 input case
+      @test_broken all(p(((x,),)) .== mimo_output1) # to check for N layers 1 input case
       @test length(mimo_output1) == 2
       @test all(x -> length(x) == 3, mimo_output1)
     end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -200,8 +200,8 @@ import Flux: activations
 
     @testset "vararg input" begin
       inputs = randn(10), randn(5), randn(4)
-      @test size(Parallel(+, Dense(10, 2), Dense(5, 2), Dense(4, 2))(inputs)) == (2,)
-      @test size(Parallel(+; a = Dense(10, 2), b = Dense(5, 2), c = Dense(4, 2))(inputs)) == (2,)
+      @test size(Parallel(+, Dense(10, 2), Dense(5, 2), Dense(4, 2))(inputs...)) == (2,)
+      @test size(Parallel(+; a = Dense(10, 2), b = Dense(5, 2), c = Dense(4, 2))(inputs...)) == (2,)
     end
 
     @testset "named access" begin

--- a/test/outputsize.jl
+++ b/test/outputsize.jl
@@ -45,13 +45,13 @@ end
   m = Parallel(vcat, Dense(2, 4, relu), Dense(3, 6, relu))
   @test outputsize(m, (2,), (3,)) == (10,)
   @test outputsize(m, ((2,), (3,))) == (10,)
-  @test outputsize(m, (2,), (3,); padbatch=true) == (10, 1)
+  @test outputsize(m, (2,), (3,); padbatch = true) == (10, 1)
   @test outputsize(m, (2,7), (3,7)) == (10, 7)
 
   m = Chain(m, Dense(10, 13, tanh), softmax)
   @test outputsize(m, (2,), (3,)) == (13,)
   @test outputsize(m, ((2,), (3,))) == (13,)
-  @test outputsize(m, (2,), (3,); padbatch=true) == (13, 1)
+  @test outputsize(m, (2,), (3,); padbatch = true) == (13, 1)
   @test outputsize(m, (2,7), (3,7)) == (13, 7)
 end
 


### PR DESCRIPTION
This PR makes it so vararg inputs and layers are treated as `zip(layers, inputs)` which are then splat into the `connection`. 