### PR TITLE
Reduce allocations in Dropout

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -31,7 +31,7 @@ The [`Dropout`](@ref) layer is what you should use in most scenarios.
 function dropout(x, p; dims=:, active::Bool=true)
   active || return x
   y = rand!(similar(x, _dropout_shape(x, dims)))
-  @inbounds @. y = x * _dropout_kernel(y, p, 1-p)
+  @. y = x * _dropout_kernel(y, p, 1-p)
 end
 
 @adjoint function dropout(x, p; dims=:, active::Bool=true)
@@ -56,7 +56,7 @@ e.g. `Dropout(p; dims = 3)` will randomly zero out entire channels on WHCN input
 (also called 2D dropout).
 
 Does nothing to the input once [`Flux.testmode!`](@ref) is `true`.
-"""`
+"""
 mutable struct Dropout{F,D}
   p::F
   dims::D

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -34,7 +34,7 @@ function dropout(x, p; dims=:, active::Bool=true)
   @inbounds @. y = x * _dropout_kernel(y, p, 1-p)
 end
 
-Flux.@adjoint function dropout(x, p; dims=:, active::Bool=true)
+@adjoint function dropout(x, p; dims=:, active::Bool=true)
   active || return x, Δ -> (Δ, nothing)
   y = rand!(similar(x, _dropout_shape(x, dims)))
   return x .* _dropout_kernel.(y, p, 1-p), Δ -> (Δ .* _dropout_kernel.(y, p, 1-p), nothing)
@@ -56,7 +56,7 @@ e.g. `Dropout(p; dims = 3)` will randomly zero out entire channels on WHCN input
 (also called 2D dropout).
 
 Does nothing to the input once [`Flux.testmode!`](@ref) is `true`.
-"""
+"""`
 mutable struct Dropout{F,D}
   p::F
   dims::D

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -31,7 +31,7 @@ The [`Dropout`](@ref) layer is what you should use in most scenarios.
 function dropout(x, p; dims=:, active::Bool=true)
   active || return x
   y = rand!(similar(x, _dropout_shape(x, dims)))
-  @. y = x * _dropout_kernel(y, p, 1-p)
+  x .* _dropout_kernel.(y, p, 1-p)
 end
 
 @adjoint function dropout(x, p; dims=:, active::Bool=true)


### PR DESCRIPTION
The current implementation of `Dropout` constructs an intermediate vector before doing a matrix multiply, but these operations could be fused. This PR explicitly fuses the dropout masking, which results in a reduction in allocations and a modest speedup on CPU and GPUs for both training and inference.

Note: A helper function, `dropout_mask` was used in the previous operation (it was basically integrated directly into the dropout implementation in this PR). I can't tell if other packages are using this, so I didn't remove it. Perhaps it should be marked deprecated and then removed later?

------------------------------------------------------------------------------------------------------

Some benchmarks, first on my not great computer/GPU and then on a better one that was lent to me:

```julia
julia> versioninfo()
Julia Version 1.6.4
Commit 35f0c911f4 (2021-11-19 03:54 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, haswell)

julia> CUDA.versioninfo()
CUDA toolkit 11.4, artifact installation
NVIDIA driver 495.44.0, for CUDA 11.5
CUDA driver 11.5

Libraries: 
- CUBLAS: 11.5.4
- CURAND: 10.2.5
- CUFFT: 10.5.1
- CUSOLVER: 11.2.0
- CUSPARSE: 11.6.0
- CUPTI: 14.0.0
- NVML: 11.0.0+495.44
- CUDNN: 8.20.2 (for CUDA 11.4.0)
- CUTENSOR: 1.3.0 (for CUDA 11.2.0)

Toolchain:
- Julia: 1.6.4
- LLVM: 11.0.1
- PTX ISA support: 3.2, 4.0, 4.1, 4.2, 4.3, 5.0, 6.0, 6.1, 6.3, 6.4, 6.5, 7.0
- Device capability support: sm_35, sm_37, sm_50, sm_52, sm_53, sm_60, sm_61, sm_62, sm_70, sm_72, sm_75, sm_80

1 device:
  0: NVIDIA GeForce GTX 980 (sm_52, 2.938 GiB / 3.948 GiB available)

julia> a = CUDA.rand(256, 256, 256); b = rand(256, 256, 256); c = CUDA.rand(256, 64);

julia> @benchmark CUDA.@sync Flux.dropout($a, .1)
BenchmarkTools.Trial: 
  memory estimate:  4.28 KiB
  allocs estimate:  67
  --------------
  minimum time:     3.473 ms (0.00% GC)
  median time:      3.499 ms (0.00% GC)
  mean time:        10.601 ms (0.40% GC)
  maximum time:     160.137 ms (0.78% GC)
  --------------
  samples:          477
  evals/sample:     1

julia> @benchmark CUDA.@sync new_dropout($a, .1)
BenchmarkTools.Trial: 
  memory estimate:  1.73 KiB
  allocs estimate:  24
  --------------
  minimum time:     2.285 ms (0.00% GC)
  median time:      2.314 ms (0.00% GC)
  mean time:        5.849 ms (0.37% GC)
  maximum time:     168.861 ms (0.70% GC)
  --------------
  samples:          855
  evals/sample:     1

julia> @benchmark Flux.dropout($b, .1)
BenchmarkTools.Trial: 
  memory estimate:  256.00 MiB
  allocs estimate:  11
  --------------
  minimum time:     113.488 ms (0.00% GC)
  median time:      127.785 ms (7.41% GC)
  mean time:        133.344 ms (11.72% GC)
  maximum time:     262.799 ms (56.75% GC)
  --------------
  samples:          38
  evals/sample:     1

julia> @benchmark new_dropout($b, .1)
BenchmarkTools.Trial: 
  memory estimate:  128.00 MiB
  allocs estimate:  9
  --------------
  minimum time:     97.156 ms (0.00% GC)
  median time:      113.923 ms (0.00% GC)
  mean time:        123.853 ms (12.71% GC)
  maximum time:     332.686 ms (65.71% GC)
  --------------
  samples:          41
  evals/sample:     1

julia> @benchmark CUDA.@sync Flux.dropout($c, .1)
BenchmarkTools.Trial: 
  memory estimate:  3.81 KiB
  allocs estimate:  61
  --------------
  minimum time:     24.919 μs (0.00% GC)
  median time:      26.891 μs (0.00% GC)
  mean time:        38.205 μs (0.00% GC)
  maximum time:     932.582 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark CUDA.@sync new_dropout($c, .1)
BenchmarkTools.Trial: 
  memory estimate:  896 bytes
  allocs estimate:  18
  --------------
  minimum time:     16.825 μs (0.00% GC)
  median time:      17.680 μs (0.00% GC)
  mean time:        23.051 μs (0.00% GC)
  maximum time:     266.705 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

-------------------------------------------------------------

```julia
julia> versioninfo()                                                                                                                                                       
Julia Version 1.6.4                                                                                                                                                        
Commit 35f0c911f4 (2021-11-19 03:54 UTC)                                                                                                                                   
Platform Info:                                                                                                                                                             
  OS: Linux (x86_64-pc-linux-gnu)                                                                                                                                          
  CPU: AMD Ryzen 9 3950X 16-Core Processor                                                                                                                                 
  WORD_SIZE: 64                                                                                                                                                            
  LIBM: libopenlibm                                                                                                                                                        
  LLVM: libLLVM-11.0.1 (ORCJIT, znver2)                                                                                                                                    
                                                                                                                                                                           
julia> CUDA.versioninfo()                                                                                                                                                  
CUDA toolkit 11.4, artifact installation                                                                                                                                   
NVIDIA driver 495.44.0, for CUDA 11.5                                                                                                                                      
CUDA driver 11.5                                                                                                                                                           
                                                                                                                                                                           
Libraries:                                                                                                                                                                 
- CUBLAS: 11.5.4                                                                                                                                                           
- CURAND: 10.2.5                                                                                                                                                           
- CUFFT: 10.5.1                                                                                                                                                            
- CUSOLVER: 11.2.0                                                                                                                                                         
- CUSPARSE: 11.6.0                                                                                                                                                         
- CUPTI: 14.0.0                                                                                                                                                            
- NVML: 11.0.0+495.44                                                                                                                                                      
- CUDNN: 8.20.2 (for CUDA 11.4.0)                                                                                                                                          
- CUTENSOR: 1.3.0 (for CUDA 11.2.0)                                                                                                                                        
                                                                                                                                                                           
Toolchain:                                                                                                                                                                 
- Julia: 1.6.4                                                                                                                                                             
- LLVM: 11.0.1                                                                                                                                                             
- PTX ISA support: 3.2, 4.0, 4.1, 4.2, 4.3, 5.0, 6.0, 6.1, 6.3, 6.4, 6.5, 7.0                                                                                              
- Device capability support: sm_35, sm_37, sm_50, sm_52, sm_53, sm_60, sm_61, sm_62, sm_70, sm_72, sm_75, sm_80                                                            
                                                                                                                                                                           
1 device:                                                                                                                                                                  
  0: NVIDIA GeForce RTX 2060 (sm_75, 4.548 GiB / 5.792 GiB available) 

julia> @benchmark CUDA.@sync Flux.dropout($a, .1)                                                                                                                          
BenchmarkTools.Trial: 2392 samples with 1 evaluation.                                                                                                                      
 Range (min … max):  1.714 ms …  10.763 ms  ┊ GC (min … max): 0.00% … 0.00%                                                                                                
 Time  (median):     1.792 ms               ┊ GC (median):    0.00%                                                                                                        
 Time  (mean ± σ):   2.088 ms ± 501.271 μs  ┊ GC (mean ± σ):  1.12% ± 4.41%                                                                                                
                                                                                                                                                                           
  ▃█▇  ▁▃▂  ▁▃▂▁▁  ▁▁▂ ▁▂▁               ▂▂  ▁                                                                                                                             
  ███▇▄████▇█████▇████████▇▇▇▆▆▆█▆▅▆▅▅▄▅▆██▇▇█▆▆▆▇▅▅▆▆▅▆▅▅▆▄▅ █                                                                                                            
  1.71 ms      Histogram: log(frequency) by time      3.52 ms <                                                                                                            
                                                                                                                                                                           
 Memory estimate: 4.34 KiB, allocs estimate: 69.                                                                                                                           
                                                                                                                                                                           
julia> @benchmark CUDA.@sync new_dropout($a, .1)                                                                                                                           
BenchmarkTools.Trial: 4003 samples with 1 evaluation.                                                                                                                      
 Range (min … max):  1.088 ms …   3.040 ms  ┊ GC (min … max): 0.00% … 44.48%                                                                                               
 Time  (median):     1.276 ms               ┊ GC (median):    0.00%                                                                                                        
 Time  (mean ± σ):   1.247 ms ± 175.018 μs  ┊ GC (mean ± σ):  0.78% ±  3.65%                                                                                               
                                                                                                                                                                           
    ▃█▂        ▆▆                                                                                                                                                          
  ▂▄███▄▂▁▁▁▂▃▇███▃▂▂▂▁▂▂▂▂▂▂▂▂▁▂▁▁▁▂▂▂▂▂▂▂▂▁▁▁▁▁▁▂▁▂▂▂▂▂▂▁▂▂ ▃                                                                                                            
  1.09 ms         Histogram: frequency by time        1.99 ms <                                                                                                            
                                                                                                                                                                           
 Memory estimate: 1.77 KiB, allocs estimate: 25.                                                                                                                           
                                                                                                                                                                           
julia> @benchmark Flux.dropout($b, .1)                                                                                                                                     
BenchmarkTools.Trial: 61 samples with 1 evaluation.                                                                                                                        
 Range (min … max):  66.213 ms … 185.794 ms  ┊ GC (min … max):  0.00% … 62.21%                                                                                             
 Time  (median):     80.290 ms               ┊ GC (median):    13.02%                                                                                                      
 Time  (mean ± σ):   81.996 ms ±  19.175 ms  ┊ GC (mean ± σ):  15.68% ± 11.43%                                                                                             
                                                                                                                                                                           
  ▅       █   ▅                                                                                                                                                            
  █▅▁▅▁▁▅▁█▁▁▁█▁▁▁▁▁▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅ ▁                                                                                                           
  66.2 ms       Histogram: log(frequency) by time       166 ms <                                                                                                           
                                                                                                                                                                           
 Memory estimate: 256.00 MiB, allocs estimate: 11.

julia> @benchmark new_dropout($b, .1)                                                                                                                                      
BenchmarkTools.Trial: 100 samples with 1 evaluation.                                                                                                                       
 Range (min … max):  41.640 ms … 161.174 ms  ┊ GC (min … max):  0.00% … 72.10%                                                                                             
 Time  (median):     46.021 ms               ┊ GC (median):     1.87%                                                                                                      
 Time  (mean ± σ):   50.089 ms ±  15.792 ms  ┊ GC (mean ± σ):  13.74% ± 12.79%                                                                                             
                                                                                                                                                                           
  █▂    ▇▄                                                                                                                                                                 
  ██▆▁▁▁██▆▆▁▁▁▁▁▁▁▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅ ▅                                                                                                           
  41.6 ms       Histogram: log(frequency) by time       142 ms <                                                                                                           
                                                                                                                                                                           
 Memory estimate: 128.00 MiB, allocs estimate: 9.                                                                                                                          
                                                                                                                                                                           
julia> @benchmark CUDA.@sync Flux.dropout($c, .1)                                                                                                                          
BenchmarkTools.Trial: 10000 samples with 1 evaluation.                                                                                                                     
 Range (min … max):  15.639 μs … 267.015 μs  ┊ GC (min … max): 0.00% … 0.00%                                                                                               
 Time  (median):     16.471 μs               ┊ GC (median):    0.00%                                                                                                       
 Time  (mean ± σ):   16.732 μs ±   2.683 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%                                                                                               
                                                                                                                                                                           
         ▂▃▅█▅▇▅▃▁                                                                                                                                                         
  ▁▁▁▂▂▄▅██████████▇▅▄▃▃▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃                                                                                                           
  15.6 μs         Histogram: frequency by time         19.5 μs <                                                                                                           
                                                                                                                                                                           
 Memory estimate: 3.33 KiB, allocs estimate: 59.                                                                                                                           
                                                                                                                                                                           
julia> @benchmark CUDA.@sync new_dropout($c, .1)                                                                                                                           
BenchmarkTools.Trial: 10000 samples with 1 evaluation.                                                                                                                     
 Range (min … max):  13.616 μs … 352.747 μs  ┊ GC (min … max): 0.00% … 0.00%                                                                                               
 Time  (median):     14.608 μs               ┊ GC (median):    0.00%                                                                                                       
 Time  (mean ± σ):   14.767 μs ±   3.820 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%                                                                                               
                                                                                                                                                                           
               ▂▆██▆▃▁                                                                                                                                                     
  ▁▁▁▂▂▂▂▂▁▂▂▃▅███████▇▅▄▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂                                                                                                           
  13.6 μs         Histogram: frequency by time         17.2 μs <                                                                                                           
                                                                                                                                                                           
 Memory estimate: 816 bytes, allocs estimate: 16.  
```
------------------------------------------------------------------------------------------

An example for gradient calculation. `m1` has the current `Dropout` implementation, and `m2` has the updated one:

```julia
julia> m1 = gpu(m1)
Chain(Diagonal(10000), Dropout(0.1))  # 20_000 parameters

julia> m2 = gpu(m2)
Chain(Diagonal(10000), NewDropout(0.1))  # 20_000 parameters

julia> @benchmark CUDA.@sync g1 = Flux.gradient(Flux.params(m1)) do
           sum(m1(x))/10000
       end
BenchmarkTools.Trial: 
  memory estimate:  22.53 KiB
  allocs estimate:  369
  --------------
  minimum time:     148.950 μs (0.00% GC)
  median time:      166.127 μs (0.00% GC)
  mean time:        248.822 μs (3.34% GC)
  maximum time:     112.305 ms (15.11% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark CUDA.@sync g2 = Flux.gradient(Flux.params(m2)) do
           sum(m2(x))/10000
       end
BenchmarkTools.Trial: 
  memory estimate:  18.81 KiB
  allocs estimate:  273
  --------------
  minimum time:     123.252 μs (0.00% GC)
  median time:      145.639 μs (0.00% GC)
  mean time:        223.976 μs (2.80% GC)
  maximum time:     131.651 ms (12.27% GC)
  --------------
  samples:          10000
  evals/sample:     1
```