### PR TITLE
Rename `Diagonal` to `Scale`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ been removed in favour of MLDatasets.jl.
 * Many utily functions and the `DataLoader` are [now provided by MLUtils.jl](https://github.com/FluxML/Flux.jl/pull/1874).
 * The DataLoader is now compatible with generic dataset types implementing `MLUtils.numobs` and `MLUtils.getobs`.
 * Added [truncated normal initialisation](https://github.com/FluxML/Flux.jl/pull/1877) of weights.
+* The `Flux.Diagonal` layer is now called `Scale`, and accepts an activation function.
 
 ## v0.12.10
 * `Dropout`/`AlphaDropout` now supports [user-specified RNGs](https://github.com/FluxML/Flux.jl/pull/1838)

--- a/docs/src/models/layers.md
+++ b/docs/src/models/layers.md
@@ -56,7 +56,7 @@ Maxout
 SkipConnection
 Parallel
 Flux.Bilinear
-Flux.Diagonal
+Flux.Scale
 Flux.Embedding
 ```
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -39,6 +39,15 @@ function Optimise.update!(x::AbstractArray, x̄)
   x .-= x̄
 end
 
+function Diagonal(size::Integer...; kw...)
+  Base.depwarn("Flux.Diagonal is now Flux.Scale, and also allows an activation function.", :Diagonal)
+  Scale(size...; kw...)
+end
+function Diagonal(size::Tuple; kw...)
+  Base.depwarn("Flux.Diagonal is now Flux.Scale, and also allows an activation function.", :Diagonal)
+  Scale(size...; kw...)
+end
+
 # Channel notation: Changed to match Conv, but very softly deprecated!
 # Perhaps change to @deprecate for v0.14, but there is no plan to remove these.
 Dense(in::Integer, out::Integer, σ = identity; kw...) =

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -211,17 +211,17 @@ julia> Flux.params(b)
 Params([[1 2 3 4]])
 ```
 """
-struct Scale{F<:Function, A<:AbstractArray, B}
+struct Scale{F, A<:AbstractArray, B}
   scale::A
   bias::B
   σ::F
-  function Scale(scale::A, bias = true, σ::F = identity) where {A<:AbstractArray, F<:Function}
+  function Scale(scale::A, bias::B = true, σ::F = identity) where {A<:AbstractArray, B<:Union{Bool, AbstractArray}, F}
     b = create_bias(scale, bias, size(scale)...)
     new{F, A, typeof(b)}(scale, b, σ)
   end
 end
 
-Scale(size::Integer...; bias = true, init = ones32, _act = identity) = Scale(init(size...), bias, _act)
+Scale(s1::Integer, s23::Integer...; bias = true, init = ones32, _act = identity) = Scale(init(s1, s23...), bias, _act)
 Scale(size_act...; bias = true, init = ones32) = Scale(size_act[1:end-1]...; bias, init, _act = size_act[end])
 
 @functor Scale

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -189,7 +189,7 @@ Used by [`LayerNorm`](@ref) with `affine=true`.
 # Examples
 ```jldoctest
 julia> a = Flux.Scale(2)
-Scale(2)      # 4 parameters
+Scale(2)            # 4 parameters
 
 julia> Flux.params(a)
 Params([Float32[1.0, 1.0], Float32[0.0, 0.0]])

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -55,7 +55,7 @@ _show_children(m::Maxout) = m.layers
 _show_children(p::Parallel) = (p.connection, p.layers...)
 
 for T in [
-    :Conv, :ConvTranspose, :CrossCor, :Dense, :Bilinear, :Embedding,
+    :Conv, :ConvTranspose, :CrossCor, :Dense, :Scale, :Bilinear, :Embedding,
     :BatchNorm, :LayerNorm, :InstanceNorm, :GroupNorm,
   ]
   @eval function Base.show(io::IO, m::MIME"text/plain", x::$T)

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -105,6 +105,11 @@ import Flux: activations
     @test Flux.Scale(2, 3, 4; bias = false)(rand(2, 3, 4)) |> size == (2, 3, 4)
     @test Flux.Scale(2, 3; bias = false)(rand(2, 1, 4)) |> size == (2, 3, 4)
     @test Flux.Scale(2, 3, tanh; bias = false, init = zeros)(rand(2, 1, 4)) == zeros(2, 3, 4)
+    
+    @test_throws MethodError Flux.Scale(1.)
+    @test_throws MethodError Flux.Scale(1., 2.)
+    @test_throws Exception Flux.Scale()
+    @test_throws MethodError Flux.Scale(sin)
   end
 
   @testset "Maxout" begin

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -87,20 +87,24 @@ import Flux: activations
     end
   end
 
-  @testset "Diagonal" begin
-    @test length(Flux.Diagonal(10)(randn(10))) == 10
-    @test length(Flux.Diagonal(10)(randn(1))) == 10
-    @test length(Flux.Diagonal(10; bias = false)(randn(10))) == 10
-    @test_throws DimensionMismatch Flux.Diagonal(10)(randn(2))
+  @testset "Scale" begin
+    @test length(Flux.Scale(10)(randn(10))) == 10
+    @test length(Flux.Scale(10)(randn(1))) == 10
+    @test length(Flux.Scale(10; bias = false)(randn(10))) == 10
+    @test length(Flux.Scale(10, tanh)(randn(10))) == 10
+    @test_throws DimensionMismatch Flux.Scale(10)(randn(2))
 
-    @test Flux.Diagonal(2)([1 2]) == [1 2; 1 2]
-    @test Flux.Diagonal(2)([1, 2]) == [1, 2]
-    @test Flux.Diagonal(2; bias = false)([1 2; 3 4]) == [1 2; 3 4]
+    @test Flux.Scale(2)([1 2]) == [1 2; 1 2]
+    @test Flux.Scale(2)([1, 2]) == [1, 2]
+    @test Flux.Scale(2; init = randn)([1, 2]) != [1, 2]
+    @test Flux.Scale(2; bias = false)([1 2; 3 4]) == [1 2; 3 4]
+    @test Flux.Scale(2, abs2; bias = false, init = ones)([1 2; 3 4]) == [1 4; 9 16]
 
-    @test Flux.Diagonal(2)(rand(2, 3, 4)) |> size == (2, 3, 4)
-    @test Flux.Diagonal(2, 3;)(rand(2, 3, 4)) |> size == (2, 3, 4)
-    @test Flux.Diagonal(2, 3, 4; bias = false)(rand(2, 3, 4)) |> size == (2, 3, 4)
-    @test Flux.Diagonal(2, 3; bias = false)(rand(2, 1, 4)) |> size == (2, 3, 4)
+    @test Flux.Scale(2)(rand(2, 3, 4)) |> size == (2, 3, 4)
+    @test Flux.Scale(2, 3;)(rand(2, 3, 4)) |> size == (2, 3, 4)
+    @test Flux.Scale(2, 3, 4; bias = false)(rand(2, 3, 4)) |> size == (2, 3, 4)
+    @test Flux.Scale(2, 3; bias = false)(rand(2, 1, 4)) |> size == (2, 3, 4)
+    @test Flux.Scale(2, 3, tanh; bias = false, init = zeros)(rand(2, 1, 4)) == zeros(2, 3, 4)
   end
 
   @testset "Maxout" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -457,7 +457,7 @@ end
                                   +),
                                 LayerNorm(8)))
   @test length(mod_skip) == 6
-  @test mod_skip[end] isa Flux.Diagonal
+  @test mod_skip[end] isa Flux.Scale
 end
 
 @testset "Patience triggers" begin


### PR DESCRIPTION
This avoids the awkward collision with LinearAlgebra.Dense. 

It also changes it to be written `Scale(2,3,tanh)` without making a tuple of the sizes, and similarly allows `LayerNorm(2,3,tanh)`.

Builds on #1925