### PR TITLE
remove DepthwiseConv type in favor of Conv

### DIFF
--- a/docs/src/models/layers.md
+++ b/docs/src/models/layers.md
@@ -25,7 +25,6 @@ CrossCor
 SamePad
 Flux.flatten
 Flux.convfilter
-Flux.depthwiseconvfilter
 ```
 
 ## Upsampling Layers

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -128,6 +128,8 @@ julia> Flux.params(c1) |> length
 """
 function Conv(w::AbstractArray{T,N}, b = true, σ = identity;
               stride = 1, pad = 0, dilation = 1, groups = 1) where {T,N}
+
+  @assert size(w, N) % groups == 0 "Output channel dimension must be divisible by groups."
   stride = expand(Val(N-2), stride)
   dilation = expand(Val(N-2), dilation)
   pad = calc_padding(Conv, pad, size(w)[1:N-2], dilation, stride)
@@ -155,6 +157,8 @@ distribution.
 function convfilter(filter::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer};
           init = glorot_uniform, groups = 1) where N
   cin, cout = ch
+  @assert cin % groups == 0 "Input channel dimension must be divisible by groups."
+  @assert cout % groups == 0 "Output channel dimension must be divisible by groups."
   init(filter..., cin÷groups, cout)
 end
 

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -55,7 +55,7 @@ _show_children(m::Maxout) = m.layers
 _show_children(p::Parallel) = (p.connection, p.layers...)
 
 for T in [
-    :Conv, :ConvTranspose, :CrossCor, :DepthwiseConv, :Dense, :Bilinear, :Embedding,
+    :Conv, :ConvTranspose, :CrossCor, :Dense, :Bilinear, :Embedding,
     :BatchNorm, :LayerNorm, :InstanceNorm, :GroupNorm,
   ]
   @eval function Base.show(io::IO, m::MIME"text/plain", x::$T)

--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -153,7 +153,7 @@ end
 
 ## fixes for layers that don't work out of the box
 
-for (fn, Dims) in ((:conv, DenseConvDims), (:depthwiseconv, DepthwiseConvDims))
+for (fn, Dims) in ((:conv, DenseConvDims),)
   @eval begin
     function NNlib.$fn(a::AbstractArray{Nil}, b::AbstractArray{Nil}, dims::$Dims)
       fill(nil, NNlib.output_size(dims)..., NNlib.channels_out(dims), size(a)[end])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -383,7 +383,7 @@ Has the following behaviour
 
 Some caveats: 
 * Not all layers will be identity mapping when used with this init. Exceptions
-  include recurrent layers, `DepthwiseConv` and normalization layers.
+  include recurrent layers and normalization layers.
 
 * Layers must have `input_size == output_size` for identity mapping to be
   possible. When this is not the case, extra dimensions of the array are padded with zeros.

--- a/test/cuda/layers.jl
+++ b/test/cuda/layers.jl
@@ -11,7 +11,7 @@
 end
 
 # TODO: These layers get into scalar indexing issues.
-const BROKEN_LAYERS = Union{DepthwiseConv}
+const BROKEN_LAYERS = Union{}
 
 const ACTIVATIONS = [identity, relu, tanh,
                      sigmoid, exp, softplus,

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -81,6 +81,10 @@ end
     c = Conv((3,4,5), 100 => 25, groups = 5)
     @test size(c.weight) == (3,4,5, 20, 25)
     @test size(c(ip)) == (8,8,8, 25, 2)
+
+    # Test that we cannot ask for non-integer multiplication factors
+    @test_throws AssertionError Conv((2, 2), 3=>10, groups=2)
+    @test_throws AssertionError Conv((2, 2), 2=>9, groups=2)
   end
 end
 


### PR DESCRIPTION
Implement @mcabbott's [comment](https://github.com/FluxML/Flux.jl/issues/459#issuecomment-1073238976)

Also adds the assertion 
```julia
  @assert cin % groups == 0 "Input channel dimension must be divisible by groups."
  @assert cout % groups == 0 "Output channel dimension must be divisible by groups."
```
for standard convolutions.

Close #1667, close #459