### PR TITLE
Changed view to eachslice for folding in recurrent

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -85,7 +85,7 @@ reset!(m) = foreach(reset!, functor(m)[1])
 flip(f, xs) = reverse(f.(reverse(xs)))
 
 function (m::Recur)(x::AbstractArray{T, 3}) where T
-  h = [m(view(x, :, :, i)) for i in 1:size(x, 3)]
+  h = [m(x_t) for x_t in eachslice(x, dims=3)]
   sze = size(h[1])
   reshape(reduce(hcat, h), sze[1], sze[2], length(h))
 end


### PR DESCRIPTION
Chang folding to use `eachslice`. Seriously improves memory and run time for large networks as seen in #1872.

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
