### PR TITLE
Allow activation function for Diagonal

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -138,13 +138,13 @@ julia> Flux.params(d1)  # no trainable bias
 Params([[1.0 1.0 … 1.0 1.0; 1.0 1.0 … 1.0 1.0]])
 ```
 """
-struct Dense{F, M<:AbstractMatrix, B}
+struct Dense{M<:AbstractMatrix, B, F}
   weight::M
   bias::B
   σ::F
   function Dense(W::M, bias = true, σ::F = identity) where {M<:AbstractMatrix, F}
     b = create_bias(W, bias, size(W,1))
-    new{F,M,typeof(b)}(W, b, σ)
+    new{M, typeof(b), F}(W, b, σ)
   end
 end
 
@@ -158,7 +158,7 @@ end
 function (a::Dense)(x::AbstractVecOrMat)
   W, b = a.weight, a.bias
   σ = NNlib.fast_act(a.σ, x)  # replaces tanh => tanh_fast, etc
-  return σ.(W*x .+ b)
+  return σ.(W * x .+ b)
 end
 
 (a::Dense)(x::AbstractArray) = 
@@ -172,35 +172,37 @@ function Base.show(io::IO, l::Dense)
 end
 
 """
-    Diagonal(size::Integer...; bias=true, init=ones32)
-    Diagonal(scale::AbstractArray, [bias])
+    Diagonal(size::Integer...; σ = identity, bias=true, init=ones32)
+    Diagonal(scale::AbstractArray, [bias, activation])
 
 Create an element-wise linear layer, which performs
 
-    y = scale .* x .+ bias
+    y = σ.(scale .* x .+ bias)
 
-with no activation function.
- 
 The learnable scale & bias are initialised `init(size...)` and `zeros32(size...)`,
 with `init=ones32` by default. You may specify the function `init`, 
 turn off trainable bias with `bias=false`, or provide the array(s) explicitly.
 
 Used by [`LayerNorm`](@ref).
 """
-struct Diagonal{A<:AbstractArray, B}
+struct Diagonal{A<:AbstractArray, B, F}
   scale::A
   bias::B
-  function Diagonal(W::M, bias = true) where M<:AbstractArray
+  σ::F
+  function Diagonal(W::M, bias = true, σ::F = identity) where {M<:AbstractArray, F}
     b = create_bias(W, bias, size(W)...)
-    new{M, typeof(b)}(W, b)
+    new{M, typeof(b), F}(W, b, σ)
   end
 end
 
-Diagonal(sz::Integer...; bias = true, init = ones32) = Diagonal(init(sz...), bias)
+Diagonal(sz::Integer...; σ = identity, bias = true, init = ones32) = Diagonal(init(sz...), bias, σ)
 
 @functor Diagonal
 
-(a::Diagonal)(x) = a.scale .* x .+ a.bias
+function (a::Diagonal)(x::AbstractArray)
+  σ = NNlib.fast_act(a.σ, x)  # replaces tanh => tanh_fast, etc
+  return σ == typeof(identity) ? a.scale .* x .+ a.bias : σ.(a.scale .* x .+ a.bias)
+end
 
 function Base.show(io::IO, l::Diagonal)
   print(io, "Diagonal(", join(size(l.scale), ", "))
@@ -212,7 +214,7 @@ end
     Maxout(layers...)
     Maxout(f, n_alts)
 
-This contains a number of internal layes, each of which receives the same input.
+This contains a number of internal layers, each of which receives the same input.
 Its output is the elementwise maximum of the the internal layers' outputs.
 
 Instead of defining layers individually, you can provide a zero-argument function

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -200,7 +200,7 @@ Diagonal(sz::Integer...; σ = identity, bias = true, init = ones32) = Diagonal(i
 
 function (a::Diagonal)(x::AbstractArray)
   σ = NNlib.fast_act(a.σ, x)  # replaces tanh => tanh_fast, etc
-  return σ == typeof(identity) ? a.scale .* x .+ a.bias : σ.(a.scale .* x .+ a.bias)
+  return σ === typeof(identity) ? a.scale .* x .+ a.bias : σ.(a.scale .* x .+ a.bias)
 end
 
 function Base.show(io::IO, l::Diagonal)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -138,13 +138,13 @@ julia> Flux.params(d1)  # no trainable bias
 Params([[1.0 1.0 … 1.0 1.0; 1.0 1.0 … 1.0 1.0]])
 ```
 """
-struct Dense{M<:AbstractMatrix, B, F}
+struct Dense{F, M<:AbstractMatrix, B}
   weight::M
   bias::B
   σ::F
   function Dense(W::M, bias = true, σ::F = identity) where {M<:AbstractMatrix, F}
     b = create_bias(W, bias, size(W,1))
-    new{M, typeof(b), F}(W, b, σ)
+    new{F,M,typeof(b)}(W, b, σ)
   end
 end
 
@@ -156,9 +156,8 @@ end
 @functor Dense
 
 function (a::Dense)(x::AbstractVecOrMat)
-  W, b = a.weight, a.bias
   σ = NNlib.fast_act(a.σ, x)  # replaces tanh => tanh_fast, etc
-  return σ.(W * x .+ b)
+  return σ.(a.weight * x .+ a.bias)
 end
 
 (a::Dense)(x::AbstractArray) = 

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -165,16 +165,13 @@ struct LayerNorm{F,D,T,N}
 end
 
 function LayerNorm(sz, λ=identity; affine::Bool=true, ϵ::Real=1f-5)
-  diag = affine ? Diagonal(sz...) : identity
+  diag = affine ? Diagonal(sz...; σ = λ) : Base.Fix1(broadcast, λ)
   return LayerNorm(λ, diag, ϵ, Tuple(sz), affine)
 end
 
 @functor LayerNorm
 
-function (a::LayerNorm)(x)
-  x = a.diag(normalise(x, dims=1:length(a.size), ϵ=a.ϵ))
-  return a.λ === identity ? x : a.λ.(x)
-end
+(a::LayerNorm)(x) = a.diag(normalise(x, dims=1:length(a.size), ϵ=a.ϵ))
 
 function Base.show(io::IO, l::LayerNorm)
   print(io, "LayerNorm($(l.size)")

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -89,19 +89,18 @@ import Flux: activations
 
   @testset "Diagonal" begin
     @test length(Flux.Diagonal(10)(randn(10))) == 10
-    @test length(Flux.Diagonal(10)(1)) == 10
     @test length(Flux.Diagonal(10)(randn(1))) == 10
     @test length(Flux.Diagonal(10; bias = false)(randn(10))) == 10
     @test_throws DimensionMismatch Flux.Diagonal(10)(randn(2))
 
     @test Flux.Diagonal(2)([1 2]) == [1 2; 1 2]
-    @test Flux.Diagonal(2)([1,2]) == [1,2]
+    @test Flux.Diagonal(2)([1, 2]) == [1, 2]
     @test Flux.Diagonal(2; bias = false)([1 2; 3 4]) == [1 2; 3 4]
 
-    @test Flux.Diagonal(2)(rand(2,3,4)) |> size == (2, 3, 4)
-    @test Flux.Diagonal(2,3)(rand(2,3,4)) |> size == (2, 3, 4)
-    @test Flux.Diagonal(2, 3, 4; bias = false)(rand(2,3,4)) |> size == (2, 3, 4)
-    @test Flux.Diagonal(2, 3; bias = false)(rand(2,1,4)) |> size == (2, 3, 4)
+    @test Flux.Diagonal(2)(rand(2, 3, 4)) |> size == (2, 3, 4)
+    @test Flux.Diagonal(2, 3;)(rand(2, 3, 4)) |> size == (2, 3, 4)
+    @test Flux.Diagonal(2, 3, 4; bias = false)(rand(2, 3, 4)) |> size == (2, 3, 4)
+    @test Flux.Diagonal(2, 3; bias = false)(rand(2, 1, 4)) |> size == (2, 3, 4)
   end
 
   @testset "Maxout" begin


### PR DESCRIPTION
Following up on #1911 , this PR allows for an activation function argument to be passed to `Flux.Diagonal` and reroutes the `LayerNorm` activation function to `Flux.Diagonal` now. This reduces memory and time taken for `LayerNorm` with an activation function.

Before this PR (Julia master, Flux master):

```julia
julia> l = LayerNorm(768, relu);

julia> x = rand(Float32, 768, 128, 2);

julia> @benchmark $(l)($x)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  193.291 μs …   4.904 ms  ┊ GC (min … max):  0.00% … 91.62%
 Time  (median):     310.625 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   385.946 μs ± 415.163 μs  ┊ GC (mean ± σ):  19.75% ± 16.07%

  ▂▃█▇▂                                                         ▁
  █████▆▅▅▄▃▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▃▄▄▆▆▆▇▅▆▇▆▇▇▆▆▆▅▅▆▅▅▅▆▅▅▁▅ █
  193 μs        Histogram: log(frequency) by time       2.75 ms <

 Memory estimate: 2.25 MiB, allocs estimate: 18.
```

After this PR:
```julia
julia> @benchmark $(l)($x)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  168.333 μs …   1.870 ms  ┊ GC (min … max):  0.00% … 84.42%
 Time  (median):     245.667 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   281.375 μs ± 209.594 μs  ┊ GC (mean ± σ):  13.78% ± 14.90%

  ▄▃▄█▇▃                                                        ▁
  ███████▅▅▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▅▅▆▆▇▇██▇▇▇▇ █
  168 μs        Histogram: log(frequency) by time       1.43 ms <

 Memory estimate: 1.50 MiB, allocs estimate: 16.
```

PS: there are some formatting changes that I just made because they caught my eye, but if they're jarring I can always remove them