### PR TITLE
Remove Recurrent cell eltype restriction

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -100,7 +100,7 @@ end
 RNNCell(in::Integer, out::Integer, σ=tanh; init=Flux.glorot_uniform, initb=zeros32, init_state=zeros32) = 
   RNNCell(σ, init(out, in), init(out, out), initb(out), init_state(out,1))
 
-function (m::RNNCell{F,A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {F,A,V,T}
+function (m::RNNCell)(h, x::Union{AbstractVecOrMat,OneHotArray})
   σ, Wi, Wh, b = m.σ, m.Wi, m.Wh, m.b
   h = σ.(Wi*x .+ Wh*h .+ b)
   sz = size(x)
@@ -154,7 +154,7 @@ function LSTMCell(in::Integer, out::Integer;
   return cell
 end
 
-function (m::LSTMCell{A,V,<:NTuple{2,AbstractMatrix{T}}})((h, c), x::Union{AbstractVecOrMat{T},OneHotArray}) where {A,V,T}
+function (m::LSTMCell)((h, c), x::Union{AbstractVecOrMat,OneHotArray})
   b, o = m.b, size(h, 1)
   g = m.Wi*x .+ m.Wh*h .+ b
   input = σ.(gate(g, o, 1))
@@ -222,7 +222,7 @@ end
 GRUCell(in, out; init = glorot_uniform, initb = zeros32, init_state = zeros32) =
   GRUCell(init(out * 3, in), init(out * 3, out), initb(out * 3), init_state(out,1))
 
-function (m::GRUCell{A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {A,V,T}
+function (m::GRUCell)(h, x::Union{AbstractVecOrMat,OneHotArray})
   b, o = m.b, size(h, 1)
   gx, gh, r, z = _gru_output(m.Wi, m.Wh, b, x, h)
   h̃ = tanh.(gate(gx, o, 3) .+ r .* gate(gh, o, 3) .+ gate(b, o, 3))
@@ -276,7 +276,7 @@ GRUv3Cell(in, out; init = glorot_uniform, initb = zeros32, init_state = zeros32)
   GRUv3Cell(init(out * 3, in), init(out * 2, out), initb(out * 3), 
             init(out, out), init_state(out,1))
 
-function (m::GRUv3Cell{A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {A,V,T}
+function (m::GRUv3Cell)(h, x::Union{AbstractVecOrMat,OneHotArray})
   b, o = m.b, size(h, 1)
   gx, gh, r, z = _gru_output(m.Wi, m.Wh, b, x, h)
   h̃ = tanh.(gate(gx, o, 3) .+ (m.Wh_h̃ * (r .* h)) .+ gate(b, o, 3))

--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -14,8 +14,10 @@ struct Nil <: Number end
 const nil = Nil()
 
 Nil(::T) where T<:Number = nil
-(::Type{T})(::Nil) where T<:Number = nil
-Base.convert(::Type{Nil}, ::Number) = nil
+Nil(::Nil) = nil
+(::Type{T})(::Nil) where T<:Number = T(NaN)
+Base.convert(::Type{Nil}, ::Type{T}) where T<:Number = T(NaN)
+
 
 Base.float(::Type{Nil}) = Nil
 

--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -17,8 +17,10 @@ Nil(::T) where T<:Number = nil
 Nil(::Nil) = nil
 (::Type{T})(::Nil) where T<:Number = T(NaN)
 Base.convert(::Type{T}, ::Nil) where T<:Number = T(NaN)
+Base.convert(::Nil, ::Type{T}) where T<:Number = nil
 
 Base.float(::Type{Nil}) = Float64
+Base.float(::Nil) = NaN
 
 for f in [:copy, :zero, :one, :oneunit,
           :+, :-, :abs, :abs2, :inv,

--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -16,10 +16,9 @@ const nil = Nil()
 Nil(::T) where T<:Number = nil
 Nil(::Nil) = nil
 (::Type{T})(::Nil) where T<:Number = T(NaN)
-Base.convert(::Type{Nil}, ::Type{T}) where T<:Number = T(NaN)
+Base.convert(::Type{T}, ::Nil) where T<:Number = T(NaN)
 
-
-Base.float(::Type{Nil}) = Nil
+Base.float(::Type{Nil}) = Float64
 
 for f in [:copy, :zero, :one, :oneunit,
           :+, :-, :abs, :abs2, :inv,

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -93,6 +93,6 @@ end
     m = R(3, 5)
     x = rand(Float64, 3, 1)
     Flux.reset!(m)
-    @test_throws MethodError m(x)
+    @test size(m(x)) == (5, 1)
   end
 end

--- a/test/outputsize.jl
+++ b/test/outputsize.jl
@@ -130,6 +130,22 @@ end
   @test outputsize(m, (5, 5, 2, 1)) == (5, 5, 2, 1)
 end
 
+@testset "recurrent" begin
+    @testset for R in [RNN, GRU, LSTM, GRUv3]
+        m = R(10, 5)
+        @test_throws DimensionMismatch outputsize(m, (5, 2)) == (5, 1)
+        @test outputsize(m, (10,)) == (5,)
+        @test outputsize(m, (10,); padbatch=true) == (5, 1)
+        @test outputsize(m, (10, 2)) == (5, 2)
+        @test outputsize(m, (10, 2); padbatch=true) == (5, 2, 1)
+    end
+    m = Chain(Dense(5, 10), RNN(10, 8), GRU(8, 6), LSTM(6, 4), GRUv3(4, 2), Dense(2, 3))
+    @test outputsize(m, (5,)) == (3,)
+    @test outputsize(m, (5,); padbatch=true) == (3, 1)
+    @test outputsize(m, (5, 2)) == (3, 2)
+    @test outputsize(m, (5, 2); padbatch=true) == (3, 2, 1)
+end
+
 @testset "normalisation" begin
   m = Dropout(0.1)
   @test outputsize(m, (10, 10)) == (10, 10)


### PR DESCRIPTION
Remove type restriction in the methods associated with recurrent cells `RNN`, `LSTM`, `GRU` and `GRUv3`.

Change conversion of `Nil` to other types, so `Nil()` gets converted to `NaN16, NaN32, NaN` for the corresponding float types and also complex types with float real and imaginary parts. Conversion errors for Integer and Rational types, in accordance to the errors when converting non integer floats.

This allows `outputsize` to work with recurrent cells as well.

Suitable tests were added.

This should fix #1565.

### PR Checklist

- [X ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
