### PR TITLE
fix CI build

### DIFF
--- a/test/cuda/curnn.jl
+++ b/test/cuda/curnn.jl
@@ -8,7 +8,7 @@ using Flux, CUDA, Test
   θ = gradient(() -> sum(m(x)), params(m))
   @test x isa CuArray
   @test θ[m.cell.Wi] isa CuArray
-  @test collect(m̄[].cell.Wi) == collect(θ[m.cell.Wi])
+  @test collect(m̄.cell.Wi) == collect(θ[m.cell.Wi])
 end
 
 @testset "RNN" begin


### PR DESCRIPTION
I also found another case with the RNNs on CPU that ought to work (it is taken from the CUDA tests):

```Julia
julia> m = LSTM(10,5);

julia> x = gpu(rand(10))
10-element Vector{Float64}:
 0.2904022727983888
 0.3478379218964027
 0.42768958025210235
 0.04257538661918936
 0.8775572608007804
 0.9921291141175299
 0.4817815828890992
 0.5651999360978797
 0.8793599163240291
 0.6348052530428492

julia> m(x)
ERROR: MethodError: no method matching (::Flux.LSTMCell{Matrix{Float32}, Vector{Float32}, Tuple{Matrix{Float32}, Matrix{Float32}}})(::Tuple{Matrix{Float32}, Matrix{Float32}}, ::Matrix{Float64})
Closest candidates are:
  (::Flux.LSTMCell{A, V, var"#s370"} where var"#s370"<:Tuple{AbstractMatrix{T}, AbstractMatrix{T}})(::Any, ::Union{AbstractVector{T}, AbstractMatrix{T}, Flux.OneHotArray}) where {A, V, T} at /Users/dhairyagandhi/Downloads/temp/bld/Flux.jl/src/layers/recurrent.jl:157
Stacktrace:
 [1] (::Flux.Recur{Flux.LSTMCell{Matrix{Float32}, Vector{Float32}, Tuple{Matrix{Float32}, Matrix{Float32}}}, Tuple{Matrix{Float32}, Matrix{Float32}}})(x::Matrix{Float64})
   @ Flux ~/Downloads/temp/bld/Flux.jl/src/layers/recurrent.jl:47
 [2] top-level scope
   @ REPL[13]:1
 [3] top-level scope
   @ ~/.julia/packages/CUDA/YpW0k/src/initialization.jl:52
```