### PR TITLE
Recur type stability for 3d arrays

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -20,7 +20,7 @@ end
 
 # Type stable and AD-friendly helper for iterating over the last dimension of an array
 function eachlastdim(A::AbstractArray{T,N}) where {T,N}
-  inds_before = ntuple(Returns(:), N-1)
+  inds_before = ntuple(_ -> :, N-1)
   return (view(A, inds_before..., i) for i in axes(A, N))
 end
 

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -29,7 +29,7 @@ function ∇eachlastdim(dys_raw, x::AbstractArray{T1, dim}) where {T1,dim}
   dys = unthunk(dys_raw)
   i1 = findfirst(dy -> dy isa AbstractArray, dys)
   if i1 === nothing  # all slices are Zero!
-      return fill!(similar(x, float(T1), axes(x)), float(T1))
+      return fill!(similar(x, float(T1), axes(x)), zero(T1))
   end
   T = promote_type(eltype(dys[i1]), T1)
   # The whole point of this gradient is that we can allocate one `dx` array:

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -25,17 +25,16 @@ function eachlastdim(A::AbstractArray{T,N}) where {T,N}
 end
 
 # adapted from https://github.com/JuliaDiff/ChainRules.jl/blob/f13e0a45d10bb13f48d6208e9c9d5b4a52b96732/src/rulesets/Base/indexing.jl#L77
-function ∇eachlastdim(dys_raw, x::AbstractArray{T1, dim}) where {T1,dim}
+function ∇eachlastdim(dys_raw, x::AbstractArray{T, N}) where {T, N}
   dys = unthunk(dys_raw)
   i1 = findfirst(dy -> dy isa AbstractArray, dys)
-  if i1 === nothing  # all slices are Zero!
-      return fill!(similar(x, float(T1), axes(x)), zero(T1))
+  if isnothing(i1)  # all slices are Zero!
+      return fill!(similar(x, T, axes(x)), zero(T))
   end
-  T = promote_type(eltype(dys[i1]), T1)
   # The whole point of this gradient is that we can allocate one `dx` array:
-  dx = similar(x, T, axes(x))
-  for i in axes(x, dim)
-      slice = selectdim(dx, dim, i)
+  dx = similar(x, T, axes(x))::AbstractArray
+  for i in axes(x, N)
+      slice = selectdim(dx, N, i)
       if dys[i] isa AbstractZero
           fill!(slice, zero(eltype(slice)))
       else

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -126,6 +126,8 @@ end
     x_size = size(x)
     y = collect(eachslice(x; dims=ndims(x)))
     @test @inferred(Flux.∇eachlastdim(y, x)) == x
+    ZeroTangent = Flux.Zygote.ZeroTangent
+    NoTangent = Flux.Zygote.NoTangent
     abstract_zeros_vector = [ZeroTangent(), ZeroTangent(), NoTangent(), NoTangent()]
     @test @inferred(Flux.∇eachlastdim(abstract_zeros_vector, x)) == zeros(size(x))
     x2 = rand(Float64, x_size[1:end-1])

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -120,3 +120,19 @@ end
   @test dx ≈ cat(fill(1, slicedim), fill(0, slicedim),
               fill(3, slicedim), fill(0, slicedim); dims=ndims(x))
 end
+
+@testset "∇eachlastdim" begin
+    x = rand(3, 3, 1, 2, 4)
+    x_size = size(x)
+    y = collect(eachslice(x; dims=ndims(x)))
+    @test @inferred(Flux.∇eachlastdim(y, x)) == x
+    abstract_zeros_vector = [ZeroTangent(), ZeroTangent(), NoTangent(), NoTangent()]
+    @test @inferred(Flux.∇eachlastdim(abstract_zeros_vector, x)) == zeros(size(x))
+    x2 = rand(Float64, x_size[1:end-1])
+    x3 = rand(Float64, x_size[1:end-1])
+    mixed_vector = [ZeroTangent(), x2, x3, ZeroTangent()]
+    @test @inferred(Flux.∇eachlastdim(mixed_vector, x)) ≈ cat(zeros(x_size[1:end-1]), 
+                                                         x2, 
+                                                         x3, 
+                                                         zeros(x_size[1:end-1]); dims=ndims(x))
+end

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -108,15 +108,15 @@ end
 end
 
 @testset "eachlastdim" begin
-  x = rand(3, 6)
+  x = rand(3, 3, 1, 2, 4)
+  @test length(Flux.eachlastdim(x)) == size(x, ndims(x))
+  @test collect(@inferred(Flux.eachlastdim(x))) == collect(eachslice(x; dims=ndims(x)))
   slicedim = (size(x)[1:end-1]..., 1)
   res, (dx,) = Flux.withgradient(x) do x
-    x1, _, x3, _, x5, x6 = Flux.eachlastdim(x)
-    sum(x1) + sum(x3 .* 3) + sum(x5 * 5) + sum(x6 * 6)
+    x1, _, x3, _ = Flux.eachlastdim(x)
+    sum(x1) + sum(x3 .* 3)
   end
-  @test res ≈ sum(x[:, 1]) + 3sum(x[:, 3]) + 
-              5sum(x[:, 5]) + 6sum(x[:, 6])
-  @test dx ≈ hcat(fill(1, slicedim), fill(0, slicedim),
-              fill(3, slicedim), fill(0, slicedim),
-              fill(5, slicedim), fill(6, slicedim))
+  @test res ≈ sum(selectdim(x, ndims(x), 1)) + 3sum(selectdim(x, ndims(x), 3))
+  @test dx ≈ cat(fill(1, slicedim), fill(0, slicedim),
+              fill(3, slicedim), fill(0, slicedim); dims=ndims(x))
 end

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -106,3 +106,17 @@ end
   @test res == sum(x[1:2, :]) + 2sum(x[5:6, :])
   @test dx == [ones(2, 5); zeros(2, 5); fill(2, 2, 5)]
 end
+
+@testset "eachlastdim" begin
+  x = rand(3, 6)
+  slicedim = (size(x)[1:end-1]..., 1)
+  res, (dx,) = Flux.withgradient(x) do x
+    x1, _, x3, _, x5, x6 = Flux.eachlastdim(x)
+    sum(x1) + sum(x3 .* 3) + sum(x5 * 5) + sum(x6 * 6)
+  end
+  @test res ≈ sum(x[:, 1]) + 3sum(x[:, 3]) + 
+              5sum(x[:, 5]) + 6sum(x[:, 6])
+  @test dx ≈ hcat(fill(1, slicedim), fill(0, slicedim),
+              fill(3, slicedim), fill(0, slicedim),
+              fill(5, slicedim), fill(6, slicedim))
+end


### PR DESCRIPTION
Fixes https://github.com/FluxML/Flux.jl/issues/1947

Defines the function eachlastdim (we can change the name for something more descriptive) that returns a generator over the last dimension of an Array, it also defines its corresponding rrule using ChainRule.jl [∇eachslice](https://github.com/JuliaDiff/ChainRules.jl/blob/f13e0a45d10bb13f48d6208e9c9d5b4a52b96732/src/rulesets/Base/indexing.jl#L77)

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
