### PR TITLE
Simplify mse() to use `abs2()`

### DIFF
--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -44,7 +44,7 @@ julia> Flux.mse(y_model, y_true)
 """
 function mse(ŷ, y; agg = mean)
   _check_sizes(ŷ, y)
-  agg(abs2.(ŷ .- y)))
+  agg(abs2.(ŷ .- y))
 end
 
 """

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -44,8 +44,7 @@ julia> Flux.mse(y_model, y_true)
 """
 function mse(ŷ, y; agg = mean)
   _check_sizes(ŷ, y)
-  error = ŷ .- y
-  real(agg(error .* conj(error)))
+  agg(abs2.(ŷ .- y)))
 end
 
 """


### PR DESCRIPTION
This simplifies the implementation of `mse()` a bit, as requested by @DhairyaLGandhi 