### PR TITLE
Improvements for LayerNorm

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -178,7 +178,7 @@ end
 
 function Base.show(io::IO, l::LayerNorm)
   print(io, "LayerNorm($(l.size)")
-  a.λ === identity || print(io, ", $(l.λ)")
+  l.λ === identity || print(io, ", ", l.λ)
   hasaffine(l) || print(io, ", affine=false")
   print(io, ")")
 end

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -164,7 +164,7 @@ struct LayerNorm{F,D,T,N}
   affine::Bool
 end
 
-function LayerNorm(sz, λ=nothing; affine=true, ϵ=1f-5)
+function LayerNorm(sz, λ=identity; affine=true, ϵ=1f-5)
   sz = sz isa Integer ? (sz,) : sz
   diag = affine ? Diagonal(sz...) : identity
   return LayerNorm(λ, diag, ϵ, sz, affine)
@@ -174,12 +174,12 @@ end
 
 function (a::LayerNorm)(x)
   x = a.diag(normalise(x, dims=1:length(a.size), ϵ=a.ϵ))
-  return isnothing(a.λ) ? x : a.λ.(x)
+  return a.λ === identity ? x : a.λ.(x)
 end
 
 function Base.show(io::IO, l::LayerNorm)
   print(io, "LayerNorm($(l.size)")
-  isnothing(l.λ) || print(io, ", $(l.λ)")
+  a.λ === identity || print(io, ", $(l.λ)")
   hasaffine(l) || print(io, ", affine=false")
   print(io, ")")
 end

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -139,7 +139,7 @@ testmode!(m::AlphaDropout, mode=true) =
   (m.active = (isnothing(mode) || mode == :auto) ? nothing : !mode; m)
 
 """
-    LayerNorm(sz, λ=nothing; affine=true, ϵ=1fe-5)
+    LayerNorm(sz, λ=identity; affine=true, ϵ=1fe-5)
 
 A [normalisation layer](https://arxiv.org/abs/1607.06450) designed to be
 used with recurrent hidden states.
@@ -164,10 +164,9 @@ struct LayerNorm{F,D,T,N}
   affine::Bool
 end
 
-function LayerNorm(sz, λ=identity; affine=true, ϵ=1f-5)
-  sz = sz isa Integer ? (sz,) : sz
+function LayerNorm(sz, λ=identity; affine::Bool=true, ϵ::Real=1f-5)
   diag = affine ? Diagonal(sz...) : identity
-  return LayerNorm(λ, diag, ϵ, sz, affine)
+  return LayerNorm(λ, diag, ϵ, Tuple(sz), affine)
 end
 
 @functor LayerNorm

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -33,9 +33,8 @@ Normalise `x` to mean 0 and standard deviation 1 across the dimension(s) given b
 Per default, `dims` is the last dimension. 
 `ϵ` is a small additive factor added to the denominator for numerical stability.
 """
-function normalise(x::AbstractArray; dims=ndims(x), ϵ=ofeltype(x, 1e-5))
+@inline function normalise(x::AbstractArray; dims=ndims(x), ϵ=ofeltype(x, 1e-5))
   μ = mean(x, dims=dims)
-    #   σ = std(x, dims=dims, mean=μ, corrected=false) # use this when Zygote#478 gets merged
-  σ = std(x, dims=dims, corrected=false)
-  return (x .- μ) ./ (σ .+ ϵ)
+  σ = std(x, dims=dims, mean=μ, corrected=false)
+  return @. (x - μ) / (σ + ϵ)
 end


### PR DESCRIPTION
Inspired by [this](https://discourse.julialang.org/t/flux-layernorm-slower-than-pytorch/78084) discussion, this PR achieves some speedup in LayerNorm by a. passing the mean to `std` as an argument (there was a note to make this change after it had been implemented but it never really happened) and b. tweaking some mild implementation details (it removes a broadcasted `identity` that was proving to be a bottleneck for large array sizes, for example).

Before this PR (Julia 1.8.0-beta2.3, Flux master):
```julia
julia> l = LayerNorm(768);

julia> x = rand(Float32, 768, 128, 2);

julia> @benchmark $(l)($x)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  200.292 μs …  10.650 ms  ┊ GC (min … max):  0.00% … 96.39%
 Time  (median):     311.625 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   412.579 μs ± 625.478 μs  ┊ GC (mean ± σ):  23.83% ± 14.70%

  ▃█▄▁                                                          ▁
  ████▇▄▄▄▁▄▁▃▁▃▁▁▁▁▁▁▁▁▃▁▄▁▃▁▄▃▁▁▄▁▄▅▃▄▅▄▆▆▄▅▅▅▆▆▅▄▃▅▅▅▄▅▄▅▄▄▅ █
  200 μs        Histogram: log(frequency) by time       4.42 ms <

 Memory estimate: 2.25 MiB, allocs estimate: 24.
```

After this PR:
```julia
julia> @benchmark $(l)($x)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  167.875 μs …   5.326 ms  ┊ GC (min … max):  0.00% … 95.32%
 Time  (median):     243.792 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   282.340 μs ± 341.526 μs  ┊ GC (mean ± σ):  14.86% ± 11.55%

    █                                                            
  ▃▆█▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▂▂▂▁▂▂▂▂▂▂▂▂▁▁▁▂▂▂▂ ▂
  168 μs           Histogram: frequency by time         2.39 ms <

 Memory estimate: 1.50 MiB, allocs estimate: 16.
```
