### PR TITLE
Update documentation on Split layer

### DIFF
--- a/docs/src/models/advanced.md
+++ b/docs/src/models/advanced.md
@@ -196,7 +196,7 @@ Split(paths...) = Split(paths)
 
 Flux.@functor Split
 
-(m::Split)(x::AbstractArray) = tuple(map(f -> f(x), m.paths))
+(m::Split)(x::AbstractArray) = map(f -> f(x), m.paths)
 ```
 
 Now we can test to see that our `Split` does indeed produce multiple outputs.


### PR DESCRIPTION
Minimal update to the documentation. Removes `tuple(...)` from the output of the [`Split` layer](https://fluxml.ai/Flux.jl/stable/models/advanced/#Multiple-outputs:-a-custom-Split-layer). The output is already a tuple in the desired form.