### PR TITLE
Turn off doctests while building docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, Flux, NNlib, Functors
 
 DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive = true)
 makedocs(modules = [Flux, NNlib, Functors],
-         doctest = VERSION == v"1.5",
+         doctest = false,
          sitename = "Flux",
          pages = ["Home" => "index.md",
                   "Building Models" =>

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -90,7 +90,7 @@ julia> Conv((1,1), 3 => 7; pad = (20,10,0,0))(xs) |> size
 (130, 100, 7, 50)
 
 julia> Conv((5,5), 3 => 7; stride = 2, dilation = 4)(xs) |> size
-(42, 42, 7, 5
+(42, 42, 7, 50)
 ```
 """
 struct Conv{N,M,F,A,V}

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -90,7 +90,7 @@ julia> Conv((1,1), 3 => 7; pad = (20,10,0,0))(xs) |> size
 (130, 100, 7, 50)
 
 julia> Conv((5,5), 3 => 7; stride = 2, dilation = 4)(xs) |> size
-(42, 42, 7, 50)
+(42, 42, 7, 50
 ```
 """
 struct Conv{N,M,F,A,V}

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -90,7 +90,7 @@ julia> Conv((1,1), 3 => 7; pad = (20,10,0,0))(xs) |> size
 (130, 100, 7, 50)
 
 julia> Conv((5,5), 3 => 7; stride = 2, dilation = 4)(xs) |> size
-(42, 42, 7, 50
+(42, 42, 7, 5
 ```
 """
 struct Conv{N,M,F,A,V}


### PR DESCRIPTION
Fixes #1914 

Now the doctests run only in the workflows, and only on `Julia` `1.6`!

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
