### PR TITLE
Don't export flatten

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -10,7 +10,7 @@ using MacroTools: @forward
 using Zygote: Params, @adjoint, gradient, pullback, @nograd
 export gradient
 
-export Chain, Dense, Maxout, SkipConnection, Parallel, flatten,
+export Chain, Dense, Maxout, SkipConnection, Parallel,
        RNN, LSTM, GRU, GRUv3,
        SamePad, Conv, CrossCor, ConvTranspose, DepthwiseConv,
        AdaptiveMaxPool, AdaptiveMeanPool, GlobalMaxPool, GlobalMeanPool, MaxPool, MeanPool,


### PR DESCRIPTION
```julia
julia> WARNING: both Flux and Iterators export "flatten"; uses of it in module DiffEqFlux must be qualified
```

Yeah no, that interferes with a very common Base module.