### PR TITLE
Use `var` to speed up normalisation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -195,7 +195,7 @@ function _norm_layer_forward(
     σ² = reshape(l.σ², stats_shape)
   else # trainmode or testmode without tracked stats
     μ = mean(x; dims=reduce_dims)
-    σ² = mean((x .- μ).^2; dims=reduce_dims)
+    σ² = var(x; mean=μ, dims=reduce_dims, corrected=false)
     if l.track_stats
       _track_stats!(l, x, μ, σ², reduce_dims) # update moving mean/std
     end


### PR DESCRIPTION
In [this comparison](https://discourse.julialang.org/t/ann-lux-jl-explicitly-parameterized-neural-networks-in-julia/81689/5), I think that [one line](https://github.com/FluxML/Flux.jl/blob/5f17f1c32fc1cdc2c65a6f5c583f4a2734238dca/src/layers/normalise.jl#L198) accounts for Flux's extra memory use, compared to [Lux's version](https://github.com/avik-pal/Lux.jl/blob/main/src/layers/normalize.jl#L147-L148) with `var`. (Perhaps that wasn't supported earlier?). This PR fixes it:
```julia
julia> x = rand(rng, Float32, 128, 1000);

julia> @btime gradient(model -> sum(model(x)), model);
  4.906 ms (1305 allocations: 29.19 MiB)  # before
  3.136 ms (1219 allocations: 23.32 MiB)  # after

julia> v, re = destructure(model);

julia> @btime gradient(v -> sum(re(v)(x)), v);
  5.044 ms (1562 allocations: 29.47 MiB)  # before
  3.306 ms (1476 allocations: 23.60 MiB)  # after
```
compared to Lux, same machine same size:
```julia
julia> @btime gradient(p -> sum(Lux.apply(model, x, p, st)[1]), ps);
  4.069 ms (2679 allocations: 23.41 MiB)

julia> ca = ComponentArray(ps);

julia> @btime gradient(p -> sum(Lux.apply(model, x, p, st)[1]), ca);
  4.327 ms (3061 allocations: 24.62 MiB)
```