### PR TITLE
Simplify `trainable`, `functor` and `Parallel`

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -36,4 +36,3 @@ zeros32(::Type, dims...) = throw(ArgumentError("Flux.zeros32 is always Float32, 
 
 
 # v0.13 deprecations
-@deprecate Maxout(layers::Tuple) Maxout(layers...)

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -82,8 +82,7 @@ function Dropout(p; dims=:, rng = rng_from_array())
 end
 
 @functor Dropout
-
-trainable(a::Dropout) = ()
+trainable(a::Dropout) = (;)
 
 function (a::Dropout)(x)
   _isactive(a) || return x
@@ -122,8 +121,7 @@ AlphaDropout(p, active) = AlphaDropout(p, active, rng_from_array())
 AlphaDropout(p; rng = rng_from_array()) = AlphaDropout(p, nothing, rng)
 
 @functor AlphaDropout
-
-trainable(a::AlphaDropout) = ()
+trainable(a::AlphaDropout) = (;)
 
 function (a::AlphaDropout)(x::AbstractArray{T}) where T
   _isactive(a) || return x
@@ -288,7 +286,7 @@ function BatchNorm(chs::Int, λ=identity;
 end
 
 @functor BatchNorm
-trainable(bn::BatchNorm) = hasaffine(bn) ? (bn.β, bn.γ) : ()
+trainable(bn::BatchNorm) = hasaffine(bn) ? (β = bn.β, γ = bn.γ) : (;)
 
 function (BN::BatchNorm)(x)
   @assert size(x, ndims(x)-1) == BN.chs
@@ -364,7 +362,7 @@ function InstanceNorm(chs::Int, λ=identity;
 end
 
 @functor InstanceNorm
-trainable(in::InstanceNorm) = hasaffine(in) ? (in.β, in.γ) : ()
+trainable(in::InstanceNorm) = hasaffine(in) ? (β = in.β, γ = in.γ) : (;)
 
 function (l::InstanceNorm)(x)
   @assert ndims(x) > 2
@@ -426,7 +424,7 @@ mutable struct GroupNorm{F,V,N,W}
 end
 
 @functor GroupNorm
-trainable(gn::GroupNorm) = hasaffine(gn) ? (gn.β, gn.γ) : ()
+trainable(gn::GroupNorm) = hasaffine(gn) ? (β = gn.β, γ = gn.γ) : (;)
 
 function GroupNorm(chs::Int, G::Int, λ=identity;
               initβ=zeros32, initγ=ones32, 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -65,7 +65,7 @@ function (m::Recur)(x)
 end
 
 @functor Recur
-trainable(a::Recur) = (a.cell,)
+trainable(a::Recur) = (; cell = a.cell)
 
 Base.show(io::IO, m::Recur) = print(io, "Recur(", m.cell, ")")
 

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -14,7 +14,7 @@ for T in [
 end
 
 function _big_show(io::IO, obj, indent::Int=0, name=nothing)
-  children = trainable(obj)
+  children = _show_children(obj)
   if all(_show_leaflike, children)
     _layer_show(io, obj, indent, name)
   else
@@ -47,6 +47,11 @@ _show_leaflike(x) = isleaf(x)  # mostly follow Functors, except for:
 _show_leaflike(::Tuple{Vararg{<:Number}}) = true         # e.g. stride of Conv
 _show_leaflike(::Tuple{Vararg{<:AbstractArray}}) = true  # e.g. parameters of LSTMcell
 _show_leaflike(::Diagonal) = true                        # appears inside LayerNorm
+
+_show_children(x) = trainable(x)  # except for layers which hide their Tuple:
+_show_children(c::Chain) = c.layers
+_show_children(m::Maxout) = m.layers
+_show_children(p::Parallel) = (p.connection, p.layers...)
 
 for T in [
     :Conv, :ConvTranspose, :CrossCor, :DepthwiseConv, :Dense,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -775,15 +775,20 @@ Chain(
           # plus 2 non-trainable, 128 parameters, summarysize 200.312 KiB.
 
 julia> Flux.modules(m2)
-5-element Vector{Any}:
+7-element Vector{Any}:
  Chain(Chain(Dense(784, 64), BatchNorm(64, relu)), Dense(64, 10))  # 51_018 parameters, plus 128 non-trainable
+ (Chain(Dense(784, 64), BatchNorm(64, relu)), Dense(64, 10))
  Chain(Dense(784, 64), BatchNorm(64, relu))  # 50_368 parameters, plus 128 non-trainable
+ (Dense(784, 64), BatchNorm(64, relu))
  Dense(784, 64)      # 50_240 parameters
  BatchNorm(64, relu)  # 128 parameters, plus 128 non-trainable
  Dense(64, 10)       # 650 parameters
 
 julia> L2(m) = sum(sum(abs2, l.weight) for l in Flux.modules(m) if l isa Dense)
 L2 (generic function with 1 method)
+
+julia> L2(m2) isa Float32
+true
 ```
 """
 modules(m) = [x for x in Functors.fcollect(m) if !isleaflike(x)]

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -25,6 +25,9 @@ import Flux: activations
     @test m[:first] == m[1]
     @test m[1:2] == m
 
+    @test m == m
+    @test m == fmap(identity, m)  # does not forget names
+
     @test_throws ArgumentError Chain(layers = Dense(10, 10), two = identity) # reserved name
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,55 +8,58 @@ using CUDA
 
 Random.seed!(0)
 
-@testset "Utils" begin
-  include("utils.jl")
-end
+@testset verbose=true "Flux.jl" begin
 
-@testset "Onehot" begin
-  include("onehot.jl")
-end
-
-@testset "Optimise" begin
-  include("optimise.jl")
-end
-
-@testset "Data" begin
-  include("data.jl")
-end
-
-@testset "Losses" begin
-  include("losses.jl")
-  include("ctc.jl")
-  CUDA.functional() && include("ctc-gpu.jl")
-end
-
-@testset "Layers" begin
-  include("layers/basic.jl")
-  include("layers/normalisation.jl")
-  include("layers/stateless.jl")
-  include("layers/recurrent.jl")
-  include("layers/conv.jl")
-  include("layers/upsample.jl")
-  include("layers/show.jl")
-end
-
-@testset "outputsize" begin
-  using Flux: outputsize
-  include("outputsize.jl")
-end
-
-@testset "CUDA" begin
-  if CUDA.functional()
-    include("cuda/runtests.jl")
-  else
-    @warn "CUDA unavailable, not testing GPU support"
+  @testset "Utils" begin
+    include("utils.jl")
   end
-end
 
-@static if VERSION == v"1.6"
-  using Documenter
-  @testset "Docs" begin
-    DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive=true)
-    doctest(Flux)
+  @testset "Onehot" begin
+    include("onehot.jl")
+  end
+
+  @testset "Optimise" begin
+    include("optimise.jl")
+  end
+
+  @testset "Data" begin
+    include("data.jl")
+  end
+
+  @testset "Losses" begin
+    include("losses.jl")
+    include("ctc.jl")
+    CUDA.functional() && include("ctc-gpu.jl")
+  end
+
+  @testset "Layers" begin
+    include("layers/basic.jl")
+    include("layers/normalisation.jl")
+    include("layers/stateless.jl")
+    include("layers/recurrent.jl")
+    include("layers/conv.jl")
+    include("layers/upsample.jl")
+    include("layers/show.jl")
+  end
+
+  @testset "outputsize" begin
+    using Flux: outputsize
+    include("outputsize.jl")
+  end
+
+  @testset "CUDA" begin
+    if CUDA.functional()
+      include("cuda/runtests.jl")
+    else
+      @warn "CUDA unavailable, not testing GPU support"
+    end
+  end
+
+  @static if VERSION == v"1.6"
+    using Documenter
+    @testset "Docs" begin
+      DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive=true)
+      doctest(Flux)
+    end
   end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -446,21 +446,26 @@ end
   m5 =  Chain(m4, m2)
   modules = Flux.modules(m5)
   # Depth-first descent
-  @test length(modules) == 5
+  @test length(modules) == 6
   @test modules[1] === m5
-  @test modules[2] === m4
-  @test modules[3] === m1
-  @test modules[4] === m2
-  @test modules[5] === m3
+  @test modules[3] === m4
+  @test modules[4] === m1
+  @test modules[5] === m2
+  @test modules[6] === m3
 
-  modules = Flux.modules(Chain(Dense(2,3), BatchNorm(3), LSTM(3,4)))
-  @test length(modules) == 5
+  mod_par = Flux.modules(Parallel(Flux.Bilinear(2,2,2,cbrt), Dense(2,2,abs), Dense(2,2,abs2)))
+  @test length(mod_par) == 5
 
-  modules = Flux.modules(Chain(SkipConnection(
+  mod_rnn = Flux.modules(Chain(Dense(2,3), BatchNorm(3), LSTM(3,4)))
+  @test length(mod_rnn) == 6
+  @test mod_rnn[end] isa Flux.LSTMCell
+
+  mod_skip = Flux.modules(Chain(SkipConnection(
                                   Conv((2,3), 4=>5; pad=6, stride=7),
                                   +),
                                 LayerNorm(8)))
-  @test length(modules) == 5
+  @test length(mod_skip) == 6
+  @test mod_skip[end] isa Flux.Diagonal
 end
 
 @testset "Patience triggers" begin


### PR DESCRIPTION
This does a few things to do with Functors / Optimisers:
* Changes all uses of `trainable` to return a NamedTuple, which is what Optimisers now wants.
* Removes the use of `trainable` on Parallel, since all fields are trainable, the layers are just one wrapper deeper.
* Removes the inner constructor from `Chain`, so that it can simply be `@functor Chain`. Fixes #1857 . 
* Likewise removes the inner constructor from `Maxout`.
* Adjusts the `show` code not to use `trainable`. This is most of why all these changes are in one PR.

The downside of no longer hiding the Tuple inside Chain from Functors.jl is that `fcollect` and hence `Flux.modules` will see it. ~~This is why the tests fail. I'm not too sure what this is for, and whether this matters.~~ Tests updated to allow this.

The PR also changes Parallel to call its `connection` exactly once, always. And to allow, with N layers, either 1 input or exactly N inputs. It used to zip, but (IMO) allowing N-1 inputs just seems like a bug magnet. These can be separated if anyone feels strongly. Fixes #1685, closes #1698.
