### PR TITLE
Use faster activation functions

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -154,7 +154,7 @@ end
 @functor Dense
 
 function (a::Dense)(x::AbstractVecOrMat)
-  W, b= a.weight, a.bias
+  W, b = a.weight, a.bias
   σ = NNlib.fast_act(a.σ, x)  # replaces tanh => tanh_fast, etc
   return σ.(W*x .+ b)
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -154,7 +154,8 @@ end
 @functor Dense
 
 function (a::Dense)(x::AbstractVecOrMat)
-  W, b, σ = a.weight, a.bias, a.σ
+  W, b= a.weight, a.bias
+  σ = NNlib.fast_act(a.σ, x)  # replaces tanh => tanh_fast, etc
   return σ.(W*x .+ b)
 end
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -161,7 +161,8 @@ end
 @functor Conv
 
 function (c::Conv)(x::AbstractArray)
-  σ, b = c.σ, reshape(c.bias, ntuple(_ -> 1, length(c.stride))..., :, 1)
+  b = reshape(c.bias, ntuple(_ -> 1, length(c.stride))..., :, 1)
+  σ = NNlib.fast_act(c.σ, x)
   cdims = DenseConvDims(x, c.weight; stride = c.stride, padding = c.pad, dilation = c.dilation, groups = c.groups)
   σ.(conv(x, c.weight, cdims) .+ b)
 end
@@ -278,7 +279,8 @@ end
 @nograd conv_transpose_dims
 
 function (c::ConvTranspose)(x::AbstractArray)
-  σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
+  b = reshape(c.bias, map(_->1, c.stride)..., :, 1)
+  σ = NNlib.fast_act(c.σ, x)
   cdims = conv_transpose_dims(c, x)
   σ.(∇conv_data(x, c.weight, cdims) .+ b)
 end
@@ -371,7 +373,8 @@ depthwiseconvfilter(filter::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer};
                     init = glorot_uniform) where N = init(filter..., div(ch[2], ch[1]), ch[1])
 
 function (c::DepthwiseConv)(x)
-  σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
+  b = reshape(c.bias, map(_->1, c.stride)..., :, 1)
+  σ = NNlib.fast_act(c.σ, x)
   cdims = DepthwiseConvDims(x, c.weight; stride=c.stride, padding=c.pad, dilation=c.dilation)
   σ.(depthwiseconv(x, c.weight, cdims) .+ b)
 end
@@ -450,7 +453,8 @@ function crosscor(x, w, ddims::DenseConvDims)
 end
 
 function (c::CrossCor)(x::AbstractArray)
-  σ, b = c.σ, reshape(c.bias, map(_->1, c.stride)..., :, 1)
+  b = reshape(c.bias, map(_->1, c.stride)..., :, 1)
+  σ = NNlib.fast_act(c.σ, x)
   cdims = DenseConvDims(x, c.weight; stride=c.stride, padding=c.pad, dilation=c.dilation)
   σ.(crosscor(x, c.weight, cdims) .+ b)
 end

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -161,7 +161,7 @@ end
 @functor Conv
 
 function (c::Conv)(x::AbstractArray)
-  b = reshape(c.bias, ntuple(_ -> 1, length(c.stride))..., :, 1)
+  b = reshape(c.bias, map(_->1, c.stride)..., :, 1)
   σ = NNlib.fast_act(c.σ, x)
   cdims = DenseConvDims(x, c.weight; stride = c.stride, padding = c.pad, dilation = c.dilation, groups = c.groups)
   σ.(conv(x, c.weight, cdims) .+ b)


### PR DESCRIPTION
This substitutes `tanh_fast` where possible, since `tanh` often dominates the forward pass of small networks. Builds on #1761, but in the months that sat waiting, I have mislaid the benchmarks I ran. Best case 2x better forwards, worst case no improvement, modulo noise.

Intersects with https://github.com/FluxML/Flux.jl/pull/1832, which would also do this to conv layers, but not to RNNs.

Closes #1272; this version is significantly faster, and this PR applies it to more cases.