### PR TITLE
Fix type-stability for normalization layers

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -162,9 +162,7 @@ end
 
 function (c::Conv)(x::AbstractArray)
   σ, b = c.σ, reshape(c.bias, ntuple(_ -> 1, length(c.stride))..., :, 1)
-  cdims = DenseConvDims(
-    x, c.weight; stride=c.stride, padding=c.pad,
-    dilation=c.dilation, groups=c.groups)
+  cdims = DenseConvDims(x, c.weight; stride = c.stride, padding = c.pad, dilation = c.dilation, groups = c.groups)
   σ.(conv(x, c.weight, cdims) .+ b)
 end
 
@@ -658,23 +656,19 @@ julia> lay(rand(Float32, 100, 7, 50)) |> size
 (34, 7, 50)
 ```
 """
-struct MaxPool{N, M}
+struct MaxPool{N,M}
   k::NTuple{N,Int}
   pad::NTuple{M,Int}
   stride::NTuple{N,Int}
 end
 
-function MaxPool(k::NTuple{N, Integer}; pad = 0, stride = k) where N
+function MaxPool(k::NTuple{N,Integer}; pad = 0, stride = k) where N
   stride = expand(Val(N), stride)
   pad = calc_padding(MaxPool, pad, k, 1, stride)
   return MaxPool(k, pad, stride)
 end
 
 function (m::MaxPool)(x)
-  # size_x = size(x)
-  # kernel, stride, padding, dilation = NNlib.prepare_pooldims(
-  #   Val(N), size_x, m.k; padding=m.pad, stride=m.stride)
-  # pdims = PoolDims{kernel, stride, padding, dilation}(size_x)
   pdims = PoolDims(x, m.k; padding=m.pad, stride=m.stride)
   return maxpool(x, pdims)
 end

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -162,7 +162,9 @@ end
 
 function (c::Conv)(x::AbstractArray)
   σ, b = c.σ, reshape(c.bias, ntuple(_ -> 1, length(c.stride))..., :, 1)
-  cdims = DenseConvDims(x, c.weight; stride = c.stride, padding = c.pad, dilation = c.dilation, groups = c.groups)
+  cdims = DenseConvDims(
+    x, c.weight; stride=c.stride, padding=c.pad,
+    dilation=c.dilation, groups=c.groups)
   σ.(conv(x, c.weight, cdims) .+ b)
 end
 
@@ -656,19 +658,23 @@ julia> lay(rand(Float32, 100, 7, 50)) |> size
 (34, 7, 50)
 ```
 """
-struct MaxPool{N,M}
+struct MaxPool{N, M}
   k::NTuple{N,Int}
   pad::NTuple{M,Int}
   stride::NTuple{N,Int}
 end
 
-function MaxPool(k::NTuple{N,Integer}; pad = 0, stride = k) where N
+function MaxPool(k::NTuple{N, Integer}; pad = 0, stride = k) where N
   stride = expand(Val(N), stride)
-  pad = calc_padding(MaxPool ,pad, k, 1, stride)
+  pad = calc_padding(MaxPool, pad, k, 1, stride)
   return MaxPool(k, pad, stride)
 end
 
 function (m::MaxPool)(x)
+  # size_x = size(x)
+  # kernel, stride, padding, dilation = NNlib.prepare_pooldims(
+  #   Val(N), size_x, m.k; padding=m.pad, stride=m.stride)
+  # pdims = PoolDims{kernel, stride, padding, dilation}(size_x)
   pdims = PoolDims(x, m.k; padding=m.pad, stride=m.stride)
   return maxpool(x, pdims)
 end

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -188,13 +188,6 @@ function Base.show(io::IO, l::LayerNorm)
   print(io, ")")
 end
 
-_maybe_promote_type(::Type{T1}, ::Type{T2}) where {T1, T2} = promote_type(T1, T2)
-_maybe_promote_type(::Type{Nothing}, ::Type{T2}) where T2 = T2
-_maybe_promote_type(::Type{T1}, ::Type{Nothing}) where T1 = T1
-
-_maybe_eltype(::Type{T}) where T <: AbstractArray = eltype(T)
-_maybe_eltype(::Type{Nothing}) = Nothing
-
 # For InstanceNorm, GroupNorm, and BatchNorm.
 # Compute the statistics on the slices specified by reduce_dims.
 # reduce_dims=[1,...,N-2,N] for BatchNorm

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -149,9 +149,15 @@ end
     #  1.3
     #  1.3
     @test m.σ² ≈ .1 .* var(x, dims=2, corrected=false) .* (3 / 2).+ .9 .* [1., 1.]
-    
+
     x′ = m(x)
     @test isapprox(x′[1], (1 .- 0.3) / sqrt(1.3), atol = 1.0e-5)
+
+    @inferred m(x)
+  end
+
+  let m = BatchNorm(2; track_stats=false), x = [1.0 3.0 5.0; 2.0 4.0 6.0]
+    @inferred m(x)
   end
 
   # with activation function
@@ -159,29 +165,34 @@ end
                                       2.0 4.0 6.0]
     y = m(x)
     @test isapprox(y, sigmoid.((x .- m.μ) ./ sqrt.(m.σ² .+ m.ϵ)), atol = 1.0e-7)
+    @inferred m(x)
   end
 
   let m = trainmode!(BatchNorm(2)), x = reshape(Float32.(1:6), 3, 2, 1)
     y = reshape(permutedims(x, [2, 1, 3]), 2, :)
     y = permutedims(reshape(m(y), 2, 3, 1), [2, 1, 3])
     @test m(x) == y
+    @inferred m(x)
   end
 
   let m = trainmode!(BatchNorm(2)), x = reshape(Float32.(1:12), 2, 3, 2, 1)
     y = reshape(permutedims(x, [3, 1, 2, 4]), 2, :)
     y = permutedims(reshape(m(y), 2, 2, 3, 1), [2, 3, 1, 4])
     @test m(x) == y
+    @inferred m(x)
   end
 
   let m = trainmode!(BatchNorm(2)), x = reshape(Float32.(1:24), 2, 2, 3, 2, 1)
     y = reshape(permutedims(x, [4, 1, 2, 3, 5]), 2, :)
     y = permutedims(reshape(m(y), 2, 2, 2, 3, 1), [2, 3, 4, 1, 5])
     @test m(x) == y
+    @inferred m(x)
   end
 
   let m = BatchNorm(32), x = randn(Float32, 416, 416, 32, 1);
     m(x)
     @test (@allocated m(x)) <  100_000_000
+    @inferred m(x)
   end
 
   @test length(Flux.params(BatchNorm(10))) == 2
@@ -232,6 +243,8 @@ end
       @test length(m.μ) == 2
       @test length(m.σ²) == 2
       @test y ≈ (x .- reshape(m.μ, 1,2,1)) ./ sqrt.(reshape(m.σ², 1,2,1) .+ 1f-5)   atol=1.0e-5
+
+      @inferred m(x)
   end
 
   # with activation function
@@ -242,10 +255,12 @@ end
     affine_shape[[1,3]] .= 1
 
     y = evalwgrad(m, x)
-    y = m(x) # inference time after a training step    
+    y = m(x) # inference time after a training step
     μ = reshape(m.μ, affine_shape...)
     σ² = reshape(m.σ², affine_shape...)
     @test y ≈ sigmoid.((x .- μ) ./ sqrt.(σ² .+ m.ϵ))   atol=1.0e-7
+
+    @inferred m(x)
   end
 
   # with activation function
@@ -253,24 +268,28 @@ end
       x = reshape(collect(1:prod(sizes)), sizes)
 
     @test Flux.hasaffine(m) == true
-    @test length(params(m)) == 2  
+    @test length(params(m)) == 2
     x = Float64.(x)
     y = m(x)
     μ = mean(x, dims=1)
     σ² = var(x, dims=1, corrected=false)
     @test y ≈ sigmoid.((x .- μ) ./ sqrt.(σ² .+ m.ϵ))   atol=1.0e-7
+
+    @inferred m(x)
   end
 
   let m = InstanceNorm(2, sigmoid), sizes = (3, 2, 2),
       x = reshape(collect(1:prod(sizes)), sizes)
     @test Flux.hasaffine(m) == false
     @test length(params(m)) == 0
-    
+
     x = Float64.(x)
     y = m(x)
     μ = mean(x, dims=1)
     σ² = var(x, dims=1, corrected=false)
     @test y ≈ sigmoid.((x .- μ) ./ sqrt.(σ² .+ m.ϵ))   atol=1.0e-7
+
+    @inferred m(x)
   end
 
 
@@ -279,6 +298,8 @@ end
     y = reshape(permutedims(x, [3, 1, 2, 4, 5]), :, 2, 3)
     y = reshape(m(y), sizes...)
     @test m(x) == y
+
+    @inferred m(x)
   end
 
   # check that μ, σ², and the output are the correct size for higher rank tensors
@@ -288,6 +309,8 @@ end
     @test size(m.μ) == (sizes[end - 1], )
     @test size(m.σ²) == (sizes[end - 1], )
     @test size(y) == sizes
+
+    @inferred m(x)
   end
 
   # show that instance norm is equal to batch norm when channel and batch dims are squashed
@@ -299,6 +322,8 @@ end
   let m = InstanceNorm(32), x = randn(Float32, 416, 416, 32, 1);
     m(x)
     @test (@allocated m(x)) <  100_000_000
+
+    @inferred m(x)
   end
 
   @test length(Flux.params(InstanceNorm(10))) == 0


### PR DESCRIPTION
This PR fixes type-stability for normalization layers.
This also makes ResNet model type-stable (as well as others).

While there is [PR](https://github.com/FluxML/Flux.jl/pull/1509) that reworks normalization layers, it is not clear what is the status of it.
@ToucheSir has also suggested that functional part should be moved into NNlib.jl, so I'm not sure if this PR should be accepted in the first place...
But at least we can use it to look at what improvements type-stability can bring in this case...

~~Also I feel it is not the cleanest solution, as it essentially computes the output type `o::_basetype(typeof(x)){O, N}`.~~

### Benchmark:

```julia
using Test
using Flux
using BenchmarkTools

function main()
    x = rand(Float32, 28, 28, 64, 4)
    bn = BatchNorm(64)
    θ = Flux.params(bn)

    @info "forward"
    @time bn(x)
    @btime $bn($x)

    @info "grad"
    @time gradient(θ) do
        sum(bn(x))
    end
    @btime gradient($θ) do
        sum($bn($x))
    end

    @inferred bn(x) # master fails here
end
```

Before:

```julia
[ Info: forward
  0.254515 seconds (856.55 k allocations: 43.045 MiB, 98.02% compilation time)
  911.059 μs (29 allocations: 785.33 KiB)
[ Info: grad
  4.050493 seconds (12.31 M allocations: 635.845 MiB, 3.65% gc time, 99.81% compilation time)
  2.838 ms (804 allocations: 13.05 MiB)
```

After:

```julia
[ Info: forward
  0.000917 seconds (15 allocations: 1.532 MiB)
  455.609 μs (15 allocations: 1.53 MiB)
[ Info: grad
  2.245501 seconds (7.16 M allocations: 372.776 MiB, 3.75% gc time, 99.17% compilation time)
  2.337 ms (694 allocations: 12.28 MiB)
```

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
- [ ] API changes require approval from a committer (different from the author, if applicable)
