### PR TITLE
Add a workflow to delete PR previews

### DIFF
--- a/.github/workflows/clean_preview.yml
+++ b/.github/workflows/clean_preview.yml
@@ -1,0 +1,27 @@
+# from https://github.com/CliMA/ClimaTimeSteppers.jl
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - name: Delete preview and history + push changes
+        run: |
+            if [ -d "previews/PR$PRNUM" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "previews/PR$PRNUM"
+              git commit -m "delete preview"
+              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin gh-pages-new:gh-pages
+            fi
+        env:
+            PRNUM: ${{ github.event.number }}


### PR DESCRIPTION
Fixes #1940 

Added a workflow to clean up PR previews from the `gh-pages` branch whenever a PR is closed or merged.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
