### PR TITLE
Allow NamedTuples in `batchmemaybe`

### DIFF
--- a/src/data/dataloader.jl
+++ b/src/data/dataloader.jl
@@ -13,7 +13,7 @@ struct DataLoader{D,R<:AbstractRNG}
 end
 
 """
-    Flux.DataLoader(data; batchsize=1, shuffle=false, partial=true, rng=GLOBAL_RNG)
+    Flux.DataLoader(data; batchsize = 1, shuffle = false, partial = true, rng = GLOBAL_RNG)
 
 An object that iterates over mini-batches of `data`, 
 each mini-batch containing `batchsize` observations
@@ -23,8 +23,8 @@ Takes as input a single data tensor, or a tuple (or a named tuple) of tensors.
 The last dimension in each tensor is the observation dimension, i.e. the one
 divided into mini-batches.
 
-If `shuffle=true`, it shuffles the observations each time iterations are re-started.
-If `partial=false` and the number of observations is not divisible by the batchsize, 
+If `shuffle = true`, it shuffles the observations each time iterations are re-started.
+If `partial = false` and the number of observations is not divisible by the batchsize, 
 then the last mini-batch is dropped.
 
 The original data is preserved in the `data` field of the DataLoader.

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -78,7 +78,7 @@ function stop()
 end
 
 batchmemaybe(x) = tuple(x)
-batchmemaybe(x::Tuple) = x
+batchmemaybe(x::Union{NamedTuple,Tuple}) = x
 
 """
     train!(loss, params, data, opt; cb)


### PR DESCRIPTION
This allows named tuples to be treated exactly like tuples for `train!`. RFC for comments on the expected behaviour.