### PR TITLE
Add `MLUtils` to doc dependencies and fix missing `DataLoader` docstring

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
 
 [compat]
 Documenter = "0.26"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
-using Documenter, Flux, NNlib, Functors
+using Documenter, Flux, NNlib, Functors, MLUtils
 
 DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive = true)
-makedocs(modules = [Flux, NNlib, Functors],
+makedocs(modules = [Flux, NNlib, Functors, MLUtils],
          doctest = VERSION == v"1.5",
          sitename = "Flux",
          pages = ["Home" => "index.md",

--- a/docs/src/data/dataloader.md
+++ b/docs/src/data/dataloader.md
@@ -1,7 +1,7 @@
 # DataLoader
 
-Flux provides the `DataLoader` type in the `Flux.Data` module to handle iteration over mini-batches of data.
+Flux re-exports the `DataLoader` type from [MLUtils](https://github.com/JuliaML/MLUtils.jl) to handle iteration over mini-batches of data.
 
 ```@docs
-Flux.Data.DataLoader
+MLUtils.DataLoader
 ```


### PR DESCRIPTION
Fixes #1909 

Fixed the missing docstring by adding a new doc dependency (`MLUtils`)!

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
