### PR TITLE
`PairwiseFusion` layer, take 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Flux Release Notes
 
+## v0.13.4
+* Added [`PairwiseFusion` layer](https://github.com/FluxML/Flux.jl/pull/1983)
+
 ## v0.13
 * After a deprecations cycle, the datasets in `Flux.Data` have
 been removed in favour of MLDatasets.jl.

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -16,7 +16,7 @@ export gradient
 # Pirate error to catch a common mistake. (Internal function `base` because overloading `update!` is more likely to give ambiguities.)
 Optimisers.base(dx::Zygote.Grads) = error("Optimisers.jl cannot be used with Zygote.jl's implicit gradients, `Params` & `Grads`")
 
-export Chain, Dense, Maxout, SkipConnection, Parallel,
+export Chain, Dense, Maxout, SkipConnection, Parallel, PairwiseFusion,
        RNN, LSTM, GRU, GRUv3,
        SamePad, Conv, CrossCor, ConvTranspose, DepthwiseConv,
        AdaptiveMaxPool, AdaptiveMeanPool, GlobalMaxPool, GlobalMeanPool, MaxPool, MeanPool,

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -595,18 +595,23 @@ end
                $(y_symbols[N + 1]) = connection($(y_symbols[i]), $(getinput(i + 1)))) 
              for i in 1:N - 1])
   push!(calls, :($(y_symbols[N]) = layers[$N]($(y_symbols[N + 1]))))
-  push!(calls, :(return $(y_symbols[N])))
+  push!(calls, :(return tuple($(Tuple(y_symbols[1:N])...))))
   return Expr(:block, calls...)
 end
 
 @functor PairwiseFusion
 
 Base.getindex(m::PairwiseFusion, i) = m.layers[i]
-Base.getindex(m::PairwiseFusion, i::AbstractVector) = PairwiseFusion(m.connection, m.layers[i])
 Base.getindex(m::PairwiseFusion{<:Any, <:NamedTuple}, i::AbstractVector) =
   PairwiseFusion(m.connection, NamedTuple{keys(m)[i]}(Tuple(m.layers)[i]))
 
 Base.keys(m::PairwiseFusion) = keys(getfield(m, :layers))
+
+function Base.show(io::IO, m::PairwiseFusion)
+  print(io, "PairwiseFusion(", m.connection, ", ")
+  _show_layers(io, m.layers)
+  print(io, ")")
+end
 
 """
     Embedding(in => out; init=randn)

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -538,7 +538,7 @@ end
 
 This layer behaves differently based on input type:
 
-1. If input `x` is a tuple of length `N`, matching the number of `layers`, 
+1. If input `x` is a tuple of length N (or the input is `xs` with N `x`'s), matching the number of `layers`, 
   then each layer receives a new input `x[i]` combined with the previous output `y[i-1]` using `connection`.
   Thus `(y1, y2, y3) = PairwiseFusion(connection, layer1, layer2, layer3)((x1, x2, x3))`
   may be drawn as:
@@ -567,7 +567,7 @@ end
 
 ## Returns
 
-A tuple of length `N` with the output of each fusion ((`y1`, `y2`, ..., `yN`) in the example above).
+A tuple of length N with the output of each fusion ((`y1`, `y2`, ..., `yN`) in the example above).
 """
 struct PairwiseFusion{F, T<:Union{Tuple, NamedTuple}}
   connection::F
@@ -597,6 +597,7 @@ function (m::PairwiseFusion)(x::T) where {T}
   _pairwise_check(x, m.layers, T)
   applypairwisefusion(m.layers, m.connection, x)
 end
+(m::PairwiseFusion)(xs...) = m(xs)
 
 @generated function applypairwisefusion(layers::Tuple{Vararg{<:Any,N}}, connection, x::T) where {N, T}
   y_symbols = [gensym() for _ in 1:(N + 1)]

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -582,11 +582,15 @@ function PairwiseFusion(connection; kw...)
 end
 
 function (m::PairwiseFusion)(x::T) where {T}
-  getinput(i) = T <: Union{Tuple, Vector} ? x[i] : x
-  nx = length(x)
   nlayers = length(m.layers)
-  if nx != nlayers
-    throw(ArgumentError("PairwiseFusion with $nlayers layers takes $nlayers inputs, but got $nx inputs"))
+  if T <: Union{Tuple, Vector}
+    getinput(i) = x[i]
+    nx = length(x)
+    if nx != nlayers
+      throw(ArgumentError("PairwiseFusion with $nlayers layers takes $nlayers inputs, but got $nx inputs"))
+    end
+  else
+    getinput(i) = x
   end
   outputs = [m.layers[1](getinput(1))]
   for i in 2:nlayers

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -525,38 +525,37 @@ end
 
 ## Arguments
 
-- `connection`: Takes 2 inputs and combines them
+- `connection`: A function taking 2 inputs and combining them into a single output 
 - `layers`: The layers whose outputs are combined
 
 ## Inputs
 
 This layer behaves differently based on input type:
 
-1. Input `x` is a tuple of length `N`. Then `layers` must be a tuple of length `N`. 
-
-With 3 layers, it takes 3 inputs and returns 3 outputs.
-`(y1, y2, y3) = PairwiseFusion(connection, layer1, layer2, layer3)((x1, x2, x3))`
-may be drawn as:
+1. If input `x` is a tuple of length `N`, matching the number of `layers`, 
+  then each layer receives a new input `x[i]` combined with the previous output `y[i-1]` using `connection`.
+  Thus `(y1, y2, y3) = PairwiseFusion(connection, layer1, layer2, layer3)((x1, x2, x3))`
+  may be drawn as:
 ```
 x1 → layer1 → y1 ↘
                   connection → layer2 → y2 ↘
               x2 ↗                          connection → layer3 → y3
                                         x3 ↗
 ```
-
-In code:
+... or written as:
 ```julia
 y1 = layer1(x1)
 y2 = layer2(connection(x2, y1))
 y3 = layer3(connection(x3, y2))
 ```
 
-2. Any other kind of input:
+2. With just one input, each layer receives the same `x` combined with the previous output.
+   Thus `y = PairwiseFusion(connection, layers...)(x)` obeys:
 
 ```julia
-y₁ = x
-for i in 1:N
-    yᵢ₊₁ = connection(x, layers[i](yᵢ))
+y[1] == layers[1](x)
+for i in 2:length(layers)
+    y[i] == connection(x, layers[i](y[i-1]))
 end
 ```
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -523,18 +523,6 @@ end
 """
     PairwiseFusion(connection, layers...)
 
-```
-x1 --> layer1 --> y1
-                  |
-                  |--> connection --> layer2 --> y2
-                  |                              |
-                  x2                             |--> connection --> layer3 --> y3
-                                                 |                              |
-                                                 x3                             |--> connection --> y4
-                                                                                |
-                                                                                x4
-```
-
 ## Arguments
 
 - `connection`: Takes 2 inputs and combines them
@@ -544,21 +532,31 @@ x1 --> layer1 --> y1
 
 This layer behaves differently based on input type:
 
-1. Input `x` is a tuple of length `N`. Then `layers` must be a tuple of length `N`. The computation is as follows:
+1. Input `x` is a tuple of length `N`. Then `layers` must be a tuple of length `N`. 
 
+With 3 layers, it takes 3 inputs and returns 3 outputs.
+`(y1, y2, y3) = PairwiseFusion(connection, layer1, layer2, layer3)((x1, x2, x3))`
+may be drawn as:
+```
+x1 → layer1 → y1 ↘
+                  connection → layer2 → y2 ↘
+              x2 ↗                          connection → layer3 → y3
+                                        x3 ↗
+```
+
+In code:
 ```julia
-y = x[1]
-for i in 1:N
-    y = connection(x[i], layers[i](y))
-end
+y1 = layer1(x1)
+y2 = layer2(connection(x2, y1))
+y3 = layer3(connection(x3, y2))
 ```
 
 2. Any other kind of input:
 
 ```julia
-y = x
+y₁ = x
 for i in 1:N
-    y = connection(x, layers[i](y))
+    yᵢ₊₁ = connection(x, layers[i](yᵢ))
 end
 ```
 

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -25,7 +25,7 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
       for k in Base.keys(obj)
         _big_show(io, obj[k], indent+2, k)
       end
-    elseif obj isa Parallel{<:Any, <:NamedTuple}
+    elseif obj isa Parallel{<:Any, <:NamedTuple} || obj isa PairwiseFusion{<:Any, <:NamedTuple}
       _big_show(io, obj.connection, indent+2)
       for k in Base.keys(obj)
         _big_show(io, obj[k], indent+2, k)

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -1,6 +1,6 @@
 
 for T in [
-    :Chain, :Parallel, :SkipConnection, :Recur, :Maxout  # container types
+    :Chain, :Parallel, :SkipConnection, :Recur, :Maxout, :PairwiseFusion  # container types
   ]
   @eval function Base.show(io::IO, m::MIME"text/plain", x::$T)
     if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL
@@ -53,6 +53,7 @@ _show_children(x) = trainable(x)  # except for layers which hide their Tuple:
 _show_children(c::Chain) = c.layers
 _show_children(m::Maxout) = m.layers
 _show_children(p::Parallel) = (p.connection, p.layers...)
+_show_children(f::PairwiseFusion) = (f.connection, f.layers...)
 
 for T in [
     :Conv, :ConvTranspose, :CrossCor, :Dense, :Scale, :Bilinear, :Embedding,

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -358,4 +358,11 @@ end
   @test length(y) == 2
   @test size(y[1]) == (30, 10)
   @test size(y[2]) == (10, 10)
+
+  x = rand(1, 10)
+  layer = PairwiseFusion(.+,  Dense(1, 10),  Dense(10, 1))
+  y = layer(x)
+  @test length(y) == 2
+  @test size(y[1]) == (10, 10)
+  @test size(y[2]) == (1, 10)
 end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -350,3 +350,12 @@ end
   @test Flux.destructure(m1)[2](z1)[1].weight ≈ Flux.destructure(m1v)[2](z1)[1].weight
   # Note that Flux.destructure(m1v)[2](z) has a Chain{Tuple}, as does m1v[1:2]
 end
+
+@testset "PairwiseFusion" begin
+  x = (rand(1, 10), rand(30, 10))
+  layer = PairwiseFusion(+,  Dense(1, 30),  Dense(30, 10))
+  y = layer(x)
+  @test length(y) == 2
+  @test size(y[1]) == (30, 10)
+  @test size(y[2]) == (10, 10)
+end

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -365,4 +365,7 @@ end
   @test length(y) == 2
   @test size(y[1]) == (10, 10)
   @test size(y[2]) == (1, 10)
+
+  @test PairwiseFusion(vcat, x->x.+1, x->x.+2, x->x.^3)(2, 10, 20) == (3, [5, 12], [125, 1728, 8000])
+  @test PairwiseFusion(vcat, x->x.+1, x->x.+2, x->x.^3)(7) == (8, [10, 9], [1000, 729, 343])
 end


### PR DESCRIPTION
I messed up the commits on #1971 a little bit, so this one should close #1971. If merged, this will also close #1989.

---

This PR implements a `PairwiseFusion` layer similar to the one in [Lux](https://github.com/avik-pal/Lux.jl/blob/0ca5a265b7ef8c6d3da2b2dfacfefc56a39f5163/src/layers/basic.jl#L335-L388). This might be especially useful for implementing models like [Res2Net](https://github.com/FluxML/Metalhead.jl/pull/123), since the forward pass for the bottleneck layer is quite similar to this.

## PR Checklist
- [x] Add pretty-printing similar to `Parallel`
- [x] Tests are added
- [x] Entry in NEWS.md
- [x] Documentation, if applicable
