### PR TITLE
Add `Split` as a convenience constructor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## v0.12.9
 * Fixed incorrect output and added GPU compatibility for [AlphaDropout](https://github.com/FluxML/Flux.jl/pull/1781).
-* Add trilinear [Upsample layer](https://github.com/FluxML/Flux.jl/pull/1792).
+* Added trilinear [Upsample layer](https://github.com/FluxML/Flux.jl/pull/1792).
+* Added [`Split` convenience constructor](https://github.com/FluxML/Flux.jl/pull/1820).
 
 ## v0.12.8
 * Optimized inference and gradient calculation of OneHotMatrix[pr](https://github.com/FluxML/Flux.jl/pull/1756)

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -10,7 +10,7 @@ using MacroTools: @forward
 using Zygote: Params, @adjoint, gradient, pullback, @nograd
 export gradient
 
-export Chain, Dense, Maxout, SkipConnection, Parallel, flatten,
+export Chain, Dense, Maxout, SkipConnection, Parallel, Split, flatten,
        RNN, LSTM, GRU, GRUv3,
        SamePad, Conv, CrossCor, ConvTranspose, DepthwiseConv,
        AdaptiveMaxPool, AdaptiveMeanPool, GlobalMaxPool, GlobalMeanPool, MaxPool, MeanPool,

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -486,6 +486,29 @@ function Base.show(io::IO, m::Parallel)
 end
 
 """
+    Split(layers...)
+
+Create a `Split` layer that passes an input array to each path in `layers`.
+The output is a tuple of the multiple outputs from each path.
+
+Equivalent to `Parallel(tuple, layers...)`.
+
+```jldoctest
+julia> model = Split(Dense(4, 2), Dense(4, 1))
+Parallel(
+  tuple,
+  Dense(4, 2),                          # 10 parameters
+  Dense(4, 1),                          # 5 parameters
+)                   # Total: 4 arrays, 15 parameters, 316 bytes.
+julia> y1, y2 = model(rand(4, 5));
+
+julia> size(y1), size(y2)
+((2, 5), (1, 5))
+```
+"""
+Split(layers...) = Parallel(tuple, layers...)
+
+"""
     Embedding(in, out; init=randn)
 
 A lookup table that stores embeddings of dimension `out` 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -242,6 +242,16 @@ import Flux: activations
       @test gs[2].x ≈ gs_reg[2].x
       @test gs[3].x ≈ gs_reg[3].x
     end
+
+    @testset "Split" begin
+      x = rand(4, 5)
+      split = Split(Dense(4, 2), Dense(4, 1))
+      par = Parallel(tuple, split.layers...)
+
+      @test split(x) == par(x)
+      @test length(split(x)) == length(split.layers)
+      @test size.(split(x)) == ((2, 5), (1, 5))
+    end
   end
 
   @testset "Embedding" begin


### PR DESCRIPTION
This adds a `Split` convenience constructor that just creates a `Parallel` layer. Can be useful for models learning parameters of a distribution (VAEs, etc.).

Closes #1289.

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
