### PR TITLE
Use view for RNN gate slice extraction

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -1,7 +1,7 @@
 
 gate(h, n) = (1:h) .+ h*(n-1)
 gate(x::AbstractVector, h, n) = @view x[gate(h,n)]
-gate(x::AbstractMatrix, h, n) = x[gate(h,n),:]
+gate(x::AbstractMatrix, h, n) = view(x, gate(h,n), :)
 
 # Stateful recurrence
 
@@ -97,7 +97,7 @@ struct RNNCell{F,A,V,S}
   state0::S
 end
 
-RNNCell(in::Integer, out::Integer, σ=tanh; init=Flux.glorot_uniform, initb=zeros32, init_state=zeros32) = 
+RNNCell(in::Integer, out::Integer, σ=tanh; init=Flux.glorot_uniform, initb=zeros32, init_state=zeros32) =
   RNNCell(σ, init(out, in), init(out, out), initb(out), init_state(out,1))
 
 function (m::RNNCell{F,A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {F,A,V,T}
@@ -194,7 +194,7 @@ function Base.getproperty(m::LSTMCell, sym::Symbol)
   elseif sym === :c
     Zygote.ignore() do
       @warn "LSTMCell field :c has been deprecated. Use m::LSTMCell.state0[2] instead."
-    end  
+    end
     return getfield(m, :state0)[2]
   else
     return getfield(m, sym)
@@ -273,7 +273,7 @@ struct GRUv3Cell{A,V,S}
 end
 
 GRUv3Cell(in, out; init = glorot_uniform, initb = zeros32, init_state = zeros32) =
-  GRUv3Cell(init(out * 3, in), init(out * 2, out), initb(out * 3), 
+  GRUv3Cell(init(out * 3, in), init(out * 2, out), initb(out * 3),
             init(out, out), init_state(out,1))
 
 function (m::GRUv3Cell{A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {A,V,T}

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -96,3 +96,13 @@ end
     @test_throws MethodError m(x)
   end
 end
+
+@testset "multigate" begin
+  x = rand(6, 5)
+  res, (dx,) = Flux.withgradient(x) do x
+    x1, _, x3 = Flux.multigate(x, 2, Val(3))
+    sum(x1) + sum(x3 .* 2)
+  end
+  @test res == sum(x[1:2, :]) + 2sum(x[5:6, :])
+  @test dx == [ones(2, 5); zeros(2, 5); fill(2, 2, 5)]
+end


### PR DESCRIPTION
This was originally passed over in https://github.com/FluxML/Flux.jl/pull/907, but I don't find the argument in that PR particularly compelling as the return value is only ever used once. Any negative impact on caching is going to happen anyhow during the slice materialization, so we might as well just let the subsequent fused broadcasts handle said materialization for us while reducing allocations.

Pinging @jeremiedb, @sdobber and @mkschleg if they have any interesting benchmarks to run this on. Otherwise I'll try to get something working with https://github.com/FluxML/Flux.jl/blob/master/perf/bench_utils.jl locally.

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [N/A] Documentation, if applicable
- [N/A] API changes require approval from a committer (different from the author, if applicable)
