### PR TITLE
Expose env var to disallow cuda

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -179,6 +179,11 @@ end
 
 function check_use_cuda()
   if use_cuda[] === nothing
+    if get(ENV, "FLUX_DISALLOW_CUDA", "false") in ("1", "true")
+      use_cuda[] = false
+      @debug "Flux: CUDA disallowed" ENV["FLUX_DISALLOW_CUDA"]
+      return
+    end
     use_cuda[] = CUDA.functional()
     if use_cuda[] && !CUDA.has_cudnn()
       @warn "CUDA.jl found cuda, but did not find libcudnn. Some functionality will not be available."


### PR DESCRIPTION
While it's possible to set `Flux.use_cuda[] = false`, on some machines with underpowered but cuda-functional gpus, it would be nice to have a more system-wide permanent way to opt out of cuda.

So this adds env var `FLUX_DISALLOW_CUDA` which can be set to "true" etc. to disallow cuda