### PR TITLE
Update train.jl to add a more detailed `train!` docstring

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -91,8 +91,7 @@ respect to `params` through backpropagation and call the optimizer `opt`.
         
 If `d` is a tuple of arguments to `loss` call `loss(d...)`, else call `loss(d)`.
         
-To get the trainable parameters, generally you pass the model to the [`Flux.params`](@ref)
-function (the just the layers you want to train) like `train!(loss, params(model), ...)`.
+To pass trainable parameters, call [`Flux.params`](@ref) with your model or just the layers you want to train, like `train!(loss, params(model), ...)`.
 
 A callback is given with the keyword argument `cb`. For example, this will print
 "training" every 10 seconds (using [`Flux.throttle`](@ref)):

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -83,19 +83,21 @@ batchmemaybe(x::Tuple) = x
 """
     train!(loss, params, data, opt; cb)
         
-`train!` uses a loss function (`loss`) and training data (`data`) to improve the 
-parameters (`params`) of your model based on a pluggable optimiser (`opt`).
+`train!` uses a [Loss-Functions](@ref) (`loss`) and training [Datasets](@ref) (`data`) to improve the 
+[Model-parameters](@ref) (`params`) of your model based on a pluggable [Optimisers](@ref) (`opt`).
         
 For each datapoint `d` in `data`, compute the gradient of  `loss` with
 respect to `params` through backpropagation and call the optimizer `opt`.
 If `d` is a tuple of arguments to `loss` call `loss(d...)`, else call `loss(d)`.
         
-To pass trainable parameters, call [`Flux.params`](@ref) with your model or just the layers you want to train, like `train!(loss, params(model), ...)`.
+To pass trainable parameters, call [`Flux.params`](@ref) with your model or just the 
+layers you want to train, like `train!(loss, params(model), ...)` or `train!(loss, params(model[1:end-2), ...)` respectively.
 
-A callback is given with the keyword argument `cb`. For example, this will print
-"training" every 10 seconds (using [`Flux.throttle`](@ref)):
-    train!(loss, params, data, opt, cb = throttle(() -> println("training"), 10))
-
+[Callbacks]@ref) are given with the keyword argument `cb`. For example, this will print "training" 
+every 10 seconds (using [`Flux.throttle`](@ref)):
+```julia
+train!(loss, params, data, opt, cb = throttle(() -> println("training"), 10))
+```
 The callback can call [`Flux.stop`](@ref) to interrupt the training loop.
 
 Multiple optimisers and callbacks can be passed to `opt` and `cb` as arrays.

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -83,7 +83,7 @@ batchmemaybe(x::Tuple) = x
 """
     train!(loss, params, data, opt; cb)
         
-`train!` uses a [Loss Functions](@ref) (`loss`) and training [Datasets](@ref) (`data`) to improve the 
+`train!` uses a `loss` function and training `data` to improve the 
 [Model parameters](@ref) (`params`) based on a pluggable [Optimisers](@ref) (`opt`).
         
 For each datapoint `d` in `data`, compute the gradient of  `loss` with

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -83,8 +83,8 @@ batchmemaybe(x::Tuple) = x
 """
     train!(loss, params, data, opt; cb)
         
-`train!` uses a [`loss function`](@ref Loss Functions) (`loss`) and training [`data`](@ref Datasets) (`data`) to improve the 
-[`patameters`](@ref Model parameters) (`params`) of your model based on a pluggable [`optimisers`](@ref Optimisers) (`opt`).
+`train!` uses a [Loss Functions](@ref) (`loss`) and training [Datasets](@ref) (`data`) to improve the 
+[Model parameters](@ref) (`params`) based on a pluggable [Optimisers](@ref) (`opt`).
         
 For each datapoint `d` in `data`, compute the gradient of  `loss` with
 respect to `params` through backpropagation and call the optimizer `opt`.

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -88,7 +88,6 @@ parameters (`params`) of your model based on a pluggable optimiser (`opt`).
         
 For each datapoint `d` in `data`, compute the gradient of  `loss` with
 respect to `params` through backpropagation and call the optimizer `opt`.
-        
 If `d` is a tuple of arguments to `loss` call `loss(d...)`, else call `loss(d)`.
         
 To pass trainable parameters, call [`Flux.params`](@ref) with your model or just the layers you want to train, like `train!(loss, params(model), ...)`.

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -83,8 +83,8 @@ batchmemaybe(x::Tuple) = x
 """
     train!(loss, params, data, opt; cb)
         
-`train!` uses a [Loss-Functions](@ref) (`loss`) and training [Datasets](@ref) (`data`) to improve the 
-[Model-parameters](@ref) (`params`) of your model based on a pluggable [Optimisers](@ref) (`opt`).
+`train!` uses a [`loss function`](@ref Flux.Training.Loss-Functions) (`loss`) and training [`data`](@ref Flux.Training.Datasets) (`data`) to improve the 
+[`patameters`](@ref Flux.Training.Model-parameters) (`params`) of your model based on a pluggable [`optimisers`](@ref Flux.Training.Optimisers) (`opt`).
         
 For each datapoint `d` in `data`, compute the gradient of  `loss` with
 respect to `params` through backpropagation and call the optimizer `opt`.
@@ -95,9 +95,8 @@ layers you want to train, like `train!(loss, params(model), ...)` or `train!(los
 
 [Callbacks](@ref) are given with the keyword argument `cb`. For example, this will print "training" 
 every 10 seconds (using [`Flux.throttle`](@ref)):
-```julia
-train!(loss, params, data, opt, cb = throttle(() -> println("training"), 10))
-```
+`train!(loss, params, data, opt, cb = throttle(() -> println("training"), 10))`
+        
 The callback can call [`Flux.stop`](@ref) to interrupt the training loop.
 
 Multiple optimisers and callbacks can be passed to `opt` and `cb` as arrays.

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -83,8 +83,8 @@ batchmemaybe(x::Tuple) = x
 """
     train!(loss, params, data, opt; cb)
         
-`train!` uses a [`loss function`](@ref Flux.Training.Loss-Functions) (`loss`) and training [`data`](@ref Flux.Training.Datasets) (`data`) to improve the 
-[`patameters`](@ref Flux.Training.Model-parameters) (`params`) of your model based on a pluggable [`optimisers`](@ref Flux.Training.Optimisers) (`opt`).
+`train!` uses a [`loss function`](@ref Loss Functions) (`loss`) and training [`data`](@ref Datasets) (`data`) to improve the 
+[`patameters`](@ref Model parameters) (`params`) of your model based on a pluggable [`optimisers`](@ref Optimisers) (`opt`).
         
 For each datapoint `d` in `data`, compute the gradient of  `loss` with
 respect to `params` through backpropagation and call the optimizer `opt`.

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -82,11 +82,17 @@ batchmemaybe(x::Tuple) = x
 
 """
     train!(loss, params, data, opt; cb)
-
+        
+`train!` uses a loss function (`loss`) and training data (`data`) to improve the 
+parameters (`params`) of your model based on a pluggable optimiser `opt`.
+        
 For each datapoint `d` in `data`, compute the gradient of  `loss` with
 respect to `params` through backpropagation and call the optimizer `opt`.
-
+        
 If `d` is a tuple of arguments to `loss` call `loss(d...)`, else call `loss(d)`.
+        
+To get the trainable parameters, generally you pass the model to the [`Flux.params`](@ref)
+function (the just the layers you want to train) like `train!(loss, params(model), ...)`.
 
 A callback is given with the keyword argument `cb`. For example, this will print
 "training" every 10 seconds (using [`Flux.throttle`](@ref)):

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -84,7 +84,7 @@ batchmemaybe(x::Tuple) = x
     train!(loss, params, data, opt; cb)
         
 `train!` uses a loss function (`loss`) and training data (`data`) to improve the 
-parameters (`params`) of your model based on a pluggable optimiser `opt`.
+parameters (`params`) of your model based on a pluggable optimiser (`opt`).
         
 For each datapoint `d` in `data`, compute the gradient of  `loss` with
 respect to `params` through backpropagation and call the optimizer `opt`.

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -93,7 +93,7 @@ If `d` is a tuple of arguments to `loss` call `loss(d...)`, else call `loss(d)`.
 To pass trainable parameters, call [`Flux.params`](@ref) with your model or just the 
 layers you want to train, like `train!(loss, params(model), ...)` or `train!(loss, params(model[1:end-2), ...)` respectively.
 
-[Callbacks]@ref) are given with the keyword argument `cb`. For example, this will print "training" 
+[Callbacks](@ref) are given with the keyword argument `cb`. For example, this will print "training" 
 every 10 seconds (using [`Flux.throttle`](@ref)):
 ```julia
 train!(loss, params, data, opt, cb = throttle(() -> println("training"), 10))


### PR DESCRIPTION
Right now, the `train!` function docstring does not tell you what you need to do with respect to params. I tried to add that and moved a sentence from somewhere else in the docs about what the train function does to the top of the doc string.
