### PR TITLE
Fix failing `params` doctests

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -69,11 +69,11 @@ BatchNorm(2, relu)  # 4 parameters, plus 4 non-trainable
 julia> params(bn)  # only the trainable parameters
 Params([Float32[0.0, 0.0], Float32[1.0, 1.0]])
 
-julia> params([1, 2, 3], [4.0])  # one or more arrays of numbers
-Params([[1, 2, 3], [4.0]])
+julia> params([1, 2, 3], [4])  # one or more arrays of numbers
+Params([[1, 2, 3], [4]])
 
-julia> params([[1, 2, 3], [4.0]])  # unpacks array of arrays
-Params([[1, 2, 3], [4.0]])
+julia> params([[1, 2, 3], [4]])  # unpacks array of arrays
+Params([[1, 2, 3], [4]])
 
 julia> params(1, [2 2], (alpha=[3,3,3], beta=Ref(4), gamma=sin))  # ignores scalars, unpacks NamedTuples
 Params([[2 2], [3, 3, 3]])


### PR DESCRIPTION
```julia
julia> [[1, 2, 3], [4.0]]
2-element Vector{Vector{Float64}}:
 [1.0, 2.0, 3.0]
 [4.0]

julia> [[1, 2, 3], [4]]
2-element Vector{Vector{Int64}}:
 [1, 2, 3]
 [4]
```

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
