### PR TITLE
Show `using Flux` before BSON `@load`

### DIFF
--- a/docs/src/saving.md
+++ b/docs/src/saving.md
@@ -24,6 +24,8 @@ julia> @save "mymodel.bson" model
 Load it again:
 
 ```jldoctest saving
+julia> using Flux # must precede @load
+
 julia> using BSON: @load
 
 julia> @load "mymodel.bson" model

--- a/docs/src/saving.md
+++ b/docs/src/saving.md
@@ -24,7 +24,7 @@ julia> @save "mymodel.bson" model
 Load it again:
 
 ```jldoctest saving
-julia> using Flux # must precede @load
+julia> using Flux # Flux must be loaded before calling @load
 
 julia> using BSON: @load
 


### PR DESCRIPTION
To a novice, it is not obvious that `Flux` module must be in scope before one can `@load` a model saved with `BSON.@save`.  This small documentation change makes that requirement explicit.