### PR TITLE
Add spaces around `=` for kwargs

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,12 +1,12 @@
 # v0.12 deprecations
-@deprecate Dropout(p, dims) Dropout(p; dims=dims)
-@deprecate InstanceNorm(λ, β, γ, μ, σ², ϵ, momentum, active=nothing) InstanceNorm(λ, β, γ, μ, σ², ϵ, momentum, true, true, active, length(β))
-@deprecate BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, active=nothing) BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, true, true, active, length(β))
-@deprecate GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum, active=nothing) GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum, true, true, active, length(β))
+@deprecate Dropout(p, dims) Dropout(p; dims = dims)
+@deprecate InstanceNorm(λ, β, γ, μ, σ², ϵ, momentum, active = nothing) InstanceNorm(λ, β, γ, μ, σ², ϵ, momentum, true, true, active, length(β))
+@deprecate BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, active = nothing) BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, true, true, active, length(β))
+@deprecate GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum, active = nothing) GroupNorm(G, λ, β, γ, μ, σ², ϵ, momentum, true, true, active, length(β))
 @deprecate outdims(f, inputsize) outputsize(f, inputsize)
-@deprecate Conv(; weight,  bias, activation=identity, kws...) Conv(weight, bias, activation; kws...) 
-@deprecate ConvTranspose(; weight, bias, activation=identity, kws...) ConvTranspose(weight, bias, activation; kws...) 
-@deprecate DepthwiseConv(; weight, bias, activation=identity, kws...) DepthwiseConv(weight, bias, activation; kws...) 
+@deprecate Conv(; weight,  bias, activation = identity, kws...) Conv(weight, bias, activation; kws...) 
+@deprecate ConvTranspose(; weight, bias, activation = identity, kws...) ConvTranspose(weight, bias, activation; kws...) 
+@deprecate DepthwiseConv(; weight, bias, activation = identity, kws...) DepthwiseConv(weight, bias, activation; kws...) 
 
 function Base.getproperty(a::Dense, s::Symbol)
   if s === :W

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -346,13 +346,13 @@ julia> Flux.identity_init(3,3,2,2)
 ```
 """
 # Assume bias
-identity_init(cols; gain=1, shift=0) = zeros32(cols)
+identity_init(cols; gain = 1, shift = 0) = zeros32(cols)
 
 # Assume matrix multiplication
-identity_init(rows, cols; gain=1, shift=0) = circshift(Matrix{Float32}(I * gain, rows,cols), shift)
+identity_init(rows, cols; gain = 1, shift = 0) = circshift(Matrix{Float32}(I * gain, rows,cols), shift)
 
 # Assume convolution
-function identity_init(dims...; gain=1, shift=0)
+function identity_init(dims...; gain = 1, shift = 0)
   nin, nout = dims[end-1], dims[end]
   centers = map(d -> cld(d, 2), dims[1:end-2])
   weights = zeros32(dims)
@@ -696,7 +696,7 @@ going more than once per `wait` duration; but if you'd like to disable the
 execution on the leading edge, pass `leading=false`. To enable execution on
 the trailing edge, pass `trailing=true`.
 """
-function throttle(f, timeout; leading=true, trailing=false)
+function throttle(f, timeout; leading = true, trailing = false)
   cooldown = true
   later = nothing
   result = nothing


### PR DESCRIPTION
I tried to make `deprecations.jl` and `utils.jl` adhere to code style i.e to have spaces around `=` as mentioned here https://github.com/FluxML/Flux.jl/issues/1765.
