### PR TITLE
Fix doc string of Upsample

### DIFF
--- a/src/layers/upsample.jl
+++ b/src/layers/upsample.jl
@@ -1,6 +1,6 @@
 """
-  Upsample(mode = :nearest; [scale, size]) 
-  Upsample(scale, mode = :nearest)  
+    Upsample(mode = :nearest; [scale, size]) 
+    Upsample(scale, mode = :nearest)  
 
 An upsampling layer. One of two keywords must be given:
 


### PR DESCRIPTION
Documentation of [Upsample](https://fluxml.ai/Flux.jl/stable/models/layers/#Flux.Upsample) is not rendered correctly due to not enough spaces 

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
