### PR TITLE
deprecations.jl: depwarn -> Base.depwarn

### DIFF
--- a/docs/src/training/optimisers.md
+++ b/docs/src/training/optimisers.md
@@ -21,17 +21,17 @@ grads = gradient(() -> loss(x, y), θ)
 We want to update each parameter, using the gradient, in order to improve (reduce) the loss. Here's one way to do that:
 
 ```julia
-using Flux.Optimise: update!
-
 η = 0.1 # Learning Rate
 for p in (W, b)
-  update!(p, η * grads[p])
+  p .-= η * grads[p]
 end
 ```
 
 Running this will alter the parameters `W` and `b` and our loss should go down. Flux provides a more general way to do optimiser updates like this.
 
 ```julia
+using Flux: update!
+
 opt = Descent(0.1) # Gradient descent with learning rate 0.1
 
 for p in (W, b)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -35,7 +35,7 @@ end
 Zeros(args...) = Zeros()  # was used both Dense(10, 2, initb = Zeros) and Dense(rand(2,10), Zeros())
 
 function Optimise.update!(x::AbstractArray, x̄)
-  depwarn("`Flux.Optimise.update!(x, x̄)` was not used internally and has been removed. Please write `x .-= x̄` instead.", :update!)
+  Base.depwarn("`Flux.Optimise.update!(x, x̄)` was not used internally and has been removed. Please write `x .-= x̄` instead.", :update!)
   x .-= x̄
 end
 


### PR DESCRIPTION
Because `depwarn` is not imported from Base, calling `update!(...)` throws an `UndefVarError`.
Changed `depwarn` to `Base.depwarn`.

See https://discourse.julialang.org/t/flux-13-3-error-undefvarerror-depwarn-not-defined/82118

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable

No tests for depwarns exist as far as I can tell, so I did not add one. 
Changes to `NEWS.md` ~~and the docs~~ aren't necessary in my opinion.
