### PR TITLE
Recurrent benchmarks

### DIFF
--- a/perf/bench_utils.jl
+++ b/perf/bench_utils.jl
@@ -28,7 +28,7 @@ function run_benchmark(model, x; cuda=true)
     end
 
     ps = Flux.params(model)
-    y, back = if model isa Flux.Recur
+    y, back = if model isa Flux.Recur && eltype(x) isa AbstractVector
         pullback(() -> sum(sum([model(x_t) for x_t in x])), ps)
     else
         pullback(() -> sum(model(x)), ps)

--- a/perf/bench_utils.jl
+++ b/perf/bench_utils.jl
@@ -28,7 +28,7 @@ function run_benchmark(model, x; cuda=true)
     end
 
     ps = Flux.params(model)
-    y, back = if model isa Flux.Recur && eltype(x) isa AbstractVector
+    y, back = if model isa Flux.Recur && eltype(x) isa AbstractArray
         pullback(() -> sum(sum([model(x_t) for x_t in x])), ps)
     else
         pullback(() -> sum(model(x)), ps)

--- a/perf/bench_utils.jl
+++ b/perf/bench_utils.jl
@@ -28,7 +28,7 @@ function run_benchmark(model, x; cuda=true)
     end
 
     ps = Flux.params(model)
-    y, back = if model isa Flux.Recur && eltype(x) isa AbstractArray
+    y, back = if model isa Flux.Recur && eltype(x) <: AbstractArray
         pullback(() -> sum(sum([model(x_t) for x_t in x])), ps)
     else
         pullback(() -> sum(model(x)), ps)

--- a/perf/bench_utils.jl
+++ b/perf/bench_utils.jl
@@ -7,7 +7,7 @@ using Zygote: pullback, ignore
 fw(m, x) = m(x)
 bw(back) = back(1f0)
 fwbw(m, ps, x) = gradient(() -> sum(fw(m, x)), ps)
-pb(m, ps, x) = pullback(()->sum(fw(m, x)), ps)
+pb(m, ps, x) = pullback(() -> sum(fw(m, x)), ps)
 
 function run_benchmark(model, x; cuda=true)
     

--- a/perf/recurrent.jl
+++ b/perf/recurrent.jl
@@ -9,5 +9,15 @@ for n in [2, 20, 200, 2000], T in [1, 8, 16, 64]
   run_benchmark(model, x, cuda=true)    
 end
 
+println("RNN-3d")
+for n in [2, 20, 200, 2000], T in [1, 8, 16, 64]
+  x = randn(Float32, n, n, T)
+  model = RNN(n, n)
+  println("CPU n=$n, t=$T")
+  run_benchmark(model, x, cuda=false)
+  println("CUDA n=$n, t=$T")
+  run_benchmark(model, x, cuda=true)    
+end
+
 
 

--- a/perf/recurrent.jl
+++ b/perf/recurrent.jl
@@ -1,0 +1,13 @@
+
+println("RNN")
+for n in [2, 20, 200, 2000], T in [1, 8, 16, 64]
+  x = [randn(Float32, n, n) for t in 1:T]
+  model = RNN(n, n)
+  println("CPU n=$n, t=$T")
+  run_benchmark(model, x, cuda=false)
+  println("CUDA n=$n, t=$T")
+  run_benchmark(model, x, cuda=true)    
+end
+
+
+

--- a/perf/recurrent.jl
+++ b/perf/recurrent.jl
@@ -1,41 +1,62 @@
 
-println("RNN")
-for n in [2, 20, 200, 1000], T in [1, 8, 16, 64]
-  x = [randn(Float32, n, n) for t in 1:T]
-  model = RNN(n, n)
-  println("CPU n=$n, t=$T")
-  run_benchmark(model, x, cuda=false)
-  println("CUDA n=$n, t=$T")
-  try
+
+struct RNNWrapper{T}
+  rnn::T
+end
+Flux.@functor RNNWrapper
+
+# Need to specialize for RNNWrapper.
+fw(r::RNNWrapper, X::Vector{<:AbstractArray}) = begin
+  Flux.reset!(r.rnn)
+  [r.rnn(x) for x in X]
+end
+
+fw(r::RNNWrapper, X) = begin
+  Flux.reset!(r.rnn)
+  r.rnn(X)
+end
+
+fwbw(r::RNNWrapper, ps, X::Vector{<:AbstractArray}) = gradient(ps) do
+  y = fw(r, X)
+  sum(sum(y))
+end
+
+pb(r::RNNWrapper, ps, X::Vector{<:AbstractArray}) = pullback(ps) do
+  y = fw(r, X)
+  sum(sum(y))
+end
+
+function rnn_benchmark_sweep(data_creator::Function, rnn_type)
+  for n in [2, 20, 200, 1000], ts in [1, 4, 16, 64]
+    x, x_n = data_creator(n, ts)
+    model = RNNWrapper(rnn_type(n, n))
+    
+    println("$rnn_type $x_n CPU n=$n, ts=$ts")
+    run_benchmark(model, x, cuda=false)
+    
+    println("$rnn_type $x_n CUDA n=$n, ts=$ts")
+    try
       run_benchmark(model, x, cuda=true)
-  catch ex
+    catch ex
       @show typeof(ex)
       if ex isa OutOfGPUMemoryError
-          @warn "Not enough GPU memory to run test"
+        @warn "Not enough GPU memory to run test"
       else
-          rethrow(ex)
+        rethrow(ex)
       end
+    end
+  end  
+end
+
+for rnn_type in [Flux.RNN, Flux.GRU, Flux.LSTM]
+  rnn_benchmark_sweep(rnn_type) do n, ts
+    [randn(Float32, n, n) for _ in 1:ts], "Vec"
   end
 end
 
-println("RNN-3d")
-for n in [2, 20, 200, 1000], T in [1, 8, 16, 64]
-  x = randn(Float32, n, n, T)
-  model = RNN(n, n)
-  println("CPU n=$n, t=$T")
-  run_benchmark(model, x, cuda=false)
-  println("CUDA n=$n, t=$T")
-  try
-      run_benchmark(model, x, cuda=true)
-  catch ex
-      @show typeof(ex)
-      if ex isa OutOfGPUMemoryError
-          @warn "Not enough GPU memory to run test"
-      else
-          rethrow(ex)
-      end
+for rnn_type in [Flux.RNN, Flux.GRU, Flux.LSTM]
+  rnn_benchmark_sweep(rnn_type) do n, ts
+    randn(Float32, n, n, ts), "Block"
   end
 end
-
-
 

--- a/perf/recurrent.jl
+++ b/perf/recurrent.jl
@@ -1,22 +1,40 @@
 
 println("RNN")
-for n in [2, 20, 200, 2000], T in [1, 8, 16, 64]
+for n in [2, 20, 200, 1000], T in [1, 8, 16, 64]
   x = [randn(Float32, n, n) for t in 1:T]
   model = RNN(n, n)
   println("CPU n=$n, t=$T")
   run_benchmark(model, x, cuda=false)
   println("CUDA n=$n, t=$T")
-  run_benchmark(model, x, cuda=true)    
+  try
+      run_benchmark(model, x, cuda=true)
+  catch ex
+      @show typeof(ex)
+      if ex isa OutOfGPUMemoryError
+          @warn "Not enough GPU memory to run test"
+      else
+          rethrow(ex)
+      end
+  end
 end
 
 println("RNN-3d")
-for n in [2, 20, 200, 2000], T in [1, 8, 16, 64]
+for n in [2, 20, 200, 1000], T in [1, 8, 16, 64]
   x = randn(Float32, n, n, T)
   model = RNN(n, n)
   println("CPU n=$n, t=$T")
   run_benchmark(model, x, cuda=false)
   println("CUDA n=$n, t=$T")
-  run_benchmark(model, x, cuda=true)    
+  try
+      run_benchmark(model, x, cuda=true)
+  catch ex
+      @show typeof(ex)
+      if ex isa OutOfGPUMemoryError
+          @warn "Not enough GPU memory to run test"
+      else
+          rethrow(ex)
+      end
+  end
 end
 
 

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -11,3 +11,6 @@ include("conv.jl")
 
 @info "Benchmark VGG"
 include("vgg.jl")
+
+@info "Benchmark Recurrent"
+include("recurrent.jl")


### PR DESCRIPTION
Given the conversation in #1855, I think we should have benchmarks in the main repo we can use to iterate on for rnn performance. This touches benchmark_utils to add some of the `Flux.Recur` specific machinery we need. I only added tests for `RNN` using both the vector and 3d interfaces, but we can add the other cells once we are happy w/ how these operate.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
