### PR TITLE
Get the DocBot up again!

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create PR comment
-        if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && ${{ github.event.label.name == 'documentation' }} # if this is a pull request build AND the pull request is NOT made from a fork
+        if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && github.event.label.name == 'documentation' # if this is a pull request build AND the pull request is NOT made from a fork
         uses: thollander/actions-comment-pull-request@71efef56b184328c7ef1f213577c3a90edaa4aff
         with:
           message: 'Once the build has completed, you can preview any updated documentation at this URL: https://fluxml.ai/Flux.jl/previews/PR${{ github.event.number }}/ in ~20 minutes'


### PR DESCRIPTION
> Didn't we used to have a robot that build documentation previews around here?
>
> _Originally posted by @mcabbott in https://github.com/FluxML/Flux.jl/pull/1910#discussion_r831235563_

Turns out the `if` condition had a mistake in the `.yml` file. Unfortunately, `Documenter.jl` does not build previews on PRs from a fork :(

It is still required to label a PR as "documentation" in order to trigger the bot.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
