### PR TITLE
Tidy up `Maxout`

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -33,3 +33,7 @@ zeros(T::Type, dims...) = Base.zeros(T, dims...)
 
 ones32(::Type, dims...) = throw(ArgumentError("Flux.ones32 is always Float32, use Base.ones to specify the element type"))
 zeros32(::Type, dims...) = throw(ArgumentError("Flux.zeros32 is always Float32, use Base.zeros to specify the element type"))
+
+
+# v0.13 deprecations
+@deprecate Maxout(layers::Tuple) Maxout(layers...)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -228,7 +228,7 @@ See also [`Parallel`](@ref) to reduce with other operators.
 
 # Examples
 ```
-julia> m = Maxout(Dense([1;;], false, abs2), Dense([3;;]));
+julia> m = Maxout(x -> abs2.(x), x -> x .* 3);
 
 julia> m([-2 -1 0 1 2])
 1×5 Matrix{Int64}:

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -258,8 +258,6 @@ end
 @functor Maxout
 
 function (mo::Maxout)(input::AbstractArray)
-  # outs = map(lay -> lay(input), mo.over)
-  # return max.(outs...)
   # Perhaps surprisingly, pairwise max broadcast is often faster,
   # even with Zygote. See #698 and #1794
   mapreduce(f -> f(input), (acc, out) -> max.(acc, out), mo.over)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -258,8 +258,11 @@ end
 @functor Maxout
 
 function (mo::Maxout)(input::AbstractArray)
-  outs = map(lay -> lay(input), mo.over)
-  return max.(outs...)
+  # outs = map(lay -> lay(input), mo.over)
+  # return max.(outs...)
+  # Perhaps surprisingly, pairwise max broadcast is often faster,
+  # even with Zygote. See #698 and #1794
+  mapreduce(f -> f(input), (acc, out) -> max.(acc, out), mo.over)
 end
 
 trainable(mo::Maxout) = mo.over

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -1,6 +1,6 @@
 
 for T in [
-    :Chain, :Parallel, :SkipConnection, :Recur  # container types
+    :Chain, :Parallel, :SkipConnection, :Recur, :Maxout  # container types
   ]
   @eval function Base.show(io::IO, m::MIME"text/plain", x::$T)
     if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -109,13 +109,13 @@ import Flux: activations
     end
 
     @testset "simple alternatives" begin
-      mo = Maxout((x -> x, x -> 2x, x -> 0.5x))
+      mo = Maxout(x -> x, x -> 2x, x -> 0.5x)
       input = rand(40)
       @test mo(input) == 2*input
     end
 
     @testset "complex alternatives" begin
-      mo = Maxout((x -> [0.5; 0.1]*x, x -> [0.2; 0.7]*x))
+      mo = Maxout(x -> [0.5; 0.1]*x, x -> [0.2; 0.7]*x)
       input = [3.0 2.0]
       target = [0.5, 0.7].*input
       @test mo(input) == target


### PR DESCRIPTION
Maxout is from #698 . This:

* adds pretty printing
* changes the explicit signature to `Maxout(layer, layer, layer)`, rather than providing a tuple, to be more like other layers (with deprecation)
* adds more examples to the docstring, and combines the two
* changes not to use `mapreduce`. I see now this was a performance choice at the time, discussed here https://github.com/FluxML/Flux.jl/pull/647#discussion_r260863890 , but with Zygote this is much slower.

Before:
```
julia> using Flux

julia> m3 = Maxout(() -> Dense(5, 7, tanh), 3)
Maxout{Tuple{Dense{typeof(tanh), Matrix{Float32}, Vector{Float32}}, Dense{typeof(tanh), Matrix{Float32}, Vector{Float32}}, Dense{typeof(tanh), Matrix{Float32}, Vector{Float32}}}}((Dense(5, 7, tanh), Dense(5, 7, tanh), Dense(5, 7, tanh)))

julia> x = rand(Float32, 5, 11);

julia> @btime gradient(sum∘m3, $x);
  min 112.792 μs, mean 123.774 μs (930 allocations, 49.09 KiB. GC mean 3.71%)
```
After:
```
julia> m3 = Maxout(() -> Dense(5, 7, tanh), 3)
Maxout(
  Dense(5, 7, tanh),                    # 42 parameters
  Dense(5, 7, tanh),                    # 42 parameters
  Dense(5, 7, tanh),                    # 42 parameters
)                   # Total: 6 arrays, 126 parameters, 888 bytes.

julia> x = rand(Float32, 5, 11);

julia> @btime gradient(sum∘m3, $x);
  min 34.541 μs, mean 38.448 μs (493 allocations, 32.48 KiB. GC mean 6.63%)
```