### PR TITLE
Added Common GPU Workflows in Docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,39 +1,50 @@
 using Documenter, Flux, NNlib, Functors, MLUtils, BSON
 
-DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive = true)
-makedocs(modules = [Flux, NNlib, Functors, MLUtils, BSON],
-         doctest = false,
-         sitename = "Flux",
-         pages = ["Home" => "index.md",
-                  "Building Models" =>
-                    ["Overview" => "models/overview.md",
-                     "Basics" => "models/basics.md",
-                     "Recurrence" => "models/recurrence.md",
-                     "Model Reference" => "models/layers.md",
-                     "Loss Functions" => "models/losses.md",
-                     "Regularisation" => "models/regularisation.md",
-                     "Advanced Model Building" => "models/advanced.md",
-                     "NNlib" => "models/nnlib.md",
-                     "Functors" => "models/functors.md"],
-                  "Handling Data" =>
-                    ["One-Hot Encoding" => "data/onehot.md",
-                     "MLUtils" => "data/mlutils.md"],
-                  "Training Models" =>
-                    ["Optimisers" => "training/optimisers.md",
-                     "Training" => "training/training.md"],
-                  "GPU Support" => "gpu.md",
-                  "Saving & Loading" => "saving.md",
-                  "The Julia Ecosystem" => "ecosystem.md",
-                  "Utility Functions" => "utilities.md",
-                  "Performance Tips" => "performance.md",
-                  "Datasets" => "datasets.md",
-                  "Community" => "community.md"],
-         format = Documenter.HTML(
-             analytics = "UA-36890222-9",
-             assets = ["assets/flux.css"],
-             prettyurls = get(ENV, "CI", nothing) == "true"),
-         )
 
-deploydocs(repo = "github.com/FluxML/Flux.jl.git",
-           target = "build",
-           push_preview = true)
+DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive = true)
+
+makedocs(
+    modules = [Flux, NNlib, Functors, MLUtils, BSON],
+    doctest = false,
+    sitename = "Flux",
+    pages = [
+        "Home" => "index.md",
+        "Building Models" => [
+            "Overview" => "models/overview.md",
+            "Basics" => "models/basics.md",
+            "Recurrence" => "models/recurrence.md",
+            "Model Reference" => "models/layers.md",
+            "Loss Functions" => "models/losses.md",
+            "Regularisation" => "models/regularisation.md",
+            "Advanced Model Building" => "models/advanced.md",
+            "NNlib" => "models/nnlib.md",
+            "Functors" => "models/functors.md"
+         ],
+         "Handling Data" => [
+             "One-Hot Encoding" => "data/onehot.md",
+             "MLUtils" => "data/mlutils.md"
+         ],
+         "Training Models" => [
+             "Optimisers" => "training/optimisers.md",
+             "Training" => "training/training.md"
+         ],
+         "GPU Support" => "gpu.md",
+         "Saving & Loading" => "saving.md",
+         "The Julia Ecosystem" => "ecosystem.md",
+         "Utility Functions" => "utilities.md",
+         "Performance Tips" => "performance.md",
+         "Datasets" => "datasets.md",
+         "Community" => "community.md"
+    ],
+    format = Documenter.HTML(
+        analytics = "UA-36890222-9",
+        assets = ["assets/flux.css"],
+        prettyurls = get(ENV, "CI", nothing) == "true"
+    ),
+)
+
+deploydocs(
+    repo = "github.com/FluxML/Flux.jl.git",
+    target = "build",
+    push_preview = true
+)

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -118,8 +118,9 @@ In order to train the model using the GPU both model and the training data have 
    gpu_train_loader = Flux.DataLoader((xtrain |> gpu, ytrain |> gpu), batchsize = 32)
    ```
    ```julia
-   gpu_train_loader = Flux.DataLoader(gpu.(collect.((xtrain, ytrain))), batchsize = 32)
+   gpu_train_loader = Flux.DataLoader((xtrain, ytrain) |> gpu, batchsize = 32)
    ```
+   Note that both `gpu` and `cpu` are smart enough to recurse through tuples and namedtuples.
 
 ### Saving GPU-Trained Models
 
@@ -136,8 +137,12 @@ BSON.@save "./path/to/trained_model.bson" model
 # in this approach the cpu-transferred model (referenced by the variable `model`)
 # only exists inside the `let` statement
 let model = cpu(model)
+   # ...
    BSON.@save "./path/to/trained_model.bson" model
 end
+
+# is equivalente to the above, but uses `key=value` storing directve from BSON.jl
+BSON.@save "./path/to/trained_model.bson" model = cpu(model)
 ```
 The reason behind this is that models trained in the GPU but not transferred to the CPU memory scope will expect `CuArray`s as input. In other words, Flux models expect input data coming from the same kind device in which they were trained on.
 

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -137,7 +137,7 @@ In order to train the model using the GPU both model and the training data have 
 
 ### Saving GPU-Trained Models
 
-After the training process is done one must always transfer the trained model back to the `cpu` memory scope before saving it to secundary memory. This can be done, as described in the previous section, with:
+After the training process is done, one must always transfer the trained model back to the `cpu` memory scope before serializing or saving to disk. This can be done, as described in the previous section, with:
 ```julia
 model = cpu(model) # or model = model |> cpu
 ```

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -1,6 +1,6 @@
 # GPU Support
 
-NVIDIA GPU support should work out of the box on systems with CUDA and CUDNN installed. For more details see the [CUDA](https://github.com/JuliaGPU/CUDA.jl) readme.
+NVIDIA GPU support should work out of the box on systems with CUDA and CUDNN installed. For more details see the [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) readme.
 
 ## Checking GPU Availability
 
@@ -85,6 +85,64 @@ julia> x |> cpu
  ⋮
  0.7766742
 ```
+
+## Common GPU Workflows
+
+Some of the common workflows involving the use of GPUs are presented below.
+
+### Transferring Training Data
+
+In order to train the model using the GPU both model and the training data have be transferred to GPU memory. This process can be done with the `gpu` function in two different  ways:
+
+1. Iterating over the batches in a [DataLoader](@ref) object transfering each one of the training batches at a time to the GPU. 
+   ```julia
+   train_loader = Flux.DataLoader((xtrain, ytrain), batchsize = 64, shuffle = true)
+   # ... model, optimizer and loss definitions
+   for epoch in 1:nepochs
+       for (xtrain_batch, ytrain_batch) in train_loader
+           x, y = gpu(xtrain_batch), gpu(ytrain_batch)
+           gradients = gradient(() -> loss(x, y), parameters)
+           Flux.Optimise.update!(optimizer, parameters, gradients)
+       end
+   end
+   ```
+
+1. Transferring all training data to the GPU at once before creating the [DataLoader](@ref) object. This is usually performed for smaller datasets which are sure to fit in the available GPU memory. Some possitilities are:
+   ```julia
+   gpu_x = gpu(xtrain)
+   gpu_y = gpu(ytrain)
+
+   gpu_train_loader = Flux.DataLoader((gpu_x, gpu_y), batchsize = 32)
+   ```
+   ```julia
+   gpu_train_loader = Flux.DataLoader((xtrain |> gpu, ytrain |> gpu), batchsize = 32)
+   ```
+   ```julia
+   gpu_train_loader = Flux.DataLoader(gpu.(collect.((xtrain, ytrain))), batchsize = 32)
+   ```
+
+### Saving GPU-Trained Models
+
+After the training process is done one must always transfer the trained model back to the `cpu` memory scope before saving it to secundary memory. This can be done, as described in the previous section, with:
+```julia
+model = cpu(model) # or model = model |> cpu
+```
+and then
+```julia
+using BSON
+# ...
+BSON.@save "./path/to/trained_model.bson" model
+
+# in this approach the cpu-transferred model (referenced by the variable `model`)
+# only exists inside the `let` statement
+let model = cpu(model)
+   BSON.@save "./path/to/trained_model.bson" model
+end
+```
+The reason behind this is that models trained in the GPU but not transferred to the CPU memory scope will expect `CuArray`s as input. In other words, Flux models expect input data coming from the same kind device in which they were trained on.
+
+In controlled scenarios in which the data fed to the loaded models is garanteed to be in the GPU there's no need to transfer them back to CPU memory scope, however in production environments, where artifacts are shared among different processes, equipments or configurations, there is no garantee that the CUDA.jl package will be available for the process performing inference on the model loaded from the disk.
+
 
 ## Disabling CUDA or choosing which GPUs are visible to Flux
 

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -92,7 +92,7 @@ Some of the common workflows involving the use of GPUs are presented below.
 
 ### Transferring Training Data
 
-In order to train the model using the GPU both model and the training data have be transferred to GPU memory. This process can be done with the `gpu` function in two different  ways:
+In order to train the model using the GPU both model and the training data have to be transferred to GPU memory. This process can be done with the `gpu` function in two different  ways:
 
 1. Iterating over the batches in a [DataLoader](@ref) object transfering each one of the training batches at a time to the GPU. 
    ```julia


### PR DESCRIPTION
Following the discussion in #1974, this is a very rough draft of the "Common GPU Workflows", feel free to suggest any changes or additions to this new section in the docs.

I also took the liberty of reformatting the `docs/make.jl` to make the pages and titles a bit easier to read.
