### PR TITLE
Add Base.firstindex(c::Chain) = 1

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -68,7 +68,6 @@ end
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i])
 Base.getindex(c::Chain{<:NamedTuple}, i::AbstractArray) =
   Chain(NamedTuple{Base.keys(c)[i]}(Tuple(c.layers)[i]))
-Base.firstindex(c::Chain) = 1
 function Base.show(io::IO, c::Chain)
   print(io, "Chain(")
   _show_layers(io, c.layers)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -44,7 +44,7 @@ function Chain(; kw...)
 end
 
 @forward Chain.layers Base.getindex, Base.length, Base.first, Base.last,
-  Base.iterate, Base.lastindex, Base.keys
+  Base.iterate, Base.lastindex, Base.keys, Base.firstindex
 
 @functor Chain
 
@@ -68,7 +68,7 @@ end
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i])
 Base.getindex(c::Chain{<:NamedTuple}, i::AbstractArray) =
   Chain(NamedTuple{Base.keys(c)[i]}(Tuple(c.layers)[i]))
-
+Base.firstindex(c::Chain) = 1
 function Base.show(io::IO, c::Chain)
   print(io, "Chain(")
   _show_layers(io, c.layers)

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -31,6 +31,10 @@ import Flux: activations
     @test_throws ArgumentError Chain(layers = Dense(10, 10), two = identity) # reserved name
 
     @test_nowarn Chain([Dense(10, 5, σ), Dense(5, 2)])(randn(Float32, 10))  # vector of layers
+    
+    c = Chain(Dense(10, 5, σ), Dense(5, 2), Dense(2, 1, relu))
+    @test c[1] == c[begin]
+    @test c[3] == c[end]
   end
 
   @testset "Activations" begin


### PR DESCRIPTION
I see no reason not to have this, and I ran into missing it, as I have made a habit of indexing with `begin` as opposed to 1.

I am not sure - should this be added to NEWS.md? It seems too minor for it...
- [ ] Entry in NEWS.md
