### PR TITLE
Upgrade warnings for v0.13

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,13 +1,13 @@
 # v0.12 deprecations
 
 function ones(dims...)
-  Base.depwarn("Flux.ones(size...) is deprecated, please use Flux.ones32(size...) or Base.ones(Float32, size...)", :ones)
+  Base.depwarn("Flux.ones(size...) is deprecated, please use Flux.ones32(size...) or Base.ones(Float32, size...)", :ones, force=true)
   Base.ones(Float32, dims...)
 end
 ones(T::Type, dims...) = Base.ones(T, dims...)
 
 function zeros(dims...)
-  Base.depwarn("Flux.zeros(size...) is deprecated, please use Flux.zeros32(size...) or Base.zeros(Float32, size...)", :zeros)
+  Base.depwarn("Flux.zeros(size...) is deprecated, please use Flux.zeros32(size...) or Base.zeros(Float32, size...)", :zeros, force=true)
   Base.zeros(Float32, dims...)
 end
 zeros(T::Type, dims...) = Base.zeros(T, dims...)

--- a/src/losses/utils.jl
+++ b/src/losses/utils.jl
@@ -26,12 +26,11 @@ end
 ChainRulesCore.@scalar_rule xlogy(x, y) (log(y), x/y)  # should help Diffractor's broadcasting
 ChainRulesCore.@scalar_rule xlogx(x) (log(y) + true)
 
-# This can be made an error in Flux v0.13, for now just a warning
 function _check_sizes(ŷ::AbstractArray, y::AbstractArray)
   for d in 1:max(ndims(ŷ), ndims(y)) 
-    if size(ŷ,d) != size(y,d)
-      @warn "Size mismatch in loss function! In future this will be an error. In Flux <= 0.12 broadcasting accepts this, but may not give sensible results" summary(ŷ) summary(y) maxlog=3 _id=hash(size(y))
-    end
+   size(ŷ,d) == size(y,d) || throw(DimensionMismatch(
+      "loss function expects size(ŷ) = $(size(ŷ)) to match size(y) = $(size(y))"
+    ))
   end
 end
 _check_sizes(ŷ, y) = nothing  # pass-through, for constant label e.g. y = 1


### PR DESCRIPTION
Options for v0.12 deprecations are:
* do nothing, leave things working
* make them louder, so the message is printed always not just in tests
* turn them into errors, now that there has been time to update.

Thoughts on which to do, where?