### PR TITLE
Speeding up onehotbatch by creating OneHotArray directly

### DIFF
--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -190,7 +190,7 @@ function _onehotbatch(data, labels)
   n_labels = length(labels)
   indices = _findval.(data, Ref(labels))
   if nothing in indices
-    unexpected_values = unique(data[indices .== -1])
+    unexpected_values = unique(data[indices .== nothing])
     error("Values $unexpected_values are not in labels")
   end
   OneHotArray(indices, n_labels)
@@ -200,7 +200,7 @@ function _onehotbatch(data, labels, default)
   n_labels = length(labels)
   indices = _findval.(data, Ref(labels))
   if nothing in indices
-    indices = replace!(indices, -1 => _findval(default, labels))
+    indices = replace!(indices, nothing => _findval(default, labels))
   end
   return OneHotArray(indices, n_labels)
 end

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -188,7 +188,7 @@ onehotbatch(data, labels, default...) = _onehotbatch(data, length(labels) < 32 ?
 # NB function barrier:
 function _onehotbatch(data, labels)
   n_labels = length(labels)
-  indices = _findval.(data, Ref(labels))
+  indices = map(x -> _findval(x, labels), data)
   if nothing in indices
     unexpected_values = unique(data[indices .== nothing])
     error("Values $unexpected_values are not in labels")

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -198,11 +198,15 @@ end
 
 function _onehotbatch(data, labels, default)
   n_labels = length(labels)
-  indices = _findval.(data, Ref(labels))
+  indices = map(x -> _findval(x, labels), data)
   if nothing in indices
-    indices = replace(indices, nothing => _findval(default, labels))
+    default_index = _findval(default, labels)
+    isnothing(default_index) && error("Default value $default_index is not in labels")
+    replaced_indices = replace(indices, nothing => default_index)
+    return OneHotArray(replaced_indices, n_labels)
+  else
+    return OneHotArray(indices, n_labels)
   end
-  return OneHotArray(indices, n_labels)
 end
 
 """

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -190,7 +190,7 @@ function _onehotbatch(data, labels)
   n_labels = length(labels)
   indices = _findval.(data, Ref(labels))
   if nothing in indices
-    unexpected_values = unique(data[indices .== nothinghl])
+    unexpected_values = unique(data[indices .== nothing])
     error("Values $unexpected_values are not in labels")
   end
   return OneHotArray(indices, n_labels)

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -190,7 +190,7 @@ function _onehotbatch(data, labels)
   n_labels = length(labels)
   indices = _findval.(data, Ref(labels))
   if nothing in indices
-    unexpected_values = unique(data[indices .== nothing])
+    unexpected_values = unique(data[indices .== nothinghl])
     error("Values $unexpected_values are not in labels")
   end
   OneHotArray(indices, n_labels)
@@ -200,7 +200,7 @@ function _onehotbatch(data, labels, default)
   n_labels = length(labels)
   indices = _findval.(data, Ref(labels))
   if nothing in indices
-    indices = replace!(indices, nothing => _findval(default, labels))
+    indices = replace(indices, nothing => _findval(default, labels))
   end
   return OneHotArray(indices, n_labels)
 end

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -193,7 +193,7 @@ function _onehotbatch(data, labels)
     unexpected_values = unique(data[indices .== nothinghl])
     error("Values $unexpected_values are not in labels")
   end
-  OneHotArray(indices, n_labels)
+  return OneHotArray(indices, n_labels)
 end
 
 function _onehotbatch(data, labels, default)

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -188,8 +188,9 @@ onehotbatch(data, labels, default...) = _onehotbatch(data, length(labels) < 32 ?
 function _onehotbatch(data, labels)
   indices = UInt32[something(_findval(i, labels), 0) for i in data]
   if 0 in indices
-    unexpected_values = unique(data[indices .== 0])
-    error("Values $unexpected_values are not in labels")
+    for x in data
+      isnothing(_findval(x, labels)) && error("Value $x not found in labels")
+    end
   end
   return OneHotArray(indices, length(labels))
 end

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -184,6 +184,7 @@ julia> reshape(1:15, 3, 5) * oh  # this matrix multiplication is done efficientl
 ```
 """
 onehotbatch(data, labels, default...) = _onehotbatch(data, length(labels) < 32 ? Tuple(labels) : labels, default...)
+onehotbatch(data::AbstractString, labels, default...) = onehotbatch([_ for _ in data], labels, default...)
 
 # NB function barrier:
 function _onehotbatch(data, labels)

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -187,7 +187,7 @@ onehotbatch(data, labels, default...) = _onehotbatch(data, length(labels) < 32 ?
 
 # NB function barrier:
 function _onehotbatch(data, labels)
-  indices = [_findval(i, labels) for i in data]
+  indices = UInt32[_findval(i, labels) for i in data]
   if nothing in indices
     unexpected_values = unique(data[indices .== nothing])
     error("Values $unexpected_values are not in labels")
@@ -198,7 +198,7 @@ end
 function _onehotbatch(data, labels, default)
   default_index = _findval(default, labels)
   isnothing(default_index) && error("Default value $default is not in labels")
-  indices = [isnothing(_findval(i, labels)) ? default_index : _findval(i, labels) for i in data]
+  indices = UInt32[isnothing(_findval(i, labels)) ? default_index : _findval(i, labels) for i in data]
   return OneHotArray(indices, length(labels))
 end
 

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -202,7 +202,7 @@ function _onehotbatch(data, labels, default)
   indices = map(x -> _findval(x, labels), data)
   if nothing in indices
     default_index = _findval(default, labels)
-    isnothing(default_index) && error("Default value $default_index is not in labels")
+    isnothing(default_index) && error("Default value $default is not in labels")
     replaced_indices = replace(indices, nothing => default_index)
     return OneHotArray(replaced_indices, n_labels)
   else

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -185,11 +185,10 @@ julia> reshape(1:15, 3, 5) * oh  # this matrix multiplication is done efficientl
 """
 onehotbatch(data, labels, default...) = _onehotbatch(data, length(labels) < 32 ? Tuple(labels) : labels, default...)
 
-# NB function barrier:
 function _onehotbatch(data, labels)
-  indices = UInt32[_findval(i, labels) for i in data]
-  if nothing in indices
-    unexpected_values = unique(data[indices .== nothing])
+  indices = UInt32[something(_findval(i, labels), 0) for i in data]
+  if 0 in indices
+    unexpected_values = unique(data[indices .== 0])
     error("Values $unexpected_values are not in labels")
   end
   return OneHotArray(indices, length(labels))
@@ -198,7 +197,7 @@ end
 function _onehotbatch(data, labels, default)
   default_index = _findval(default, labels)
   isnothing(default_index) && error("Default value $default is not in labels")
-  indices = UInt32[isnothing(_findval(i, labels)) ? default_index : _findval(i, labels) for i in data]
+  indices = UInt32[something(_findval(i, labels), default_index) for i in data]
   return OneHotArray(indices, length(labels))
 end
 

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -24,7 +24,6 @@ using Test
   @test_throws Exception onehotbatch([:a, :d], (:a, :b, :c))
   @test_throws Exception onehotbatch([:a, :d], [:a, :b, :c], :e)
   @test_throws Exception onehotbatch([:a, :d], (:a, :b, :c), :e)
-  @test_throws Exception onehotbatch([:a, :b], (:a, :b, :c), :d)
 
   floats = (0.0, -0.0, NaN, -NaN, Inf, -Inf)
   @test onecold(onehot(0.0, floats)) == 1

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -24,7 +24,7 @@ using Test
   @test_throws Exception onehotbatch([:a, :d], (:a, :b, :c))
   @test_throws Exception onehotbatch([:a, :d], [:a, :b, :c], :e)
   @test_throws Exception onehotbatch([:a, :d], (:a, :b, :c), :e)
-  @test_throws Exception onehotbatch([:a, :e], (:a, :b, :c), :d)
+  @test_throws Exception onehotbatch([:a, :b], (:a, :b, :c), :d)
 
   floats = (0.0, -0.0, NaN, -NaN, Inf, -Inf)
   @test onecold(onehot(0.0, floats)) == 1

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -18,10 +18,13 @@ using Test
   @test onehotbatch("abc", 'a':'c') == Bool[1 0 0; 0 1 0; 0 0 1]
   @test onehotbatch("zbc", ('a', 'b', 'c'), 'a') == Bool[1 0 0; 0 1 0; 0 0 1]
 
+  @test onehotbatch([10, 20], [30, 40, 50], 30) == Bool[1 1; 0 0; 0 0]
+
   @test_throws Exception onehotbatch([:a, :d], [:a, :b, :c])
   @test_throws Exception onehotbatch([:a, :d], (:a, :b, :c))
   @test_throws Exception onehotbatch([:a, :d], [:a, :b, :c], :e)
   @test_throws Exception onehotbatch([:a, :d], (:a, :b, :c), :e)
+  @test_throws Exception onehotbatch([:a, :e], (:a, :b, :c), :d)
 
   floats = (0.0, -0.0, NaN, -NaN, Inf, -Inf)
   @test onecold(onehot(0.0, floats)) == 1


### PR DESCRIPTION
- Speeding up `onehotbatch` by constructing array directly

Hey there.
I noticed that the `onehotbatch` function calls the `onehot` function repeatedly, and then merges the resulting `OneHotVector`s.
This leads to the `OneHotVector` constructor being called many times, especially as data grows large. This PR changes the behaviour slightly, constructing a `OneHotArray` directly.

EDIT - Testing against master:
EDIT2 - Updated after broadcasts replaced with maps
EDIT3 - Added example benchmark cases from #1861 / #1844 
EDIT4 - Update after replacing maps with comprehension

Before:
```julia
julia> small_data = rand(MersenneTwister(0), 'a':'e', 20);
julia> small_labels = 'a':'e'
julia> big_data = rand(MersenneTwister(0), '.':'z', 10^6);
julia> big_labels = '.':'z'

julia> @btime onehotbatch($small_data, $small_labels);
  694.440 ns (5 allocations: 416 bytes)

julia> @btime onehotbatch($big_data, $big_labels);
  1.474 s (8000007 allocations: 358.58 MiB

julia> @btime onehotbatch($small_data, $big_labels);
  24.796 μs (165 allocations: 7.55 KiB)

julia> @btime onehotbatch($small_data, labels) setup=(labels=Tuple(small_labels));
  415.618 ns (3 allocations: 304 bytes)

julia> @btime onehotbatch(data, $big_labels, 'c') setup=(data=rand(MersenneTwister(0), 1:50, 10^6));
  1.657 s (8000007 allocations: 358.58 MiB)

# Example cases from #1861 / #1844
julia> const bases_dna = ['A', 'C', 'G', 'T'];
julia> dna_sequence = "CCGAGGGCTATGGTTTGGAAGTTAGAACCCTGGGGCTTCTCGCGGA";
julia> short_string = String(rand('a':'z', 10));
julia> string_labels = 'a':'z';

julia> @btime onehotbatch($dna_sequence, $bases_dna);
  793.137 ns (4 allocations: 528 bytes)

julia> @btime onehotbatch($short_string, $string_labels);
  1.512 μs (5 allocations: 480 bytes)
```

After:
```julia
julia> small_data = rand(MersenneTwister(0), 'a':'e', 20);
julia> small_labels = 'a':'e'
julia> big_data = rand(MersenneTwister(0), '.':'z', 10^6);
julia> big_labels = '.':'z'

julia> @btime onehotbatch($small_data, $small_labels);
  646.539 ns (4 allocations: 272 bytes)

julia> @btime onehotbatch($big_data, $big_labels);
  9.802 ms (3 allocations: 3.81 MiB)

julia> @btime onehotbatch($small_data, $big_labels);
  522.220 ns (2 allocations: 160 bytes)

julia> @btime onehotbatch($small_data, labels) setup=(labels=Tuple(small_labels));
  371.029 ns (2 allocations: 160 bytes)

julia> @btime onehotbatch(data, $big_labels, 'c') setup=(data=rand(MersenneTwister(0), 1:50, 10^6));
  266.723 ms (3 allocations: 3.81 MiB)

# Example cases from #1861 / #1844
julia> const bases_dna = ['A', 'C', 'G', 'T'];
julia> dna_sequence = "CCGAGGGCTATGGTTTGGAAGTTAGAACCCTGGGGCTTCTCGCGGA";
julia> short_string = String(rand('a':'z', 10));
julia> string_labels = 'a':'z';

julia> @btime onehotbatch($dna_sequence, $bases_dna);
  753.800 ns (3 allocations: 288 bytes)

julia> @btime onehotbatch($short_string, $string_labels);
  1.456 μs (4 allocations: 384 bytes)
```

For very small data/labels, the older implementation is a bit faster, but then the newer one tends to do better.

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
