### PR TITLE
RFC: Restrict `train!` to `AbstractOptimiser`

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,5 +1,4 @@
 name: Downstream
-
 on:
   push:
     branches: [master]
@@ -10,6 +9,8 @@ jobs:
   test:
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     runs-on: ${{ matrix.os }}
+    env:
+      GROUP: ${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +28,7 @@ jobs:
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
           - {user: SciML, repo: OperatorLearning.jl, group: All}
-    if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
+    # if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -28,7 +28,7 @@ jobs:
           - {user: SciML, repo: DiffEqFlux.jl, group: Layers}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
           - {user: SciML, repo: OperatorLearning.jl, group: All}
-    # if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
+    if: contains(github.event.pull_request.labels.*.name, 'run downstream test')
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.13.0-DEV"
+version = "0.12.99"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.12.99"
+version = "0.13.0-DEV"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -34,6 +34,11 @@ struct Zeros
 end
 Zeros(args...) = Zeros()  # was used both Dense(10, 2, initb = Zeros) and Dense(rand(2,10), Zeros())
 
+function update!(x::AbstractArray, x̄)
+  depwarn("`Flux.update!(x, x̄)` was not used internally and has been removed. Please write `x .-= x̄` instead.", :update!)
+  x .-= x̄
+end
+
 # Channel notation: Changed to match Conv, but very softly deprecated!
 # Perhaps change to @deprecate for v0.14, but there is no plan to remove these.
 Dense(in::Integer, out::Integer, σ = identity; kw...) =

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -34,8 +34,8 @@ struct Zeros
 end
 Zeros(args...) = Zeros()  # was used both Dense(10, 2, initb = Zeros) and Dense(rand(2,10), Zeros())
 
-function update!(x::AbstractArray, x̄)
-  depwarn("`Flux.update!(x, x̄)` was not used internally and has been removed. Please write `x .-= x̄` instead.", :update!)
+function Optimise.update!(x::AbstractArray, x̄)
+  depwarn("`Flux.Optimise.update!(x, x̄)` was not used internally and has been removed. Please write `x .-= x̄` instead.", :update!)
   x .-= x̄
 end
 

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -553,7 +553,7 @@ mutable struct Optimiser <: AbstractOptimiser
   os::Vector{Any}
 end
 
-Optimiser(o...) = Optimiser(Any[o...])
+Optimiser(opts::AbstractOptimiser...) = Optimiser(Any[opts...])
 
 @forward Optimiser.os Base.getindex, Base.first, Base.last, Base.lastindex, Base.push!, Base.setindex!
 @forward Optimiser.os Base.iterate

--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -521,7 +521,7 @@ opt = AdaBelief()
 opt = AdaBelief(0.001, (0.9, 0.8))
 ```
 """
-mutable struct AdaBelief
+mutable struct AdaBelief <: AbstractOptimiser
   eta::Float64
   beta::Tuple{Float64,Float64}
   epsilon::Float64

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -93,8 +93,7 @@ The callback can call [`Flux.stop`](@ref) to interrupt the training loop.
 
 Multiple optimisers and callbacks can be passed to `opt` and `cb` as arrays.
 """
-function train!(loss, ps, data, opt::AbstractOptimiser; cb = () -> ())
-  ps = Params(ps)
+function train!(loss, ps::Params, data, opt::AbstractOptimiser; cb = () -> ())
   cb = runall(cb)
   n = (Base.IteratorSize(typeof(data)) == Base.HasLength()) ? length(data) : 0
   @withprogress for (i, d) in enumerate(data)

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -1,14 +1,6 @@
 using ProgressLogging: @progress, @withprogress, @logprogress
 import Zygote: Params, gradient
 
-"""
-    update!(x, x̄)
-
-Update the array `x` according to `x .-= x̄`.
-"""
-function update!(x::AbstractArray, x̄)
-  x .-= x̄
-end
 
 """
     update!(opt, p, g)

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -73,25 +73,42 @@ batchmemaybe(x) = tuple(x)
 batchmemaybe(x::Tuple) = x
 
 """
-    train!(loss, params, data, opt; cb)
+    train!(loss, pars::Params, data, opt::AbstractOptimiser; [cb])
         
-`train!` uses a `loss` function and training `data` to improve the 
-[Model parameters](@ref) (`params`) based on a pluggable [Optimisers](@ref) (`opt`).
-        
-For each datapoint `d` in `data`, compute the gradient of  `loss` with
-respect to `params` through backpropagation and call the optimizer `opt`.
-If `d` is a tuple of arguments to `loss` call `loss(d...)`, else call `loss(d)`.
-        
-To pass trainable parameters, call [`Flux.params`](@ref) with your model or just the 
-layers you want to train, like `train!(loss, params(model), ...)` or `train!(loss, params(model[1:end-2), ...)` respectively.
+Uses a `loss` function and training `data` to improve the 
+model's parameters according to a particular optimisation rule `opt`.
 
-[Callbacks](@ref) are given with the keyword argument `cb`. For example, this will print "training" 
-every 10 seconds (using [`Flux.throttle`](@ref)):
-`train!(loss, params, data, opt, cb = throttle(() -> println("training"), 10))`
-        
+For each `d in data`, first the gradient of the `loss` is computed like this:
+```
+    gradient(() -> loss(d...), pars)  # if d isa Tuple
+    gradient(() -> loss(d), pars)     # otherwise
+```
+Here `pars` is produced by calling [`Flux.params`](@ref) on your model.
+(Or just on the layers you want to train, like `train!(loss, params(model[1:end-2]), data, opt)`.)
+This is the "implicit" style of parameter handling.
+
+Then, this gradient is used by optimizer `opt` to update the paramters:
+```
+    update!(opt, pars, grads)
+```
+The optimiser should be from the [Flux.Optimise](@ref) module.
+Different optimisers can be combined using [Flux.Optimise.Optimiser](@ref).
+
+This training loop iterates through `data` once.
+You can use [`@epochs`](@ref) to do this several times, or 
+use for instance `Iterators.repeat` to make a longer `data` iterator.
+
+## Callbacks
+
+[Callbacks](@ref) are given with the keyword argument `cb`.
+For example, this will print "training" every 10 seconds (using [`Flux.throttle`](@ref)):
+```
+    train!(loss, params, data, opt, cb = throttle(() -> println("training"), 10))
+```
+    
 The callback can call [`Flux.stop`](@ref) to interrupt the training loop.
 
-Multiple optimisers and callbacks can be passed to `opt` and `cb` as arrays.
+Multiple callbacks can be passed to `cb` as array.
 """
 function train!(loss, ps::Params, data, opt::AbstractOptimiser; cb = () -> ())
   cb = runall(cb)

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -20,13 +20,13 @@ according to optimizer `opt`  and the gradients `gs` (the gradient `g`).
 As a result, the parameters are mutated and the optimizer's internal state may change.
 The gradient could be mutated as well.
 """
-function update!(opt, x, x̄)
+function update!(opt::AbstractOptimiser, x, x̄)
   x̄r = ArrayInterface.restructure(x, x̄) # address some cases where Zygote's
                                           # output are not mutable, see #1510 
   x .-= apply!(opt, x, x̄r)
 end
 
-function update!(opt, xs::Params, gs)
+function update!(opt::AbstractOptimiser, xs::Params, gs)
   for x in xs
     isnothing(gs[x]) && continue
     update!(opt, x, gs[x])
@@ -101,7 +101,7 @@ The callback can call [`Flux.stop`](@ref) to interrupt the training loop.
 
 Multiple optimisers and callbacks can be passed to `opt` and `cb` as arrays.
 """
-function train!(loss, ps, data, opt; cb = () -> ())
+function train!(loss, ps, data, opt::AbstractOptimiser; cb = () -> ())
   ps = Params(ps)
   cb = runall(cb)
   n = (Base.IteratorSize(typeof(data)) == Base.HasLength()) ? length(data) : 0

--- a/test/data.jl
+++ b/test/data.jl
@@ -76,7 +76,7 @@ using Random
     X = zeros(2, 10)
     loss(x) = sum((x .- θ).^2)
     d  = DataLoader(X)
-    Flux.train!(loss, [θ], ncycle(d, 10), Descent(0.1))
+    Flux.train!(loss, Params([θ]), ncycle(d, 10), Descent(0.1))
     @test norm(θ) < 1e-4
 
     # test interaction with `train!`
@@ -85,7 +85,7 @@ using Random
     Y = fill(2, 10)
     loss(x, y) = sum((y - x'*θ).^2)
     d  = DataLoader((X, Y))
-    Flux.train!(loss, [θ], ncycle(d, 10), Descent(0.1))
+    Flux.train!(loss, Params([θ]), ncycle(d, 10), Descent(0.1))
     @test norm(θ .- 1) < 1e-10
 
     # specify the rng

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -50,7 +50,7 @@ end
   l = 1
   Flux.train!(
               () -> (sleep(0.1); Flux.skip(); i+=1),
-              (),
+              Params([]),
               Iterators.repeated((), 10),
               Descent()
              )
@@ -59,7 +59,7 @@ end
 
   Flux.train!(
               () -> (sleep(0.1); i==8 && Flux.skip(); i+=1),
-              (),
+              Params([]),
               Iterators.repeated((), 10),
               Descent()
              )
@@ -68,7 +68,7 @@ end
 
   i = 0
   Flux.train!(() -> (sleep(0.1); i += 1; l),
-              (),
+              Params([]),
               Iterators.repeated((), 100),
               Descent(),
               cb = Flux.throttle(() -> (i > 3 && Flux.stop()), 1))


### PR DESCRIPTION
Flux's optimisers all (except 1 mistake?) have a supertype. So I think we can restrict `train!` and friends to demand this. 

The reason to do so is that I think it makes it possible to add a `train!` method which accepts the ones from Optimisers.jl (which have no supertype), later. And have them coexist within one version of Flux.

I guess this counts as breaking, but are there many other optimisers without the supertype in the wild? Will it break anything else?