### PR TITLE
[docs] suggest using ADAM with LR=1 when combined with ExpDecay

### DIFF
--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -627,7 +627,7 @@ for more general scheduling techniques.
 `ExpDecay` is typically composed  with other optimizers 
 as the last transformation of the gradient:
 ```julia
-opt = Optimiser(ADAM(), ExpDecay())
+opt = Optimiser(ADAM(1.0), ExpDecay())
 ```
 """
 mutable struct ExpDecay <: AbstractOptimiser


### PR DESCRIPTION
This only tweaks the example in the `ExpDecay` documentation.

The total LR is the product of the ADAM's learning rate with the current ExpDecay LR, which is kind of non-intuitive. By setting the ADAM's LR to 1, all the LR happens in the ExpDecay.