### PR TITLE
Zero is a real number (`Flux.Nil`)

### DIFF
--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -32,6 +32,7 @@ for f in [:+, :-, :*, :/, :^, :mod, :div, :rem]
 end
 
 Base.:<(::Nil, ::Nil) = true
+Base.:<=(::Nil, ::Nil) = true
 
 Base.isnan(::Nil) = false
 Base.isfinite(::Nil) = true

--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -4,13 +4,14 @@ using NNlib
 import Random
 
 """
-    Nil <: Number
+    nil = Nil()
 
-Nil is a singleton type with a single instance `nil`.
-Unlike `Nothing` and `Missing` it subtypes `Number`.
+`Nil` is a singleton type with a single instance `nil`.
+Unlike `Nothing` and `Missing` it is a number: `Nil <: Real <: Number`.
 """
-struct Nil <: Number end
+struct Nil <: Real end
 
+@doc @doc(Nil)
 const nil = Nil()
 
 Nil(::T) where T<:Number = nil
@@ -30,9 +31,7 @@ for f in [:+, :-, :*, :/, :^, :mod, :div, :rem]
   @eval Base.$f(::Nil, ::Nil) = nil
 end
 
-Base.isless(::Nil, ::Nil) = true
-Base.isless(::Nil, ::Number) = true
-Base.isless(::Number, ::Nil) = true
+Base.:<(::Nil, ::Nil) = true
 
 Base.isnan(::Nil) = false
 Base.isfinite(::Nil) = true


### PR DESCRIPTION
To see what CI thinks, this gives the special `nil` used for `outputsize` supertype `Real`.

The reason to do so is that really all the activation functions should be defined for `::Real`, not `::Any` in the name of sanity, and not `::Number` to exclude complex numbers, since they often test `x>0` etc.

Maybe this has consequences I don't see yet. They won't work in a function which with signature `::Complex`, but nor did they before -- and most complex-valued things accept real numbers too. 