### PR TITLE
Add a macro to opt-in to fancy printing, and to everything else

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 See also [github's page](https://github.com/FluxML/Flux.jl/releases) for a complete list of PRs merged before each release.
 
+## v0.14.13
+* New macro `Flux.@layer` which should be used in place of `@functor`.
+  This also adds `show` methods for pretty printing.
+
 ## v0.14.0 (July 2023)
 * Flux now requires julia v1.9 or later.
 * CUDA.jl is not a hard dependency anymore. Support is now provided through the extension mechanism, by loading `using Flux, CUDA`.
@@ -51,6 +55,7 @@ See also [github's page](https://github.com/FluxML/Flux.jl/releases) for a compl
 
 ## v0.13.6
 * Use the package [OneHotArrays.jl](https://github.com/FluxML/OneHotArrays.jl) instead of having the same code here.
+* Added [`@autosize` macro](https://github.com/FluxML/Flux.jl/pull/2078)
 
 ## v0.13.4
 * Added [`PairwiseFusion` layer](https://github.com/FluxML/Flux.jl/pull/1983)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@ See also [github's page](https://github.com/FluxML/Flux.jl/releases) for a compl
 * New macro `Flux.@layer` which should be used in place of `@functor`.
   This also adds `show` methods for pretty printing.
 
+## v0.14.12
+* New `SignDecay` optimiser, like `` WeightNorm` but for L1 norm.
+
 ## v0.14.0 (July 2023)
 * Flux now requires julia v1.9 or later.
 * CUDA.jl is not a hard dependency anymore. Support is now provided through the extension mechanism, by loading `using Flux, CUDA`.

--- a/docs/src/models/advanced.md
+++ b/docs/src/models/advanced.md
@@ -73,14 +73,7 @@ The exact same method of `trainable` can also be defined using the macro, for co
 Flux.@layer Affine trainable=(W,)
 ```
 
-There is a second, more severe, kind of restriction possible:
-
-```
-Flux.@layer Affine children=(W,)
-```
-
-This is equivalent to `Functors.@functor Affine (W,)`. It means that all no exploration of the model will ever visit the other fields: They will not be moved to the GPU by [`gpu`](@ref), and their precision will not be changed by `f32`. This is not usually recommended.
- This is generally not recommended. It requires the `struct` to have a corresponding constructor that accepts only `W` as an argument.
+There is a second, more severe, kind of restriction possible. This is not recommended, but is included here for completeness. Calling `Functors.@functor Affine (W,)` means that all no exploration of the model will ever visit the other fields: They will not be moved to the GPU by [`gpu`](@ref), and their precision will not be changed by `f32`. This requires the `struct` to have a corresponding constructor that accepts only `W` as an argument.
 
 
 ## Freezing Layer Parameters

--- a/docs/src/models/basics.md
+++ b/docs/src/models/basics.md
@@ -257,8 +257,8 @@ m(5) # => 26
 
 There is still one problem with this `Affine` layer, that Flux does not know to look inside it. This means that [`Flux.train!`](@ref) won't see its parameters, nor will [`gpu`](@ref) be able to move them to your GPU. These features are enabled by the [`@functor`](@ref Functors.@functor) macro:
 
-```
-Flux.@functor Affine
+```julia
+Flux.@layer Affine
 ```
 
 Finally, most Flux layers make bias optional, and allow you to supply the function used for generating random weights. We can easily add these refinements to the `Affine` layer as follows, using the helper function [`create_bias`](@ref Flux.create_bias):
@@ -271,4 +271,9 @@ function Affine((in, out)::Pair; bias=true, init=Flux.randn32)
 end
 
 Affine(3 => 1, bias=false, init=ones) |> gpu
+```
+
+```@docs
+Flux.@layer
+Flux.create_bias
 ```

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -9,6 +9,7 @@ using MacroTools: @forward
 
 @reexport using NNlib
 using MLUtils
+const stack = MLUtils.stack  # now exported by Base
 import Optimisers: Optimisers, trainable, destructure  # before v0.13, Flux owned these functions
 using Optimisers: freeze!, thaw!, adjust!
 using Random: default_rng
@@ -69,6 +70,9 @@ include("functor.jl")
 # Pirate error to catch a common mistake.
 Functors.functor(::Type{<:MLUtils.DataLoader}, x) = error("`DataLoader` does not support Functors.jl, thus functions like `Flux.gpu` will not act on its contents.")
 
+include("layers/show.jl")
+include("layers/macro.jl")
+
 include("layers/stateless.jl")
 include("layers/basic.jl")
 include("layers/conv.jl")
@@ -76,7 +80,6 @@ include("layers/recurrent.jl")
 include("layers/normalise.jl")
 include("layers/upsample.jl")
 include("layers/attention.jl")
-include("layers/show.jl")
 
 include("loading.jl")
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -81,6 +81,7 @@ function params!(p::Params, x, seen = IdSet())
   elseif x in seen
     nothing
   else
+    _check_new_macro(x)  # complains if you used @functor not @layer
     push!(seen, x)
     for child in trainable(x)
       params!(p, child, seen)

--- a/src/layers/attention.jl
+++ b/src/layers/attention.jl
@@ -83,8 +83,8 @@ function MultiHeadAttention(dims;
                      dropout_prob = 0.0)
 
   dims = normalize_mha_dims(dims)
-  dims.qk % nheads == 0 || throw(ArgumentError("qk_dim = $(dims.qk) should be divisible by nheads = $(nheads)")
-  dims.v % nheads == 0 || throw(ArgumentError( "v_dim = $(dims.v) should be divisible by nheads = $(nheads)")
+  dims.qk % nheads == 0 || throw(ArgumentError("qk_dim = $(dims.qk) should be divisible by nheads = $(nheads)"))
+  dims.v % nheads == 0 || throw(ArgumentError( "v_dim = $(dims.v) should be divisible by nheads = $(nheads)"))
   q_proj = Dense(dims.q_in => dims.qk; bias, init)
   k_proj = Dense(dims.k_in => dims.qk; bias, init)
   v_proj = Dense(dims.v_in => dims.v; bias, init)
@@ -149,7 +149,7 @@ function Base.show(io::IO, mha::MultiHeadAttention)
     print(io, "(", q_in, ", ", k_in, ", ", v_in, ") => (", qk, ", ", v,") => ", out)
   end
   print(io, "; nheads=", mha.nheads)
-  if mha.q_proj.bias === true
+  if mha.q_proj.bias !== false
     print(io, ", bias=true")
   end
   if mha.attn_drop.p != 0
@@ -158,11 +158,10 @@ function Base.show(io::IO, mha::MultiHeadAttention)
   print(io, ")")
 end
 
-Base.show(io::IO, ::MIME"text/plain", mha::MultiHeadAttention) = show(io, mha)
 
 #=
 
-# Test cases:
+# Test cases for printing:
 
 MultiHeadAttention((3, 4, 5) => (6, 7) => 8; nheads=1)
 MultiHeadAttention(3 => (6, 7) => 8; nheads=1)

--- a/src/layers/attention.jl
+++ b/src/layers/attention.jl
@@ -74,7 +74,7 @@ struct MultiHeadAttention{P1, D, P2}
   out_proj::P2
 end
 
-@functor MultiHeadAttention
+@layer MultiHeadAttention
 
 function MultiHeadAttention(dims; 
                      nheads::Int = 8,
@@ -83,8 +83,8 @@ function MultiHeadAttention(dims;
                      dropout_prob = 0.0)
 
   dims = normalize_mha_dims(dims)
-  @assert dims.qk % nheads == 0 "qk_dim should be divisible by nheads"
-  @assert dims.v % nheads == 0 "v_dim should be divisible by nheads"
+  dims.qk % nheads == 0 || throw(ArgumentError("qk_dim = $(dims.qk) should be divisible by nheads = $(nheads)")
+  dims.v % nheads == 0 || throw(ArgumentError( "v_dim = $(dims.v) should be divisible by nheads = $(nheads)")
   q_proj = Dense(dims.q_in => dims.qk; bias, init)
   k_proj = Dense(dims.k_in => dims.qk; bias, init)
   v_proj = Dense(dims.v_in => dims.v; bias, init)
@@ -131,3 +131,42 @@ function (mha::MultiHeadAttention)(q_in::A3, k_in::A3, v_in::A3,
   # [α] = [kv_len, q_len, nheads, batch_size]
   return x, α
 end
+
+function Base.show(io::IO, mha::MultiHeadAttention)
+  qk, q_in = size(mha.q_proj.weight)
+  qk, k_in = size(mha.k_proj.weight)
+  v, v_in = size(mha.v_proj.weight)
+  out, v = size(mha.out_proj.weight)
+  # @show q_in, k_in, v_in, qk, v, out
+  print(io, "MultiHeadAttention(")
+  if q_in == k_in == v_in == qk == v == out
+    print(io, q_in)
+  elseif q_in == k_in == v_in && qk == v
+    print(io, q_in, " => ", qk, " => ", out)
+  elseif q_in == k_in == v_in
+    print(io, q_in, " => (", qk, ", ", v,") => ", out)
+  else
+    print(io, "(", q_in, ", ", k_in, ", ", v_in, ") => (", qk, ", ", v,") => ", out)
+  end
+  print(io, "; nheads=", mha.nheads)
+  if mha.q_proj.bias === true
+    print(io, ", bias=true")
+  end
+  if mha.attn_drop.p != 0
+    print(io, ", dropout_prob=", mha.attn_drop.p)  # can't we rename this?
+  end
+  print(io, ")")
+end
+
+Base.show(io::IO, ::MIME"text/plain", mha::MultiHeadAttention) = show(io, mha)
+
+#=
+
+# Test cases:
+
+MultiHeadAttention((3, 4, 5) => (6, 7) => 8; nheads=1)
+MultiHeadAttention(3 => (6, 7) => 8; nheads=1)
+MultiHeadAttention(3 => 6 => 8; nheads=1)
+MultiHeadAttention(8; bias=true)
+
+=#

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -187,7 +187,7 @@ function convfilter(filter::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer};
   init(filter..., cin÷groups, cout)
 end
 
-@functor Conv
+@layer Conv
 
 conv_dims(c::Conv, x::AbstractArray) =
   DenseConvDims(x, c.weight; stride = c.stride, padding = c.pad, dilation = c.dilation, groups = c.groups)
@@ -309,7 +309,7 @@ function ConvTranspose(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ =
   ConvTranspose(weight, bias, σ; stride, pad, dilation, groups)
 end
 
-@functor ConvTranspose
+@layer ConvTranspose
 
 function conv_transpose_dims(c::ConvTranspose, x::AbstractArray)
   # Calculate size of "input", from ∇conv_data()'s perspective...
@@ -460,7 +460,7 @@ function CrossCor(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = iden
   return CrossCor(weight, bias, σ; stride, pad, dilation)
 end
 
-@functor CrossCor
+@layer CrossCor
 
 function crosscor(x, w, ddims::DenseConvDims)
   ddims = DenseConvDims(ddims, F=true)

--- a/src/layers/macro.jl
+++ b/src/layers/macro.jl
@@ -131,18 +131,20 @@ function _default_functor(::Type{T}, x) where {T}
      F = fieldnames(T)
      args = map(sy -> :(getfield(x, $(QuoteNode(sy)))), F)
      C = Base.typename(T).wrapper  # constructor
-     recon = VERSION > v"1.9-" ? :(Splat($C)) : :(Base.splat($C))
+     # recon = VERSION > v"1.9-" ? :(Splat($C)) : :(Base.splat($C))
+     recon = :(Base.splat($C))
      :((NamedTuple{$F}(($(args...),)), $recon))
    else
      # Getting this parameterless type takes about 2μs, every time:
-     spl = VERSION > v"1.9-" ? Splat : Base.splat
+     # spl = VERSION > v"1.9-" ? Splat : Base.splat
+     spl = Base.splat
      namedtuple(x), spl(Base.typename(T).wrapper)
    end
 end
 
 function _custom_functor(::Type{T}, x, ::Val{which}) where {T,which}
    if false
-     # TODO write the @generated version
+     # TODO write the @generated version. Or decide we don't care, or should forbid this?
    else
      remake(nt) = Base.typename(T).wrapper(map(f -> f in which ? getfield(nt, f) : getfield(x, f), fieldnames(T))...)
      NamedTuple{which}(map(s -> getfield(x, s), which)), remake

--- a/src/layers/macro.jl
+++ b/src/layers/macro.jl
@@ -1,0 +1,173 @@
+
+"""
+    @layer Dense
+    @layer :expand Chain
+    @layer BatchNorm trainable=(β,γ)
+    @layer Struct children=(α,β) trainable=(β,)
+
+This macro replaces most uses of `@functor`. Its basic purpose is the same:
+When you define a new layer, this tells Flux to explore inside it
+to see the parameters it trains, and also to move them to the GPU, change precision, etc.
+Like `@functor`, this assumes your struct has the default constructor, to enable re-building.
+
+Some keywords allow you to limit this exploration, instead of visiting all `fieldnames(T)`.
+Note that it is never necessary to tell Flux to ignore non-array objects such as functions or sizes.
+* If some fields look like parameters but should not be trained,
+  then `trainable` lets you specify which fields to include, while the rest are ignored.
+* You can likewise add restrictions to Functors's `children` (although this is seldom a good idea),
+  equivalent to `@functor Struct (α,β)`. Any `trainable` limitation must then be a subset of `children`.
+
+The macro also handles overloads of `show` for pretty printing.
+* By default, it adds methods to 3-arg `Base.show` to treat your layer much like `Dense` or `Conv`.
+* If your layer is a container, more like `Chain` or `Parallel`, then `:expand` makes `show` unfold its contents.
+* To disable all `show` overloads, there is an `:ignore` option too.
+
+(You probably still want to define 2-arg `show(io::IO, x::Layer)`, the macro does not touch this.)
+
+Note that re-running the macro with different options may not overwrite all methods, you will need to restart.
+
+# Example
+```jldoctest
+julia> struct Trio; a; b; c end
+
+julia> tri = Trio(Dense([1.1 2.2], [0.0], tanh), Dense(hcat(3.3), false), Dropout(0.4))
+Trio(Dense(2 => 1, tanh), Dense(1 => 1; bias=false), Dropout(0.4))
+
+julia> Flux.destructure(tri)  # parameters are not yet visible to Flux
+(Bool[], Restructure(Trio, ..., 0))
+
+julia> Flux.@layer :expand Trio
+
+julia> Flux.destructure(tri)  # now gpu, params, train!, etc will see inside too
+([1.1, 2.2, 0.0, 3.3], Restructure(Trio, ..., 4))
+
+julia> tri  # and layer is printed like Chain
+Trio(
+  Dense(2 => 1, tanh),                  # 3 parameters
+  Dense(1 => 1; bias=false),            # 1 parameters
+  Dropout(0.4),
+)                   # Total: 3 arrays, 4 parameters, 224 bytes.
+```
+
+"""
+macro layer(exs...)
+  out = quote end
+
+  # These functions are defined in show.jl, and each return an expression overloading Base.show
+  type, rest... = if exs[1] == QuoteNode(:expand)
+    push!(out.args, _macro_big_show(esc(exs[2])))  
+    exs[2:end]
+  elseif exs[1] == QuoteNode(:ignore)
+    exs[2:end]
+  elseif exs[1] isa QuoteNode
+    error("`@layer` accepts only two options before the layer type, `:expand` and `:ignore` (to control `show`)")
+  else
+    push!(out.args, _macro_layer_show(esc(exs[1])))
+    exs
+  end
+
+  # This function exists only for depwarns when you use @functor directly
+  push!(out.args, :(Flux._check_new_macro(::$(esc(type))) = nothing))
+  
+  i = findfirst(ex -> Meta.isexpr(ex, :(=)) && ex.args[1] == :children, rest)
+  if isnothing(i)  # then default like @functor Layer
+    push!(out.args, _macro_functor(esc(type)))
+  else
+    push!(out.args, _macro_functor(esc(type), rest[i].args[2]))
+  end
+  for j in 1:length(rest)
+    j == i && continue
+    ex = rest[j]
+    Meta.isexpr(ex, :(=)) || error("The macro `@layer` expects here `keyword = (fields...,)`, got $ex")
+
+    name = if ex.args[1] == :trainable
+      :(Optimisers.trainable)
+    elseif ex.args[1] == :functor
+      error("Can't use `functor=(...)` as a keyword to `@layer`. Use `childen=(...)` to define a method for `functor`.")
+    else
+      error("`@layer` cannot define a method for `$(ex.args[1])` at the moment, sorry.")
+      # @warn "Trying to define a method for `$(ex.args[1])` in your scope... this is experimental" maxlog=1
+      # esc(ex.args[1])
+    end
+    push!(out.args, _macro_trainable(esc(type), name, ex.args[2]))
+  end
+
+  out
+end
+
+# Temporary depwarn function, called within `params`, is also called by `show`.
+
+function _check_new_macro(x::T) where T
+  Functors.isleaf(x) && return
+  Base.depwarn("This type should probably now use `Flux.@layer` instead of `@functor`: $T", Symbol("@functor"))
+end
+_check_new_macro(::Tuple) = nothing  # defined by Functors.jl, not by users
+_check_new_macro(::NamedTuple) = nothing
+_check_new_macro(::AbstractArray) = nothing
+_check_new_macro(::Ref) = nothing
+
+# @layer's code for Functors & Adapt
+# Unlike @functor, _default_functor doesn't need to eval anything
+
+function _macro_functor(type)
+  quote
+    Functors.functor(::Type{T}, x) where {T<:$type} = $_default_functor(T, x)
+    Adapt.adapt_structure(to, layer::$type) = $fmap($adapt(to), layer)
+  end
+end
+
+function _macro_functor(type, fields)
+  Meta.isexpr(fields, :tuple) || error("expected a tuple of field names")
+  symbols = Tuple(map(_noquotenode, fields.args))
+  quote
+    Functors.functor(::Type{T}, x) where {T<:$type} = $_custom_functor(T, x, Val($symbols))
+    Adapt.adapt_structure(to, layer::$type) = $fmap($adapt(to), layer)
+  end
+end
+_macro_functor(type, field::Union{Symbol,QuoteNode}) = _macro_functor(type, :(($field,)))  # lets you forget a comma
+
+function _default_functor(::Type{T}, x) where {T}
+   if @generated
+     F = fieldnames(T)
+     args = map(sy -> :(getfield(x, $(QuoteNode(sy)))), F)
+     C = Base.typename(T).wrapper  # constructor
+     recon = VERSION > v"1.9-" ? :(Splat($C)) : :(Base.splat($C))
+     :((NamedTuple{$F}(($(args...),)), $recon))
+   else
+     # Getting this parameterless type takes about 2μs, every time:
+     spl = VERSION > v"1.9-" ? Splat : Base.splat
+     namedtuple(x), spl(Base.typename(T).wrapper)
+   end
+end
+
+function _custom_functor(::Type{T}, x, ::Val{which}) where {T,which}
+   if false
+     # TODO write the @generated version
+   else
+     remake(nt) = Base.typename(T).wrapper(map(f -> f in which ? getfield(nt, f) : getfield(x, f), fieldnames(T))...)
+     NamedTuple{which}(map(s -> getfield(x, s), which)), remake
+   end
+end
+ 
+function namedtuple(x::T) where T
+  F = fieldnames(T)
+  NamedTuple{F}(map(sy -> getfield(x, sy), F))
+end
+
+# @layer's code for Optimisers.trainable, and perhaps anything else,
+# with the pattern that keywords mean function names & what fields they pick.
+
+function _macro_trainable(type, fun, fields)
+  Meta.isexpr(fields, :tuple) || error("expected a tuple of field names")
+  symbols = Tuple(map(_noquotenode, fields.args))
+  quoted = map(QuoteNode, symbols)
+  gets = [:(getfield(x, $f)) for f in quoted]
+  quote
+    $fun(x::$type) = NamedTuple{$symbols}(($(gets...),))
+  end
+end
+_macro_trainable(type, fun, field::Union{Symbol,QuoteNode}) = _macro_trainable(type, fun, :(($field,)))  # lets you forget a comma
+
+_noquotenode(s::Symbol) = s
+_noquotenode(q::QuoteNode) = q.value  # lets you write trainable=(:x,:y) instead of (x,y)
+_noquotenode(ex) = error("expected a symbol here, as a field name, but got $ex")

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -135,8 +135,7 @@ function (m::Recur)(x)
   return y
 end
 
-@functor Recur
-trainable(a::Recur) = (; cell = a.cell)
+@layer :expand Recur trainable=(cell,)
 
 Base.show(io::IO, m::Recur) = print(io, "Recur(", m.cell, ")")
 
@@ -209,7 +208,7 @@ function (m::RNNCell{F,I,H,V,<:AbstractMatrix{T}})(h, x::AbstractVecOrMat) where
   return h, reshape_cell_output(h, x)
 end
 
-@functor RNNCell
+@layer RNNCell  # state0 is trainable, see issue 807 about this.
 
 function Base.show(io::IO, l::RNNCell)
   print(io, "RNNCell(", size(l.Wi, 2), " => ", size(l.Wi, 1))
@@ -318,7 +317,7 @@ function (m::LSTMCell{I,H,V,<:NTuple{2,AbstractMatrix{T}}})((h, c), x::AbstractV
   return (h′, c′), reshape_cell_output(h′, x)
 end
 
-@functor LSTMCell
+@layer LSTMCell
 
 Base.show(io::IO, l::LSTMCell) =
   print(io, "LSTMCell(", size(l.Wi, 2), " => ", size(l.Wi, 1)÷4, ")")
@@ -391,7 +390,7 @@ function (m::GRUCell{I,H,V,<:AbstractMatrix{T}})(h, x::AbstractVecOrMat) where {
   return h′, reshape_cell_output(h′, x)
 end
 
-@functor GRUCell
+@layer GRUCell
 
 Base.show(io::IO, l::GRUCell) =
   print(io, "GRUCell(", size(l.Wi, 2), " => ", size(l.Wi, 1)÷3, ")")
@@ -461,7 +460,7 @@ function (m::GRUv3Cell{I,H,V,HH,<:AbstractMatrix{T}})(h, x::AbstractVecOrMat) wh
   return h′, reshape_cell_output(h′, x)
 end
 
-@functor GRUv3Cell
+@layer GRUv3Cell
 
 Base.show(io::IO, l::GRUv3Cell) =
   print(io, "GRUv3Cell(", size(l.Wi, 2), " => ", size(l.Wi, 1)÷3, ")")

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -58,7 +58,6 @@ _show_leaflike(x) = isleaf(x)  # mostly follow Functors, except for:
 _show_leaflike(::Tuple{Vararg{Number}}) = true         # e.g. stride of Conv
 _show_leaflike(::Tuple{Vararg{AbstractArray}}) = true  # e.g. parameters of LSTMcell
 _show_leaflike(::AbstractArray{<:Number}) = true         # e.g. transposed arrays
-_show_leaflike(::Scale) = true                           # appears inside LayerNorm
 
 _show_children(x) = trainable(x)
 # This used to have methods for Chain, Maxout, Parallel, PairwiseFusion. Now @layer instead

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -1,63 +1,30 @@
-"""
-    @big_show MyContainer
+@nospecialize  # just for this file, for startup time
 
-This macro lets you opt-in to Flux's fancy printing.
-
-When `model::MyContainer` is returned at the REPL it will be treated like `Chain`,
-and the printing routine will recursively unfold its children.
-This is triggered by adding a method to 3-arg `Base.show(io::IO, ::MIME"text/plain", l::MyContainer)`.
-
-Custom layers which do not contain other layers (more like `Dense` than like `Chain`)
-need not call this, and should simply define 2-arg `Base.show(io::IO, l::MyLayer)`.
-
-# Example
-```jldoctest
-julia> struct Trio{A,B,C}; a::A; b::B; c::C end
-
-julia> Flux.@functor Trio
-
-julia> Flux.@big_show Trio
-
-julia> tri = Trio(Dense(10=>5,tanh), Dense(5=>2), softmax)
-Trio(
-  Dense(10 => 5, tanh),                 # 55 parameters
-  Dense(5 => 2),                        # 12 parameters
-  NNlib.softmax,
-)                   # Total: 4 arrays, 67 parameters, 492 bytes.
-```
-
-Note that there is no automatic method for 2-arg `show`, and thus
-something like `(tri, tri)` will print all the type parameters. 
-
-However, `Chain(tri, tri)` will always use Flux's recursive printing,
-even without using this macro: `Chain` is the entry point.
-"""
-macro big_show(ex)
-    ex isa Symbol || error("usage is `Flux.@big_show Chain`")
-    eex = esc(ex)
-    quote
-        function Base.show(io::IO, m::MIME"text/plain", x::$eex)
-            if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL
-              _big_show(io, x)
-            elseif !get(io, :compact, false)  # e.g. printed inside a Vector, but not a Matrix
-              _layer_show(io, x)
-            else
-              show(io, x)
-            end
-        end
+# This is called by @layer :expand, on layers which should be treated like Chain, and returns an expression:
+function _macro_big_show(ex)
+  quote
+    # Entry point:
+    function Base.show(io::IO, m::MIME"text/plain", x::$ex)
+      if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL
+        _big_show(io, x)
+      elseif !get(io, :compact, false)  # e.g. printed inside a Vector, but not a Matrix
+        _layer_show(io, x)
+      else
+        show(io, x)
+      end
     end
-end
 
-@big_show Chain
-@big_show Parallel
-@big_show SkipConnection
-@big_show Recur
-@big_show Maxout
+    # Don't show Chain(Tuple(...)), always splat that. And ignore Recur's non-trainable state:
+    Flux._show_children(x::$ex) = _flat_children(trainable(x))
+  end
+end
 
 function _big_show(io::IO, obj, indent::Int=0, name=nothing)
   pre, post = obj isa Chain{<:AbstractVector} ? ("([", "])") : ("(", ")")
   children = _show_children(obj)
   if all(_show_leaflike, children)
+    # This check may not be useful anymore: it tries to infer when to stop the recursion by looking for grandkids,
+    # but once all layers use @layer, they stop the recursion by defining a method for _big_show.
     _layer_show(io, obj, indent, name)
   else
     println(io, " "^indent, isnothing(name) ? "" : "$name = ", nameof(typeof(obj)), pre)
@@ -90,25 +57,33 @@ _show_leaflike(x) = isleaf(x)  # mostly follow Functors, except for:
 # note the covariance of tuple, using <:T causes warning or error
 _show_leaflike(::Tuple{Vararg{Number}}) = true         # e.g. stride of Conv
 _show_leaflike(::Tuple{Vararg{AbstractArray}}) = true  # e.g. parameters of LSTMcell
-_show_leaflike(::Scale) = true                           # appears inside LayerNorm
 _show_leaflike(::AbstractArray{<:Number}) = true         # e.g. transposed arrays
+_show_leaflike(::Scale) = true                           # appears inside LayerNorm
 
-_show_children(x) = trainable(x)  # except for layers which hide their Tuple:
-_show_children(c::Chain) = c.layers
-_show_children(m::Maxout) = m.layers
-_show_children(p::Parallel) = (p.connection, p.layers...)
-_show_children(f::PairwiseFusion) = (f.connection, f.layers...)
+_show_children(x) = trainable(x)
+# This used to have methods for Chain, Maxout, Parallel, PairwiseFusion. Now @layer instead
+# writes a method to use this function. It flattens the Tuple within Chain etc.
+# (The remaining special cases are for printing of layer names when a NamedTuple, above.)
+function _flat_children(x)
+    alpha = map(f -> getfield(x, f), fieldnames(typeof(x)))
+    beta = map(y -> y isa Union{Tuple, NamedTuple} ? y : (y,), alpha)
+    gamma = ((beta...)...,)
+end
 
-for T in [
-    :Conv, :ConvTranspose, :CrossCor, :Dense, :Scale, :Bilinear, :Embedding, :EmbeddingBag,
-    :BatchNorm, :LayerNorm, :InstanceNorm, :GroupNorm,
-  ]
-  @eval function Base.show(io::IO, m::MIME"text/plain", x::$T)
-    if !get(io, :compact, false)
-      _layer_show(io, x)
-    else
-      show(io, x)
+# This is called by @layer, on layers which should be treated like Dense, and returns an expression:
+function _macro_layer_show(ex)
+  quote
+    # Entry point:
+    function Base.show(io::IO, m::MIME"text/plain", x::$ex)
+      if !get(io, :compact, false)
+        _layer_show(io, x)
+      else
+        show(io, x)
+      end
     end
+
+    # Exit from _big_show recursion:
+    Flux._big_show(io::IO, obj::$ex, indent::Int=0, name=nothing) = _layer_show(io, obj, indent, name)
   end
 end
 
@@ -166,6 +141,8 @@ function _nan_show(io::IO, x)
     printstyled(io, "  (some Inf)", color=:red)
   end
 end
+
+@specialize  # un-does @nospecialze at the top of this file
 
 _any(f, xs::AbstractArray{<:Number}) = any(f, xs)
 # _any(f, xs::Union{Tuple,NamedTuple,Zygote.Params}) = any(x -> _any(f, x), xs)

--- a/test/layers/macro.jl
+++ b/test/layers/macro.jl
@@ -33,13 +33,15 @@ end
   
   m23 = MacroTest.TwoThirds([1 2], [3 4], [5 6])
   # Check that we can use the macro with a qualified type name, outside the defining module:
-  Flux.@layer :expand MacroTest.TwoThirds children=(:a,:c) trainable=(:a)  # documented as (a,c) but allow quotes
+  Flux.@layer :expand MacroTest.TwoThirds trainable=(:a)  # documented as (a,c) but allow quotes
 
-  @test Functors.children(m23) == (a = [1 2], c = [5 6])
-  m23re = Functors.functor(m23)[2]((a = [10 20], c = [50 60]))
+  m23re = Functors.functor(m23)[2]((a = [10 20], b = [3 4], c = [50 60]))
   @test m23re isa MacroTest.TwoThirds
   @test Flux.namedtuple(m23re) == (a = [10 20], b = [3 4], c = [50 60])
 
   @test Optimisers.trainable(m23) == (a = [1 2],)
+
+  @test_throws LoadError @eval Flux.@layer :zzz MacroTest.TwoThirds
+  @test_throws LoadError @eval Flux.@layer MacroTest.TwoThirds chidren=(a, b)
 end
 

--- a/test/layers/macro.jl
+++ b/test/layers/macro.jl
@@ -1,0 +1,45 @@
+using Flux, Functors, Optimisers
+
+module MacroTest
+  using Flux: @layer
+
+  struct Duo{T,S}; x::T; y::S; end
+  @layer :expand Duo
+
+  struct Trio; a; b; c end
+  # @layer Trio trainable=(a,b) test=(c) # should be (c,) but it lets you forget
+  @layer Trio trainable=(a,b)  # defining a method for test is made an error, for now
+
+  struct TwoThirds; a; b; c; end
+end
+
+@testset "@layer macro" begin
+  @test !isdefined(MacroTest, :Flux)  # That's why the module, to check scope
+
+  m2 = MacroTest.Duo(Dense(2=>2), Chain(Flux.Scale(2), Dropout(0.2)))
+
+  @test Functors.children(m2) isa NamedTuple{(:x, :y)}
+  @test length(Optimisers.destructure(m2)[1]) == 10
+
+  m3 = MacroTest.Trio([1.0], [2.0], [3.0])
+
+  @test Functors.children(m3) isa NamedTuple{(:a, :b, :c)}
+  @test fmap(zero, m3) isa MacroTest.Trio
+
+  @test Optimisers.trainable(m3) isa NamedTuple{(:a, :b)}
+  @test Optimisers.destructure(m3)[1] == [1, 2]
+
+  # @test MacroTest.test(m3) == (c = [3.0],)  # removed, for now
+  
+  m23 = MacroTest.TwoThirds([1 2], [3 4], [5 6])
+  # Check that we can use the macro with a qualified type name, outside the defining module:
+  Flux.@layer :expand MacroTest.TwoThirds children=(:a,:c) trainable=(:a)  # documented as (a,c) but allow quotes
+
+  @test Functors.children(m23) == (a = [1 2], c = [5 6])
+  m23re = Functors.functor(m23)[2]((a = [10 20], c = [50 60]))
+  @test m23re isa MacroTest.TwoThirds
+  @test Flux.namedtuple(m23re) == (a = [10 20], b = [3 4], c = [50 60])
+
+  @test Optimisers.trainable(m23) == (a = [1 2],)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ Random.seed!(0)
       include("layers/conv.jl")
       include("layers/upsample.jl")
       include("layers/show.jl")
+      include("layers/macro.jl")
     end
 
     @testset "outputsize" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -616,7 +616,7 @@ end
         a::A
         b::A
     end
-    Flux.@functor Model
+    Flux.@layer Model
     (m::Model)(x) = m.a(x) .+ m.b(x)
 
     d = Dense(1, 1)


### PR DESCRIPTION
### Originally, `@big_show`

This adds a macro which lets you tell Flux to treat some container type much the same way as it treats `Chain`, starting the recursive printing walk over all children.

Prompted by #1929. Closes #2044

Metalhead also has `show` methods for top-level layers which enable the recursive printing, which could be replaced by this macro:

https://github.com/FluxML/Metalhead.jl/blob/aba6fb832093d88dc2d2b4d5b1d2d63a0f21eb9c/src/Metalhead.jl#L53-L57

https://github.com/FluxML/Metalhead.jl/blob/c8f0a88e4d24274c53b62c2b740822aa6a781709/src/utilities.jl#L49-L52

Searching for other uses on github, I see only two:

https://github.com/avik-pal/ExplicitFluxLayers.jl/blob/8e1cff447afda225bc12144ff27ae1370e8fc3da/src/show_layers.jl

https://github.com/maxfreu/SegmentationModels.jl/blob/7bfdbaa438910baf49543f03f2931de765dbd761/src/unet.jl#L99-L112

### Later, `@layer`

Now aims to also replace `@functor`, in addition to handling `show`.

Discussed at https://github.com/FluxML/Flux.jl/pull/2028 -- a layer supertype is another way to make opting into pretty printing easier. (We wouldn't do both, so this closes https://github.com/FluxML/Flux.jl/pull/2028 .)

### PR Checklist

- [x] Tests are added
- [x] Entry in NEWS.md
- [x] Documentation, if applicable
