### PR TITLE
Update basics.md to include gradient docs

### DIFF
--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -5,7 +5,7 @@
 Flux's core feature is taking gradients of Julia code. The `gradient` function takes another Julia function `f` and a set of arguments, and returns the gradient with respect to each argument. (It's a good idea to try pasting these examples in the Julia terminal.)
 
 ```@docs
-Flux.gradient
+Flux.Zygote.gradient
 ```
 
 ```jldoctest basics

--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -4,6 +4,10 @@
 
 Flux's core feature is taking gradients of Julia code. The `gradient` function takes another Julia function `f` and a set of arguments, and returns the gradient with respect to each argument. (It's a good idea to try pasting these examples in the Julia terminal.)
 
+```@docs
+Flux.gradient
+```
+
 ```jldoctest basics
 julia> using Flux
 


### PR DESCRIPTION
Right now, when you search `gradient` in the docs, the actual docstring is not being displayed in the docs anywhere. I am not Sure if this is the right place for it but it seems close.
