### PR TITLE
add unbatch

### DIFF
--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -14,6 +14,7 @@ Flux.unstack
 Flux.chunk
 Flux.frequencies
 Flux.batch
+Flux.unbatch
 Flux.batchseq
 Base.rpad(v::AbstractVector, n::Integer, p)
 ```

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -542,6 +542,8 @@ squeezebatch(x) = reshape(x, head(size(x)))
 
 Batch the arrays in `xs` into a single array.
 
+See also [`unbatch`](@ref)
+
 # Examples
 ```jldoctest
 julia> Flux.batch([[1,2,3],[4,5,6]])
@@ -560,6 +562,27 @@ function batch(xs)
   end
   return data
 end
+
+"""
+  unbatch(x)
+
+Reverse of the [`batch`](@ref) operation,
+unstacking the last dimension of the array `x`.
+
+See also [`unstack`](@ref).
+
+# Examples
+
+```jldoctest
+julia> Flux.unbatch([1 3 5 7; 
+                     2 4 6 8])
+4-element Vector{Vector{Int64}}:
+ [1, 2]
+ [3, 4]
+ [5, 6]
+ [7, 8]
+"""
+unbatch(x::AbstractArray) = unstack(x, ndims(x))
 
 """
 Return the given sequence padded with `p` up to a maximum length of `n`.

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,7 @@
 using Flux
-using Flux: throttle, nfan, glorot_uniform, glorot_normal, kaiming_normal, kaiming_uniform, orthogonal, sparse_init, stack, unstack, Zeros
+using Flux: throttle, nfan, glorot_uniform, glorot_normal,
+             kaiming_normal, kaiming_uniform, orthogonal, 
+             sparse_init, stack, unstack, Zeros, batch, unbatch
 using StatsBase: var, std
 using Random
 using Test
@@ -327,6 +329,17 @@ end
   @test unstack(stacked_array, 2) == unstacked_array
   @test stack(unstacked_array, 2) == stacked_array
   @test stack(unstack(stacked_array, 1), 1) == stacked_array
+end
+
+
+@testset "Batching" begin
+  stacked_array=[ 8 9 3 5 
+                  9 6 6 9 
+                  9 1 7 2 
+                  7 4 10 6 ]
+  unstacked_array=[[8, 9, 9, 7], [9, 6, 1, 4], [3, 6, 7, 10], [5, 9, 2, 6]]
+  @test unbatch(stacked_array) == unstacked_array
+  @test batch(unstacked_array) == stacked_array
 end
 
 @testset "Param remapping" begin


### PR DESCRIPTION
Add `unbatch` for convenience and consistency (we currently have `stack/unstack` but only `batch` with no `unbatch`). Can be specialized by downstream packages on their custom batched types. 

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
