### PR TITLE
Replace unrolled `foldl` used to evaluate `Chain` with a better one

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -44,7 +44,17 @@ end
 
 @functor Chain
 
-(c::Chain)(x) = foldl((y,f) -> f(y), (x, c.layers...))
+function (c::Chain)(x)
+  if order() < 2
+    foldl((y,f) -> f(y), (x, c.layers...))
+  else
+    # This hand-written foldl causes high latency
+    applychain(Tuple(c.layers), x)
+  end
+end
+
+applychain(::Tuple{}, x) = x
+applychain(fs::Tuple, x) = applychain(tail(fs), first(fs)(x))
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i])
 Base.getindex(c::Chain{<:NamedTuple}, i::AbstractArray) =

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -44,7 +44,15 @@ end
 
 @functor Chain
 
-(c::Chain)(x) = foldl((y,f) -> f(y), (x, c.layers...))
+(c::Chain)(x) = applychain(c.layers, x)
+
+@generated function applychain(layers::Tuple{Vararg{<:Any,N}}, x) where {N}
+  symbols = vcat(:x, [gensym() for _ in 1:N])
+  calls = [:($(symbols[i+1]) = layers[$i]($(symbols[i]))) for i in 1:N]
+  Expr(:block, calls...)
+end
+
+applychain(layers::NamedTuple, x) = applychain(Tuple(layers), x)
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i])
 Base.getindex(c::Chain{<:NamedTuple}, i::AbstractArray) =

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -44,17 +44,7 @@ end
 
 @functor Chain
 
-function (c::Chain)(x)
-  if order() < 2
-    foldl((y,f) -> f(y), (x, c.layers...))
-  else
-    # This hand-written foldl causes high latency
-    applychain(Tuple(c.layers), x)
-  end
-end
-
-applychain(::Tuple{}, x) = x
-applychain(fs::Tuple, x) = applychain(tail(fs), first(fs)(x))
+(c::Chain)(x) = foldl((y,f) -> f(y), (x, c.layers...))
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i])
 Base.getindex(c::Chain{<:NamedTuple}, i::AbstractArray) =

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -44,10 +44,7 @@ end
 
 @functor Chain
 
-applychain(::Tuple{}, x) = x
-applychain(fs::Tuple, x) = applychain(tail(fs), first(fs)(x))
-
-(c::Chain)(x) = applychain(Tuple(c.layers), x)
+(c::Chain)(x) = foldl((y,f) -> f(y), (x, c.layers...))
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i])
 Base.getindex(c::Chain{<:NamedTuple}, i::AbstractArray) =

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -102,7 +102,7 @@ function _big_finale(io::IO, m)
   end
 end
 
-_childarray_sum(f, x::AbstractArray) = f(x)
+_childarray_sum(f, x::AbstractArray{<:Number}) = f(x)
 _childarray_sum(f, x) = isleaf(x) ? 0 : sum(y -> _childarray_sum(f, y), Functors.children(x))
 
 # utility functions

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -14,11 +14,12 @@ for T in [
 end
 
 function _big_show(io::IO, obj, indent::Int=0, name=nothing)
+  pre, post = obj isa Chain{<:AbstractVector} ? ("([", "])") : ("(", ") ")
   children = _show_children(obj)
   if all(_show_leaflike, children)
     _layer_show(io, obj, indent, name)
   else
-    println(io, " "^indent, isnothing(name) ? "" : "$name = ", nameof(typeof(obj)), "(")
+    println(io, " "^indent, isnothing(name) ? "" : "$name = ", nameof(typeof(obj)), pre)
     if obj isa Chain{<:NamedTuple} && children == getfield(obj, :layers)
       # then we insert names -- can this be done more generically? 
       for k in Base.keys(obj)
@@ -35,10 +36,10 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
       end
     end
     if indent == 0  # i.e. this is the outermost container
-      print(io, ")")
+      print(io, post)
       _big_finale(io, obj)
     else
-      println(io, " "^indent, "),")
+      println(io, " "^indent, post)
     end
   end
 end
@@ -90,12 +91,12 @@ function _big_finale(io::IO, m)
     noncnt = _childarray_sum(_->1, m) - length(ps)
     if noncnt > 0
       nonparam = underscorise(_childarray_sum(length, m) - sum(length, ps))
-      printstyled(io, " "^09, "# Total: ", length(ps), " trainable arrays, "; color=:light_black)
+      printstyled(io, " "^08, "# Total: ", length(ps), " trainable arrays, "; color=:light_black)
       println(io, pars, " parameters,")
       printstyled(io, " "^10, "# plus ", noncnt, " non-trainable, ", nonparam, " parameters, summarysize "; color=:light_black)
       print(io, bytes, ".")
     else
-      printstyled(io, " "^19, "# Total: ", length(ps), " arrays, "; color=:light_black)
+      printstyled(io, " "^18, "# Total: ", length(ps), " arrays, "; color=:light_black)
       print(io, pars, " parameters, ", bytes, ".")
     end
   end

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -14,7 +14,7 @@ for T in [
 end
 
 function _big_show(io::IO, obj, indent::Int=0, name=nothing)
-  pre, post = obj isa Chain{<:AbstractVector} ? ("([", "])") : ("(", ") ")
+  pre, post = obj isa Chain{<:AbstractVector} ? ("([", "])") : ("(", ")")
   children = _show_children(obj)
   if all(_show_leaflike, children)
     _layer_show(io, obj, indent, name)
@@ -36,10 +36,10 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
       end
     end
     if indent == 0  # i.e. this is the outermost container
-      print(io, post)
+      print(io, rpad(post, 2))
       _big_finale(io, obj)
     else
-      println(io, " "^indent, post)
+      println(io, " "^indent, post, ",")
     end
   end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -914,3 +914,31 @@ function plateau(f, width; distance = -, init_score = 0, min_dist = 1f-6)
 
   return patience(is_plateau, width)
 end
+
+
+"""
+    order()
+
+Returns `1` inside a call to `Zygote.gradient`, `2` inside nested such calls.
+
+# Examples
+```jldoctest; setup = :(using Flux, Zygote)
+julia> Flux.order()
+0
+
+julia> gradient(x -> (@show(Flux.order()); x^3), 1)
+Flux.order() = 1
+(3.0,)
+
+julia> gradient(y -> gradient(x -> (@show(Flux.order()); x^3), y)[1], 1)
+Flux.order() = 2
+(6.0,)
+
+julia> Zygote.hessian(x -> (@show(Flux.order()); x^3), 1)  # uses ForwardDiff over Zygote
+Flux.order() = 1
+6
+```
+"""
+order(::Val{n} = Val(0)) where {n} = n
+
+Zygote.@adjoint order(::Val{n}) where {n} = order(Val(n+1)), Returns(nothing)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -914,31 +914,3 @@ function plateau(f, width; distance = -, init_score = 0, min_dist = 1f-6)
 
   return patience(is_plateau, width)
 end
-
-
-"""
-    order()
-
-Returns `1` inside a call to `Zygote.gradient`, `2` inside nested such calls.
-
-# Examples
-```jldoctest; setup = :(using Flux, Zygote)
-julia> Flux.order()
-0
-
-julia> gradient(x -> (@show(Flux.order()); x^3), 1)
-Flux.order() = 1
-(3.0,)
-
-julia> gradient(y -> gradient(x -> (@show(Flux.order()); x^3), y)[1], 1)
-Flux.order() = 2
-(6.0,)
-
-julia> Zygote.hessian(x -> (@show(Flux.order()); x^3), 1)  # uses ForwardDiff over Zygote
-Flux.order() = 1
-6
-```
-"""
-order(::Val{n} = Val(0)) where {n} = n
-
-Zygote.@adjoint order(::Val{n}) where {n} = order(Val(n+1)), Returns(nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Flux: OneHotArray, OneHotMatrix, OneHotVector
 using Test
 using Random, Statistics, LinearAlgebra
 using IterTools: ncycle
+using Zygote
 using CUDA
 
 Random.seed!(0)


### PR DESCRIPTION
~~This uses Base's `foldl` to feed data through a `Chain`, instead of a hand-written version. The reason to do so is that this greatly reduced time-to-first-gradient in https://github.com/FluxML/Zygote.jl/issues/1126 . It's possible that Flux ought to bound ChainRules with this. Or at least I should check whether Zygote's bound is high enough to guarantee it'll work. But first see if CI likes this.~~

Latest version does not call either `foldl` or `Base.afoldl`, but instead replaces one hand-written version with another, as this seems to perform better. 