### PR TITLE
Fix a doctest failure

### DIFF
--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -26,7 +26,7 @@ When a function has many parameters, we can get gradients of each one at the sam
 julia> f(x, y) = sum((x .- y).^2);
 
 julia> gradient(f, [2, 1], [2, 0])
-([0, 2], [0, -2])
+([0.0, 2.0], [-0.0, -2.0])
 ```
 
 These gradients are based on `x` and `y`. Flux works by instead taking gradients based on the weights and biases that make up the parameters of a model. 

--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -51,7 +51,7 @@ julia> gs[x]
 
 julia> gs[y]
 2-element Vector{Float64}:
-  0.0
+ -0.0
  -2.0
 ```
 

--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -45,14 +45,14 @@ julia> gs = gradient(params(x, y)) do
 Grads(...)
 
 julia> gs[x]
-2-element Vector{Int64}:
- 0
- 2
+2-element Vector{Float64}:
+ 0.0
+ 2.0
 
 julia> gs[y]
-2-element Vector{Int64}:
-  0
- -2
+2-element Vector{Float64}:
+  0.0
+ -2.0
 ```
 
 Here, `gradient` takes a zero-argument function; no arguments are necessary because the `params` tell it what to differentiate.


### PR DESCRIPTION
This fixes a doctest failure that seems to be causing builds to fail. The issue seems to be that gradient now returns floats, even if the inputs are integers.

See the following stack trace:

```
┌ Error: doctest failure in ~/work/Flux.jl/Flux.jl/docs/src/models/basics.md:25-30
│ 
│ ```jldoctest basics
│ julia> f(x, y) = sum((x .- y).^2);
│ 
│ julia> gradient(f, [2, 1], [2, 0])
│ ([0, 2], [0, -2])
│ ```
│ 
│ Subexpression:
│ 
│ gradient(f, [2, 1], [2, 0])
│ 
│ Evaluated output:
│ 
│ ([0.0, 2.0], [-0.0, -2.0])
│ 
│ Expected output:
│ 
│ ([0, 2], [0, -2])
│ 
│   diff =
│    Warning: Diff output requires color.
│    ([0, 2], [0, -2])([0.0, 2.0], [-0.0, -2.0])
└ @ Documenter.DocTests ~/.julia/packages/Documenter/bFHi4/src/DocTests.jl:373
┌ Error: doctest failure in ~/work/Flux.jl/Flux.jl/docs/src/models/basics.md:37-56
│ 
│ ```jldoctest basics
│ julia> x = [2, 1];
│ 
│ julia> y = [2, 0];
│ 
│ julia> gs = gradient(params(x, y)) do
│          f(x, y)
│        end
│ Grads(...)
│ 
│ julia> gs[x]
│ 2-element Vector{Int64}:
│  0
│  2
│ 
│ julia> gs[y]
│ 2-element Vector{Int64}:
│   0
│  -2
│ ```
│ 
│ Subexpression:
│ 
│ gs[x]
│ 
│ Evaluated output:
│ 
│ 2-element Vector{Float64}:
│  0.0
│  2.0
│ 
│ Expected output:
│ 
│ 2-element Vector{Int64}:
│  0
│  2
│ 
│   diff =
│    Warning: Diff output requires color.
│    2-element Vector{Int64}:
│     0
│     2Vector{Float64}:
│     0.0
│     2.0
└ @ Documenter.DocTests ~/.julia/packages/Documenter/bFHi4/src/DocTests.jl:373
┌ Error: doctest failure in ~/work/Flux.jl/Flux.jl/docs/src/models/basics.md:37-56
│ 
│ ```jldoctest basics
│ julia> x = [2, 1];
│ 
│ julia> y = [2, 0];
│ 
│ julia> gs = gradient(params(x, y)) do
│          f(x, y)
│        end
│ Grads(...)
│ 
│ julia> gs[x]
│ 2-element Vector{Int64}:
│  0
│  2
│ 
│ julia> gs[y]
│ 2-element Vector{Int64}:
│   0
│  -2
│ ```
│ 
│ Subexpression:
│ 
│ gs[y]
│ 
│ Evaluated output:
│ 
│ 2-element Vector{Float64}:
│  -0.0
│  -2.0
│ 
│ Expected output:
│ 
│ 2-element Vector{Int64}:
│   0
│  -2
│ 
│   diff =
│    Warning: Diff output requires color.
│    2-element Vector{Int64}:
│      0
│     -2Vector{Float64}:
│     -0.0
│     -2.0
└ @ Documenter.DocTests ~/.julia/packages/Documenter/bFHi4/src/DocTests.jl:373
┌ Error: Doctesting failed
│   exception =
│    `makedocs` encountered a doctest error. Terminating build
│    Stacktrace:
│      [1] error(s::String)
│        @ Base ./error.jl:33
│      [2] runner(#unused#::Type{Documenter.Builder.Doctest}, doc::Documenter.Documents.Document)
│        @ Documenter.Builder ~/.julia/packages/Documenter/bFHi4/src/Builder.jl:217
│      [3] dispatch(#unused#::Type{Documenter.Builder.DocumentPipeline}, x::Documenter.Documents.Document)
│        @ Documenter.Utilities.Selectors ~/.julia/packages/Documenter/bFHi4/src/Utilities/Selectors.jl:170
│      [4] #2
│        @ ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:249 [inlined]
│      [5] cd(f::Documenter.var"#2#3"{Documenter.Documents.Document}, dir::String)
│        @ Base.Filesystem ./file.jl:106
│      [6] makedocs(; debug::Bool, format::Documenter.Writers.HTMLWriter.HTML, kwargs::Base.Iterators.Pairs{Symbol, Any, NTuple{6, Symbol}, NamedTuple{(:root, :source, :sitename, :doctest, :modules, :doctestfilters), Tuple{String, String, String, Symbol, Vector{Module}, Vector{Regex}}}})
│        @ Documenter ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:248
│      [7] (::Documenter.var"#all_doctests#35"{Bool, Vector{Regex}, Vector{Module}})()
│        @ Documenter ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:815
│      [8] macro expansion
│        @ ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:836 [inlined]
│      [9] macro expansion
│        @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
│     [10] doctest(source::String, modules::Vector{Module}; fix::Bool, testset::String, doctestfilters::Vector{Regex})
│        @ Documenter ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:836
│     [11] doctest(package::Module; manual::Bool, testset::Nothing, kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
│        @ Documenter ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:771
│     [12] doctest(package::Module)
│        @ Documenter ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:758
│     [13] top-level scope
│        @ none:7
│     [14] eval
│        @ ./boot.jl:360 [inlined]
│     [15] exec_options(opts::Base.JLOptions)
│        @ Base ./client.jl:261
│     [16] _start()
│        @ Base ./client.jl:485
└ @ Documenter ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:825
Doctests: Flux: Test Failed at /home/runner/.julia/packages/Documenter/bFHi4/src/Documenter.jl:836
  Expression: all_doctests()
Stacktrace:
 [1] macro expansion
   @ ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:836 [inlined]
 [2] macro expansion
   @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
 [3] doctest(source::String, modules::Vector{Module}; fix::Bool, testset::String, doctestfilters::Vector{Regex})
   @ Documenter ~/.julia/packages/Documenter/bFHi4/src/Documenter.jl:836
Test Summary:  | Fail  Total
Doctests: Flux |    1      1
ERROR: Some tests did not pass: 0 passed, 1 failed, 0 errored, 0 broken.
Error: Process completed with exit code 1.
```