### PR TITLE
Speed up `onehotbatch`

### DIFF
--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -163,8 +163,8 @@ If `xs` has more dimensions, `M = ndims(xs) > 1`, then the result is an
 `AbstractArray{Bool, M+1}` which is one-hot along the first dimension, 
 i.e. `result[:, k...] == onehot(xs[k...], labels)`.
 
-Notice that `xs::String` is fine, it does not need to be collected.
-For less than 32 classes, `labels::Tuple` will give best performance.
+Note that `xs` can be any iterable, such as a string. And that using a tuple
+for `labels` will often speed up construction, certainly for less than 32 classes.
 
 # Examples
 ```jldoctest

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -114,7 +114,7 @@ and [`onecold`](@ref) to reverse either of these, as well as to generalise `argm
 
 # Examples
 ```jldoctest
-julia> β = Flux.onehot(:b, [:a, :b, :c])
+julia> β = Flux.onehot(:b, (:a, :b, :c))
 3-element OneHotVector(::UInt32) with eltype Bool:
  ⋅
  1
@@ -163,9 +163,12 @@ If `xs` has more dimensions, `M = ndims(xs) > 1`, then the result is an
 `AbstractArray{Bool, M+1}` which is one-hot along the first dimension, 
 i.e. `result[:, k...] == onehot(xs[k...], labels)`.
 
+Notice that `xs::String` is fine, it does not need to be collected.
+For less than 32 classes, `labels::Tuple` will give best performance.
+
 # Examples
 ```jldoctest
-julia> oh = Flux.onehotbatch(collect("abracadabra"), 'a':'e', 'e')
+julia> oh = Flux.onehotbatch("abracadabra", 'a':'e', 'e')
 5×11 OneHotMatrix(::Vector{UInt32}) with eltype Bool:
  1  ⋅  ⋅  1  ⋅  1  ⋅  1  ⋅  ⋅  1
  ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  1  ⋅  ⋅
@@ -199,7 +202,7 @@ the same operation as `argmax(y, dims=1)` but sometimes a different return type.
 julia> Flux.onecold([false, true, false])
 2
 
-julia> Flux.onecold([0.3, 0.2, 0.5], [:a, :b, :c])
+julia> Flux.onecold([0.3, 0.2, 0.5], (:a, :b, :c))
 :c
 
 julia> Flux.onecold([ 1  0  0  1  0  1  0  1  0  0  1

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -1,5 +1,33 @@
-using Flux:onecold
+using Flux: onehot, onehotbatch, onecold
 using Test
+
+@testset "onehot constructors" begin
+  @test onehot(20, 10:10:30) == [false, true, false]
+  @test onehot(20, (10,20,30)) == [false, true, false]
+  @test onehot(40, (10,20,30), 20) == [false, true, false]
+
+  @test_throws Exception onehot('d', 'a':'c')
+  @test_throws Exception onehot(:d, (:a, :b, :c))
+  @test_throws Exception onehot('d', 'a':'c', 'e')
+  @test_throws Exception onehot(:d, (:a, :b, :c), :e)
+
+  @test onehotbatch([20, 10], 10:10:30) == Bool[0 1; 1 0; 0 0]
+  @test onehotbatch([20, 10], (10,20,30)) == Bool[0 1; 1 0; 0 0]
+  @test onehotbatch([40, 10], (10,20,30), 20) == Bool[0 1; 1 0; 0 0]
+
+  @test onehotbatch("abc", 'a':'c') == Bool[1 0 0; 0 1 0; 0 0 1]
+  @test onehotbatch("zbc", ('a', 'b', 'c'), 'a') == Bool[1 0 0; 0 1 0; 0 0 1]
+
+  @test_throws Exception onehotbatch([:a, :d], [:a, :b, :c])
+  @test_throws Exception onehotbatch([:a, :d], (:a, :b, :c))
+  @test_throws Exception onehotbatch([:a, :d], [:a, :b, :c], :e)
+  @test_throws Exception onehotbatch([:a, :d], (:a, :b, :c), :e)
+
+  floats = (0.0, -0.0, NaN, -NaN, Inf, -Inf)
+  @test onecold(onehot(0.0, floats)) == 1
+  @test onecold(onehot(-0.0, floats)) == 2  # as it uses isequal
+  @test onecold(onehot(Inf, floats)) == 5
+end
 
 @testset "onecold" begin
   a = [1, 2, 5, 3.]
@@ -9,7 +37,9 @@ using Test
   @test onecold(a) == 3
   @test onecold(A) == [3, 1, 4]
   @test onecold(a, labels) == 'C'
+  @test onecold(a, Tuple(labels)) == 'C'
   @test onecold(A, labels) == ['C', 'A', 'D']
+  @test onecold(A, Tuple(labels)) == ['C', 'A', 'D']
 
   data = [:b, :a, :c]
   labels = [:a, :b, :c]


### PR DESCRIPTION
Closes #1844. Before:
```julia
julia> @btime ohe_custom($sequence);  # from #1844
  min 908.784 ns, mean 962.810 ns (5 allocations, 464 bytes)

julia> @btime ohe_flux($sequence);
  min 67.083 μs, mean 69.835 μs (374 allocations, 17.30 KiB)

julia> seq = String(rand('a':'z', 10));

julia> @btime Flux.onehotbatch($seq, 'a':'z');
  min 14.750 μs, mean 15.071 μs (84 allocations, 3.84 KiB)
```
After:
```julia
julia> @btime Flux.onehotbatch($sequence, $bases_dna);  # vector of labels
  min 857.246 ns, mean 920.303 ns (4 allocations, 528 bytes)

julia> @btime Flux.onehotbatch($sequence, $(Tuple(bases_dna)));  # faster if you make the tuple
  min 586.572 ns, mean 639.020 ns (3 allocations, 496 bytes)

julia> seq = String(rand('a':'z', 10));

julia> @btime Flux.onehotbatch($seq, 'a':'z');  # 26 classes, quite a long tuple
  min 1.883 μs, mean 1.946 μs (5 allocations, 480 bytes)

julia> @btime Flux.onehotbatch($seq, $(Tuple('a':'z')));
  min 717.391 ns, mean 774.093 ns (3 allocations, 208 bytes)
```
There is probably more that could be done, e.g. to make `batch` type-stable & save a copy, but this is a start. 