### PR TITLE
Improve docs for initialisation

### DIFF
--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -24,8 +24,7 @@ Base.rpad(v::AbstractVector, n::Integer, p)
 ## Layer Initialisation
 
 Flux initialises convolutional layers and recurrent cells with `glorot_uniform` by default.
-Most layers accept a function as an `init` keyword, which controls their weight array,
-but not bias. For example:
+Most layers accept a function as an `init` keyword, which replaces this default. For example:
 
 ```jldoctest; setup = :(using Flux)
 julia> conv = Conv((3, 3), 3 => 2, relu; init=Flux.glorot_normal)
@@ -37,14 +36,18 @@ julia> conv.bias
  0.0
 ```
 
+Note that `init` creates the weight array, but not the bias vector.
+
 Many of the initialisation functions accept keywords such as `gain`, 
 and a random number generator. To make it easy to pass these to layers,
 there are methods which return a function:
 
-```jldoctest; setup = :(using Flux)
+```jldoctest; setup = :(using Flux, Random)
 julia> Dense(4 => 5, tanh; init=Flux.glorot_uniform(gain=2))
+Dense(4 => 5, tanh)  # 25 parameters
 
 julia> Dense(4 => 5, tanh; init=Flux.randn32(MersenneTwister(1)))
+Dense(4 => 5, tanh)  # 25 parameters
 ```
 
 ```@docs

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -21,17 +21,30 @@ MLUtils.batchseq
 Base.rpad(v::AbstractVector, n::Integer, p)
 ```
 
-## Layer Initialization
+## Layer Initialisation
 
-These are primarily useful if you are planning to write your own layers.
-Flux initializes convolutional layers and recurrent cells with `glorot_uniform`
-by default.
-To change the default on an applicable layer, pass the desired function with the
-`init` keyword. For example:
+Flux initialises convolutional layers and recurrent cells with `glorot_uniform` by default.
+Most layers accept a function as an `init` keyword, which controls their weight array,
+but not bias. For example:
 
 ```jldoctest; setup = :(using Flux)
-julia> conv = Conv((3, 3), 1 => 8, relu; init=Flux.glorot_normal)
-Conv((3, 3), 1 => 8, relu)  # 80 parameters
+julia> conv = Conv((3, 3), 3 => 2, relu; init=Flux.glorot_normal)
+Conv((3, 3), 3 => 2, relu)  # 56 parameters
+
+julia> conv.bias
+2-element Vector{Float32}:
+ 0.0
+ 0.0
+```
+
+Many of the initialisation functions accept keywords such as `gain`, 
+and a random number generator. To make it easy to pass these to layers,
+there are methods which return a function:
+
+```jldoctest; setup = :(using Flux)
+julia> Dense(4 => 5, tanh; init=Flux.glorot_uniform(gain=2))
+
+julia> Dense(4 => 5, tanh; init=Flux.randn32(MersenneTwister(1)))
 ```
 
 ```@docs
@@ -39,18 +52,23 @@ Flux.glorot_uniform
 Flux.glorot_normal
 Flux.kaiming_uniform
 Flux.kaiming_normal
+Flux.truncated_normal
 Flux.orthogonal
 Flux.sparse_init
+Flux.identity_init
+Flux.ones32
+Flux.rand32
 ```
 
 ## Changing the type of model parameters
+
+The default `eltype` for models is `Float32` since models are often trained/run on GPUs.
+The `eltype` of model `m` can be changed to `Float64` by `f64(m)`:
 
 ```@docs
 Flux.f64
 Flux.f32
 ```
-
-The default `eltype` for models is `Float32` since models are often trained/run on GPUs. The `eltype` of model `m` can be changed to `Float64` by `f64(m)`, or to `Float32` by `f32(m)`.
 
 ## Model Building
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -215,14 +215,16 @@ paramtype(T::Type{<:Real}, m) = fmap(x -> adapt(T, x), m)
 """
     f32(m)
 
-Convert the `eltype` of model's parameters to `Float32`.
+Converts the `eltype` of model's parameters to `Float32` (which is Flux's default).
+Recurses into structs marked with [`@functor`](@ref).
 """
 f32(m) = paramtype(Float32, m)
 
 """
     f64(m)
 
-Convert the `eltype` of model's parameters to `Float64`.
+Converts the `eltype` of model's parameters to `Float64`.
+Recurses into structs marked with [`@functor`](@ref).
 """
 f64(m) = paramtype(Float64, m)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -297,10 +297,13 @@ true
 
 """
 function orthogonal(rng::AbstractRNG, rows::Integer, cols::Integer; gain::Real = 1)
-  mat = rows > cols ? randn(rng, Float32, rows, cols) : randn(rng, Float32, cols, rows)
+  if rows < cols
+    return permutedims(orthogonal(rng, cols, rows; gain))
+  end
+  mat = randn(rng, Float32, rows, cols)
   Q, R = LinearAlgebra.qr(mat)
   mat .= Array(Q) * sign.(LinearAlgebra.Diagonal(R)) .* Float32(gain)
-  return rows > cols ? mat : permutedims(mat)
+  return mat
 end
 
 function orthogonal(rng::AbstractRNG, d1::Integer, ds::Integer...; kwargs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,8 +62,11 @@ This method is described in [1] and also known as Xavier initialization.
 
 # Examples
 ```jldoctest; setup = :(using Random; Random.seed!(0))
+julia> Flux.glorot_uniform(3, 4) |> summary
+"3×4 Matrix{Float32}"
+
 julia> round.(extrema(Flux.glorot_uniform(10, 100)), digits=3)
-(-0.234f0, 0.234f0)
+(-0.232f0, 0.234f0)
 
 julia> round.(extrema(Flux.glorot_uniform(100, 10)), digits=3)
 (-0.233f0, 0.233f0)
@@ -71,7 +74,7 @@ julia> round.(extrema(Flux.glorot_uniform(100, 10)), digits=3)
 julia> round.(extrema(Flux.glorot_uniform(100, 100)), digits=3)
 (-0.173f0, 0.173f0)
 
-julia> Dense(3 => 2, tanh; init=Flux.glorot_uniform(MersenneTwister(1)))
+julia> Dense(3 => 2, tanh; init = Flux.glorot_uniform(MersenneTwister(1)))
 Dense(3 => 2, tanh)  # 8 parameters
 
 julia> ans.bias
@@ -88,7 +91,7 @@ function glorot_uniform(rng::AbstractRNG, dims::Integer...; gain::Real=1)
   scale = Float32(gain) * sqrt(24.0f0 / sum(nfan(dims...)))
   (rand(rng, Float32, dims...) .- 0.5f0) .* scale
 end
-glorot_uniform(dims::Integer...) = glorot_uniform(rng_from_array(), dims...)
+glorot_uniform(dims::Integer...; kw...) = glorot_uniform(rng_from_array(), dims...; kw...)
 glorot_uniform(rng::AbstractRNG=rng_from_array(); init_kwargs...) = (dims...; kwargs...) -> glorot_uniform(rng, dims...; init_kwargs..., kwargs...)
 
 ChainRulesCore.@non_differentiable glorot_uniform(::Any...)
@@ -115,6 +118,12 @@ julia> round(std(Flux.glorot_normal(1000, 10)), digits=3)
 
 julia> round(std(Flux.glorot_normal(1000, 1000)), digits=3)
 0.032f0
+
+julia> Dense(10 => 1000, tanh; init = Flux.glorot_normal(gain=100))
+Dense(10 => 1000, tanh)  # 11_000 parameters
+
+julia> round(std(ans.weight), sigdigits=3)
+4.45f0
 ```
 
 # References
@@ -125,7 +134,7 @@ function glorot_normal(rng::AbstractRNG, dims::Integer...; gain::Real=1)
   std = Float32(gain) * sqrt(2.0f0 / sum(nfan(dims...)))
   randn(rng, Float32, dims...) .* std
 end
-glorot_normal(dims::Integer...; kw...) = glorot_normal(rng_from_array(), dims...; kw...)
+glorot_normal(dims::Integer...; kwargs...) = glorot_normal(rng_from_array(), dims...; kwargs...)
 glorot_normal(rng::AbstractRNG=rng_from_array(); init_kwargs...) = (dims...; kwargs...) -> glorot_normal(rng, dims...; init_kwargs..., kwargs...)
 
 ChainRulesCore.@non_differentiable glorot_normal(::Any...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -369,9 +369,6 @@ most Flux layers. Use `gain` to scale the identity by a constant.
 Often useful in the context of transfer learning, i.e when one wants to add more capacity to
 a model but start from the same mapping.
 
-Use keyword `shift` (integer or tuple) to apply circular shift to the output,
-equivalent to `Base.circshift(identity_init(size...), shift)`.
-
 Has the following behaviour
 *  1D: A `Vector` of `zeros` (useful for an identity bias)
 *  2D: An identity matrix (useful for an identity matrix multiplication)
@@ -388,12 +385,25 @@ Some caveats:
   padding must be applied so that output feature maps have the same size as input feature maps,
   e.g by using [`SamePad`](@ref).
 
+Use keyword `shift` (integer or tuple) to apply circular shift to the output,
+equivalent to `Base.circshift(identity_init(size...), shift)`.
+
+For consistency with other initialisers, it accepts `rng::AbstractRNG` as an optional
+first argument. But this is ignored, since the result is not random.
+
+# Examples
 ```jldoctest
 julia> Flux.identity_init(3,5)
 3×5 Matrix{Float32}:
  1.0  0.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0  0.0
  0.0  0.0  1.0  0.0  0.0
+
+julia> Dense(5 => 3, relu, init=Flux.identity_init)([1,-2,3,-4,5])
+3-element Vector{Float32}:
+ 1.0
+ 0.0
+ 3.0
 
 julia> Flux.identity_init(3,3,2; gain=100)
 3×3×2 Array{Float32, 3}:
@@ -408,7 +418,7 @@ julia> Flux.identity_init(3,3,2; gain=100)
  0.0    0.0  0.0
 
 julia> Conv((2,2), 1 => 1, init=Flux.identity_init(gain=10), pad=SamePad())([1 2 3; 4 5 6; 7 8 9;;;;])
-3×3×2×1 Array{Float32, 4}:
+3×3×1×1 Array{Float32, 4}:
 [:, :, 1, 1] =
  10.0  20.0  30.0
  40.0  50.0  60.0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -424,7 +424,9 @@ julia> Flux.identity_init(3,3,2; gain=100)
  0.0  100.0  0.0
  0.0    0.0  0.0
 
-julia> Conv((2,2), 1 => 1, init=Flux.identity_init(gain=10), pad=SamePad())([1 2 3; 4 5 6; 7 8 9;;;;])
+julia> x4 = cat([1 2 3; 4 5 6; 7 8 9]; dims=4);
+
+julia> Conv((2,2), 1 => 1, init=Flux.identity_init(gain=10), pad=SamePad())(x4)
 3×3×1×1 Array{Float32, 4}:
 [:, :, 1, 1] =
  10.0  20.0  30.0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,8 +52,8 @@ else
 end
 
 """
-    glorot_normal([rng=GLOBAL_RNG], size...; gain = 1) -> Array
-    glorot_normal([rng]; kw...) -> Function
+    glorot_uniform([rng=GLOBAL_RNG], size...; gain = 1) -> Array
+    glorot_uniform([rng]; kw...) -> Function
 
 Return an `Array{Float32}` of the given `size` containing random numbers drawn from a uniform
 distribution on the interval ``[-x, x]``, where `x = gain * sqrt(6 / (fan_in + fan_out))`.
@@ -62,16 +62,16 @@ This method is described in [1] and also known as Xavier initialization.
 
 # Examples
 ```jldoctest; setup = :(using Random; Random.seed!(0))
-julia> extrema(Flux.glorot_uniform(10, 100))
-(-0.23351441f0, 0.23336345f0)
+julia> round.(extrema(Flux.glorot_uniform(10, 100)), digits=3)
+(-0.234f0, 0.234f0)
 
-julia> extrema(Flux.glorot_uniform(100, 10))
-(-0.23311867f0, 0.23339099f0)
+julia> round.(extrema(Flux.glorot_uniform(100, 10)), digits=3)
+(-0.233f0, 0.233f0)
 
-julia> extrema(Flux.glorot_uniform(100, 100))
-(-0.17319304f0, 0.17320111f0)
+julia> round.(extrema(Flux.glorot_uniform(100, 100)), digits=3)
+(-0.173f0, 0.173f0)
 
-julia> Dense(3 => 2, tanh; init=glorot_uniform(MersenneTwister(1)))
+julia> Dense(3 => 2, tanh; init=Flux.glorot_uniform(MersenneTwister(1)))
 Dense(3 => 2, tanh)  # 8 parameters
 
 julia> ans.bias
@@ -107,14 +107,14 @@ This method is described in [1] and also known as Xavier initialization.
 ```jldoctest; setup = :(using Random; Random.seed!(0))
 julia> using Statistics
 
-julia> std(Flux.glorot_normal(10, 100))
-0.13758826f0
+julia> round(std(Flux.glorot_normal(10, 1000)), digits=3)
+0.044f0
 
-julia> std(Flux.glorot_normal(100, 10))
-0.13859096f0
+julia> round(std(Flux.glorot_normal(1000, 10)), digits=3)
+0.044f0
 
-julia> std(Flux.glorot_normal(100, 100))
-0.10008307f0
+julia> round(std(Flux.glorot_normal(1000, 1000)), digits=3)
+0.032f0
 ```
 
 # References
@@ -141,14 +141,14 @@ This method is described in [1] and also known as He initialization.
 
 # Examples
 ```jldoctest; setup = :(using Random; Random.seed!(0))
-julia> extrema(Flux.kaiming_uniform(100, 10))
-(-0.7729515f0, 0.7726907f0)
+julia> round.(extrema(Flux.kaiming_uniform(100, 10)), digits=3)
+(-0.774f0, 0.774f0)
 
-julia> extrema(Flux.kaiming_uniform(10, 100))
-(-0.2446668f0, 0.24487591f0)
+julia> round.(extrema(Flux.kaiming_uniform(10, 100)), digits=3)
+(-0.245f0, 0.244f0)
 
-julia> extrema(Flux.kaiming_uniform(100, 100))
-(-0.24494839f0, 0.24493338f0)
+julia> round.(extrema(Flux.kaiming_uniform(100, 100)), digits=3)
+(-0.245f0, 0.245f0)
 ```
 
 # References
@@ -178,14 +178,14 @@ This method is described in [1] and also known as He initialization.
 ```jldoctest; setup = :(using Random; Random.seed!(0))
 julia> using Statistics
 
-julia> std(Flux.kaiming_normal(10, 100))
-0.14249805f0
+julia> round(std(Flux.kaiming_normal(10, 1000)), digits=3)
+0.045f0
 
-julia> std(Flux.kaiming_normal(100, 10))
-0.45106217f0
+julia> round(std(Flux.kaiming_normal(1000, 10)), digits=3)
+0.447f0
 
-julia> std(Flux.kaiming_normal(100, 100))
-0.14089037f0
+julia> round(std(Flux.kaiming_normal(1000, 1000)), digits=3)
+0.045f0
 ```
 
 # References
@@ -330,7 +330,7 @@ julia> sum(0 .== Flux.sparse_init(10, 11, sparsity=0.9), dims=1)
 1×11 Matrix{Int64}:
  9  9  9  9  9  9  9  9  9  9  9
 
-julia> Dense(3 => 10, tanh; init=sparse_init(sparsity=0.5))
+julia> Dense(3 => 10, tanh; init=Flux.sparse_init(sparsity=0.5))
 Dense(3 => 10, tanh)  # 40 parameters
 
 julia> count(iszero, ans.weight, dims=1)
@@ -460,12 +460,12 @@ Return an `Array{Float32}` of the given `size`, filled like `rand` or `randn`.
 When the size is not provided, `rand32(rng::AbstractRNG)` returns a function.
 """
 rand32(dims::Integer...) = Base.rand(Float32, dims...)
-rand32(rng::AbstractRNG, dims::Integer...) = Base.rand32(rng, Float32, dims...)
-rand32(rng::AbstractRNG) = (dims...,) -> rand32(rng, Float32, dims...)
+rand32(rng::AbstractRNG, dims::Integer...) = Base.rand(rng, Float32, dims...)
+rand32(rng::AbstractRNG) = (dims...,) -> Base.rand(rng, Float32, dims...)
 
 @doc @doc(rand32)
 randn32(dims::Integer...) = Base.randn(Float32, dims...)
-randn32(rng::AbstractRNG, dims::Integer...) = Base.rand32(rng, Float32, dims...)
+randn32(rng::AbstractRNG, dims::Integer...) = Base.randn(rng, Float32, dims...)
 randn32(rng::AbstractRNG) = (dims...,) -> Base.randn(rng, Float32, dims...)
 
 """

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -76,6 +76,8 @@ end
       sparse_init,
       truncated_normal,
       identity_init,
+      Flux.rand32,
+      Flux.randn32,
     ]
     if init == sparse_init
       init = (args...) -> sparse_init(args...; sparsity=0.5)
@@ -200,12 +202,10 @@ end
   end
 
   @testset "identity_init" begin
-
     @testset "Basic" begin
       partial = identity_init(gain=3)
       @test partial(3, 3) == identity_init(3, 3; gain=3) == [3 0 0; 0 3 0; 0 0 3]
     end
-
     @testset "Non-identity sizes" begin
         @test identity_init(2, 3)[:, end] == zeros(Float32, 2)
         @test identity_init(3, 2; shift=1)[1, :] == zeros(Float32, 2)
@@ -213,14 +213,12 @@ end
         @test identity_init(2, 1, 3, 3)[end, :, :, :] == zeros(Float32, 1, 3, 3)
         @test identity_init(1, 2, 3, 3)[:, end, :, :] == zeros(Float32, 1, 3, 3)
     end
-
     @testset "Dense ID mapping" begin
         l = Dense(3,3, init = identity_init)
 
         indata = reshape(collect(Float32, 1:9), 3, 3)
         @test l(indata) == indata
     end
-
     @testset "$layer ID mapping with kernelsize $kernelsize" for layer in (Conv, ConvTranspose, CrossCor), kernelsize in (
         (1,),
         (3,),
@@ -233,7 +231,6 @@ end
         indata = randn(Float32, kernelsize..., nch, nch)
         @test l(indata) == indata
     end
-
     @testset "Inception identity" begin
       insize = 7
       path1 = Conv((1, 3), insize=>2; init=identity_init, pad=SamePad())


### PR DESCRIPTION
This tidies up the docs for initialisation functions:
* It removes the incomplete "see also" lists, but completes the list in the docs
* It removes some examples which printed random numbers, in favour of something interpretable
* It documents the curried forms
* It documents `zeros32` and `randn32` etc.

It also adds a few methods which seemed to be missing, like `randn32(rng, size...)`, and `glorot_normal(; gain=2)`.