### PR TITLE
Add news for bump version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * Fixed incorrect output and added GPU compatibility for [AlphaDropout](https://github.com/FluxML/Flux.jl/pull/1781).
 * Add trilinear [Upsample layer](https://github.com/FluxML/Flux.jl/pull/1792).
 * Improved [performance of RNNs](https://github.com/FluxML/Flux.jl/pull/1761)
-* Optimisers now accept an `ϵ` keyword argument
+* Optimisers now accept an `ϵ` argument
 * [Improved handling of complex values inputs](https://github.com/FluxML/Flux.jl/pull/1776) while training
 * Fixed [AlphaDropout](https://github.com/FluxML/Flux.jl/pull/1781)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 ## v0.12.9
 * Fixed incorrect output and added GPU compatibility for [AlphaDropout](https://github.com/FluxML/Flux.jl/pull/1781).
 * Add trilinear [Upsample layer](https://github.com/FluxML/Flux.jl/pull/1792).
+* Improved [performance of RNNs](https://github.com/FluxML/Flux.jl/pull/1761)
+* Optimisers now accept an `ϵ` keyword argument
+* [Improved handling of complex values inputs](https://github.com/FluxML/Flux.jl/pull/1776) while training
+* Fixed [AlphaDropout](https://github.com/FluxML/Flux.jl/pull/1781)
 
 ## v0.12.8
 * Optimized inference and gradient calculation of OneHotMatrix[pr](https://github.com/FluxML/Flux.jl/pull/1756)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.12.8"
+version = "0.12.9"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Adds some missing NEWS items and prepares for patch bump.

I don't think we are breaking any API in this version, and if we want to include some PRs to this patch, it might be good to get some feedback on what we might want to include here.