### PR TITLE
Throw an error when someone calls params(::Params, ::Number, seen)

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -39,7 +39,7 @@ Possible values include:
 trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
 
 params!(p::Params, x::AbstractArray{<:Number}, seen = IdSet()) = push!(p, x)
-params!(::Params, ::Number, seen) = error("Tried to create params with a scalar (try wrapping it as a 1D array).")
+params!(::Params, ::Real, seen) = error("Tried to create params with a scalar (try wrapping it as a 1D array).")
 
 function params!(p::Params, x, seen = IdSet())
   x in seen && return

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -39,7 +39,9 @@ Possible values include:
 trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
 
 params!(p::Params, x::AbstractArray{<:Number}, seen = IdSet()) = push!(p, x)
-params!(::Params, ::Real, seen) = @warn "Tried to create params with a scalar (try wrapping it as a 1D array)."
+params!(::Params, ::Real, seen) = Zygote.ignore() do
+  @warn "Tried to create params with a scalar (try wrapping it as a 1D array)."
+end
 
 function params!(p::Params, x, seen = IdSet())
   x in seen && return

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -39,7 +39,7 @@ Possible values include:
 trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
 
 params!(p::Params, x::AbstractArray{<:Number}, seen = IdSet()) = push!(p, x)
-params!(::Params, ::Real, seen) = error("Tried to create params with a scalar (try wrapping it as a 1D array).")
+params!(::Params, ::Real, seen) = @warn "Tried to create params with a scalar (try wrapping it as a 1D array)."
 
 function params!(p::Params, x, seen = IdSet())
   x in seen && return

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -39,6 +39,7 @@ Possible values include:
 trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
 
 params!(p::Params, x::AbstractArray{<:Number}, seen = IdSet()) = push!(p, x)
+params!(::Params, ::Number, seen) = error("Tried to create params with a scalar (try wrapping it as a 1D array).")
 
 function params!(p::Params, x, seen = IdSet())
   x in seen && return

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -216,7 +216,7 @@ end
   @test size.(params(r)) == [(5, 10), (5, 5), (5,), (5, 1)]
 
   # try to push scalar onto params
-  @test_logs ErrorException params([1f0, 2f0], 3f0)
+  @test_logs (:warn, "Tried to create params with a scalar (try wrapping it as a 1D array).") params([1f0, 2f0], 3f0)
 end
 
 @testset "Basic Stacking" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -214,6 +214,9 @@ end
   r = Any[nothing,m]
   r[1] = r
   @test size.(params(r)) == [(5, 10), (5, 5), (5,), (5, 1)]
+
+  # try to push scalar onto params
+  @test_logs ErrorException params([1f0, 2f0], 3f0)
 end
 
 @testset "Basic Stacking" begin


### PR DESCRIPTION
In response to #1730, this PR adds an error when someone tries to push a scalar onto `Params` (with a hint to wrap it as an array).

### PR Checklist

- [x] Tests are added
- [x] ~~Entry in NEWS.md~~
- [x] ~~Documentation, if applicable~~
- [x] ~~API changes require approval from a committer (different from the author, if applicable)~~
