### PR TITLE
Added the wrapper `Bidirectional` for RNN layers

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -439,9 +439,8 @@ A wrapper layer that allows bidirectional recurrent layers.
 
 
 # Examples
-```julia
-BLSTM = Bidirectional(LSTM, 3, 5)
-
+```jldoctest
+julia> BLSTM = Bidirectional(LSTM, 3, 5)
 Bidirectional(
   Recur(
     LSTMCell(3, 5),                     # 190 parameters
@@ -451,22 +450,12 @@ Bidirectional(
   ),
 )         # Total: 10 trainable arrays, 380 parameters,
           # plus 4 non-trainable, 20 parameters, summarysize 2.141 KiB.
-```
 
-```julia 
-BLSTM(rand(Float32, 3)) |> size
+julia> BLSTM(rand(Float32, 3)) |> size
 
 (10,)
-```
 
-```julia 
-model = Chain(
-  Embedding(10000, 200),
-  Bidirectional(LSTM, 200, 128),
-  Dense(256, 5),
-  softmax
-)
-
+julia> model = Chain(Embedding(10000, 200), Bidirectional(LSTM, 200, 128), Dense(256, 5), softmax)
 Chain(
   Embedding(10000, 200),                # 2_000_000 parameters
   Bidirectional(
@@ -497,7 +486,6 @@ Bidirectional(forward, backward, in::Integer, out::Integer) = Bidirectional(forw
 # Constructor to add the same cell as forward and backward with given input and output sizes
 Bidirectional(rnn, in::Integer, out::Integer) = Bidirectional(rnn, in, out, rnn, in, out)
 
-
 # Concatenate the forward and reversed backward weights
 function (m::Bidirectional)(x::Union{AbstractVecOrMat{T},OneHotArray}) where {T}
   return vcat(m.forward(x), reverse(m.backward(reverse(x; dims=1)); dims=1))
@@ -506,8 +494,7 @@ end
 Flux.@functor Bidirectional
 
 # Show adaptations
-function _big_show(io::IO, obj::Bidirectional, indent::Int=0, name=nothing)
-    
+function _big_show(io::IO, obj::Bidirectional, indent::Int=0, name=nothing)  
   println(io, " "^indent, isnothing(name) ? "" : "$name = ", nameof(typeof(obj)), "(")
   # then we insert names -- can this be done more generically? 
   for k in propertynames(obj)

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -491,14 +491,8 @@ struct Bidirectional{A,B}
   backward::B
 end
 
-# Generic constructor for every case
-Bidirectional(forward, f_in::Integer, f_out::Integer, backward, b_in::Integer, b_out::Integer) = Bidirectional(forward(f_in, f_out), backward(b_in, b_out))
-
-# Constructor for forward and backward having the same size
-Bidirectional(forward, backward, in::Integer, out::Integer) = Bidirectional(forward(in, out), backward(in, out))
-
-# Constructor to add the same cell as forward and backward with given input and output sizes
-Bidirectional(rnn, in::Integer, out::Integer) = Bidirectional(rnn(in, out), rnn(in, out))
+# Constructor that creates a bidirectional with the same layer for forward and backward
+Bidirectional(rnn, a...; ka...) = Bidirectional(rnn(a...; ka...), rnn(a...; ka...))
 
 
 # Concatenate the forward and reversed backward weights
@@ -507,15 +501,3 @@ function (m::Bidirectional)(x::Union{AbstractVecOrMat{T},OneHotArray}) where {T}
 end
 
 @functor Bidirectional
-Base.getproperty(m::Bidirectional, sym::Symbol) = getfield(m, sym)
-
-# Show adaptations
-function _big_show(io::IO, obj::Bidirectional, indent::Int=0, name=nothing)  
-  println(io, " "^indent, isnothing(name) ? "" : "$name = ", nameof(typeof(obj)), "(")
-  # then we insert names -- can this be done more generically? 
-  for k in propertynames(obj)
-      _big_show(io, getfield(obj, k), indent+2, k)
-  end
-end
-
-Base.show(io::IO, m::MIME"text/plain", x::Bidirectional) = _big_show(io, x)

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -456,19 +456,6 @@ Bidirectional(
 julia> Bidirectional(LSTM, 3, 5)(rand(Float32, 3)) |> size
 (10,)
 
-julia> Bidirectional(LSTM, 3, 5)(rand(Float32, 3))
-10-element Vector{Float32}:
-  0.009660141
- -0.011628074
- -0.017348368
- -0.002131971
-  0.0152327195
- -0.024785668
-  0.021315152
- -0.015476399
-  0.01589005
- -0.002576883
-
 julia> model = Chain(Embedding(10000, 200), Bidirectional(LSTM, 200, 128), Dense(256, 5), softmax)
 Chain(
   Embedding(10000, 200),                # 2_000_000 parameters

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -526,3 +526,11 @@ function (m::Bidirectional)(x::Union{AbstractVecOrMat{T},OneHotArray}) where {T}
 end
 
 @functor Bidirectional
+
+function Base.show(io::IO, b::Bidirectional)
+  print(io, "Bidirectional(")
+  show(io, b.forward.cell)
+  print(io, ", ")
+  show(io, b.backward.cell)
+  print(io, ")")
+end;

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -516,9 +516,8 @@ struct Bidirectional{A,B}
 end
 
 # Constructor that creates a bidirectional with the same layer for forward and backward
-# Needs to have `in` and `out` explicitly declared to avoid conflicts with the default construtor
-Bidirectional(rnn, in::Int, out::Int, a...; ka...) = Bidirectional(rnn(in, out, a...; ka...), rnn(in, out, a...; ka...))
-
+# Needs to have `in` explicitly declared to avoid conflicts with the default construtor
+Bidirectional(rnn, in::Integer, args...; ka...) = Bidirectional(rnn(in, args...; ka...), rnn(in, args...; ka...))
 
 # Concatenate the forward and reversed backward weights
 function (m::Bidirectional)(x::Union{AbstractVecOrMat{T},OneHotArray}) where {T}

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -1,6 +1,6 @@
 
 for T in [
-    :Chain, :Parallel, :SkipConnection, :Recur  # container types
+    :Chain, :Parallel, :SkipConnection, :Recur, :Bidirectional  # container types
   ]
   @eval function Base.show(io::IO, m::MIME"text/plain", x::$T)
     if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL


### PR DESCRIPTION
### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)

### Description

The implementation was based on the implementation of `BiLSTM_CNN_CRF_Model` present on [TextModels.jl](https://github.com/JuliaText/TextModels.jl)  but has a few differences:

- It leaves the `Bidirectional` usage closer to `Keras` as it allows the creation of, for example, `Bidirectional(Flux.LSTM, in, out)` inside a `Chain` declarations.
- It explicitly adds the `dims=1` parameter on the `reverse` function, which was needed in my experiments but more generic implementation may be possible (I was not able to use `flip` probably for the same reason).

I also updated the `Base.show` and `_big_show` functions so that it is printed in the same style of `Flux` giving the number of trainable parameters.  The implementation added for the `_big_show` could be added to  `src/show.jl` later.


This is my first PR here, I read the information on `CONTRIBUTING.md`, but please let me know if it is not following the correct standards. I really enjoy `Julia` even though I am still learning. 

Hope I can contribute to this great project `Flux`. 