### PR TITLE
Use `destructure` from Optimisers.jl

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -28,7 +28,7 @@ jobs:
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
           - {user: SciML, repo: OperatorLearning.jl, group: All}
-    if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
+    # if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -25,8 +25,8 @@ jobs:
           - {user: FluxML, repo: Torch.jl, group: All}
           - {user: FluxML, repo: Metalhead.jl, group: All}
           - {user: Chemellia, repo: AtomicGraphNets.jl, group: All}
-          - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
-          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
+          - {user: SciML, repo: DiffEqFlux.jl, group: All} # Layers}
+          - {user: SciML, repo: NeuralPDE.jl, group: All} # NNPDE}
           - {user: SciML, repo: OperatorLearning.jl, group: All}
     # if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
     steps:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -25,10 +25,10 @@ jobs:
           - {user: FluxML, repo: Torch.jl, group: All}
           - {user: FluxML, repo: Metalhead.jl, group: All}
           - {user: Chemellia, repo: AtomicGraphNets.jl, group: All}
-          - {user: SciML, repo: DiffEqFlux.jl, group: All} # Layers}
-          - {user: SciML, repo: NeuralPDE.jl, group: All} # NNPDE}
+          - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
+          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
           - {user: SciML, repo: OperatorLearning.jl, group: All}
-    # if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
+    if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.13.0-DEV"
+version = "0.12.99"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -34,7 +34,7 @@ MLUtils = "0.2"
 MacroTools = "0.5"
 NNlib = "0.8.2"
 NNlibCUDA = "0.2"
-Optimisers = "0.2"
+Optimisers = "0.2.1"
 ProgressLogging = "0.1"
 Reexport = "0.2, 1.0"
 SpecialFunctions = "1.8.2, 2.1.2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.12.99"
+version = "0.13.0-DEV"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -7,7 +7,7 @@ using MacroTools: @forward
 
 @reexport using NNlib
 using MLUtils
-import Optimisers: trainable  # before v0.13, Flux owned this function
+import Optimisers: trainable, destructure  # before v0.13, Flux owned these functions
 
 using Zygote, ChainRulesCore
 using Zygote: Params, @adjoint, gradient, pullback, @nograd

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -4,8 +4,6 @@ using Zygote: IdSet
 import Functors: Functors, @functor, functor, fmap, isleaf
 using SparseArrays: AbstractSparseArray
 
-trainable(m) = functor(m)[1]
-
 """
     testmode!(m, mode = true)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -390,11 +390,7 @@ end
       ∇m = gradient(m -> sum(m(x)), m)[1]
       p, re = destructure(m)
       ∇p = gradient(θ -> sum(re(θ)(x)), p)[1]
-      if VERSION >= v"1.7"
-        @test_broken ∇p ≈ destructure(∇m)[1]
-      else
-        @test ∇p ≈ destructure(∇m)[1]
-      end
+      @test ∇p ≈ destructure(∇m)[1]
     end
   end
 end


### PR DESCRIPTION
This deletes `destructure` here to use the function from Optimisers.jl, of the same name and almost the same behaviour, except that:
* it only includes trainable parameters, replacing #1742, and
* it should fix many bugs: Deal with missing gradients, shared parameters, etc.

~~But, of course, there are bugs, Flux's tests fail locally.~~

~~Should also add more tests...~~ Now includes tests from these issues:

Fixes #1826 
Fixes #1767 
Fixes #1601
Fixes #1727

Fixes #1733, closes https://github.com/FluxML/Flux.jl/pull/1742 (replaces)