### PR TITLE
Resolve two warnings in the test suite

### DIFF
--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -5,7 +5,7 @@
     rnn = r(2 => 3)
     Flux.reset!(rnn)
     grads_seq = gradient(Flux.params(rnn)) do
-        sum(rnn.(seq)[3])
+        sum([rnn(s) for s in seq][3])
     end
     Flux.reset!(rnn);
     bptt = gradient(Wh -> sum(tanh.(rnn.cell.Wi * seq[3] + Wh *
@@ -17,7 +17,7 @@
                             + rnn.cell.b)),
                     rnn.cell.Wh)
     @test grads_seq[rnn.cell.Wh] ≈ bptt[1]
-end
+  end
 end
 
 # Ref FluxML/Flux.jl#1209 2D input
@@ -27,7 +27,7 @@ end
     rnn = r(2 => 3)
     Flux.reset!(rnn)
     grads_seq = gradient(Flux.params(rnn)) do
-        sum(rnn.(seq)[3])
+        sum([rnn(s) for s in seq][3])
     end
     Flux.reset!(rnn);
     bptt = gradient(Wh -> sum(tanh.(rnn.cell.Wi * seq[3] + Wh *
@@ -39,7 +39,7 @@ end
                             + rnn.cell.b)),
                     rnn.cell.Wh)
     @test grads_seq[rnn.cell.Wh] ≈ bptt[1]
-end
+  end
 end
 
 @testset "BPTT-3D" begin

--- a/test/outputsize.jl
+++ b/test/outputsize.jl
@@ -14,7 +14,7 @@
   m = Chain(Dense(10, 8, σ), Dense(8, 4), Dense(5, 2))
   @test_throws DimensionMismatch outputsize(m, (10,))
 
-  m = Flux.Diagonal(10)
+  m = Flux.Scale(10)
   @test outputsize(m, (10, 1)) == (10, 1)
 
   m = Maxout(() -> Conv((3, 3), 3 => 16), 2)


### PR DESCRIPTION
This PR resolves two warnings in the test suite by updating outdated or discouraged code.

The errors are:

```julia
┌ Warning: Broadcasting is not safe to use with RNNs, as it does not guarantee an iteration order.
│ Re-writing this as a comprehension would be better.
│   caller = ip:0x0
└ @ Core :-1
┌ Warning: Flux.Diagonal is now Flux.Scale, and also allows an activation function.
│   caller = macro expansion at outputsize.jl:17 [inlined]
└ @ Core ~/.julia/packages/Flux/18YZE/test/outputsize.jl:17
```