### PR TITLE
Broadcasting replaced with comprehension in the Flux.flip function.

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -83,7 +83,7 @@ rnn.state = hidden(rnn.cell)
 reset!(m::Recur) = (m.state = m.cell.state0)
 reset!(m) = foreach(reset!, functor(m)[1])
 
-flip(f, xs) = reverse(f.(reverse(xs)))
+flip(f, xs) = reverse([f(x) for x in reverse(xs)])
 
 function (m::Recur)(x::AbstractArray{T, 3}) where T
   h = [m(x_t) for x_t in eachslice(x, dims=3)]


### PR DESCRIPTION
Based on [this](https://github.com/FluxML/Flux.jl/blob/38e9fa0bd6c07b5f89b7b72a2b7a86c0d7cf0403/src/deprecations.jl#L22) warning the broadcasting operator in function [`Flux.flip`](https://github.com/FluxML/Flux.jl/blob/master/src/layers/recurrent.jl#L86) has been re-written as a comprehension.

This PR is related to issue [#1936](https://github.com/FluxML/Flux.jl/issues/1936).