### PR TITLE
Get rid of documentation warnings and 404 pages

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 
 [compat]
 Documenter = "0.26"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,10 +1,10 @@
-using Documenter, Flux, NNlib, Functors, MLUtils, BSON
+using Documenter, Flux, NNlib, Functors, MLUtils, BSON, Optimisers
 
 
 DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive = true)
 
 makedocs(
-    modules = [Flux, NNlib, Functors, MLUtils, BSON],
+    modules = [Flux, NNlib, Functors, MLUtils, BSON, Optimisers],
     doctest = false,
     sitename = "Flux",
     pages = [

--- a/docs/src/data/mlutils.md
+++ b/docs/src/data/mlutils.md
@@ -20,10 +20,15 @@ Below is a non-exhaustive list of such utility functions.
 
 ```@docs
 MLUtils.unsqueeze
+MLUtils.flatten
 MLUtils.stack
 MLUtils.unstack
+MLUtils.numobs
+MLUtils.getobs
+MLUtils.getobs!
 MLUtils.chunk
 MLUtils.group_counts
+MLUtils.group_indices
 MLUtils.batch
 MLUtils.unbatch
 MLUtils.batchseq

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -86,6 +86,11 @@ julia> x |> cpu
  0.7766742
 ```
 
+```@docs
+cpu
+gpu
+```
+
 ## Common GPU Workflows
 
 Some of the common workflows involving the use of GPUs are presented below.

--- a/docs/src/models/functors.md
+++ b/docs/src/models/functors.md
@@ -9,5 +9,7 @@ Functors.isleaf
 Functors.children
 Functors.fcollect
 Functors.functor
+Functors.@functor
 Functors.fmap
+Functors.fmapstructure
 ```

--- a/docs/src/models/nnlib.md
+++ b/docs/src/models/nnlib.md
@@ -11,7 +11,9 @@ NNlib.celu
 NNlib.elu
 NNlib.gelu
 NNlib.hardsigmoid
+NNlib.sigmoid_fast
 NNlib.hardtanh
+NNlib.tanh_fast
 NNlib.leakyrelu
 NNlib.lisht
 NNlib.logcosh

--- a/docs/src/training/optimisers.md
+++ b/docs/src/training/optimisers.md
@@ -1,3 +1,7 @@
+```@meta
+CurrentModule = Flux
+```
+
 # Optimisers
 
 Consider a [simple linear regression](../models/basics.md). We create some dummy data, calculate a loss, and backpropagate to calculate gradients for the parameters `W` and `b`.
@@ -188,4 +192,14 @@ opt = Optimiser(ClipValue(1e-3), Adam(1e-3))
 ```@docs
 ClipValue
 ClipNorm
+```
+
+# Optimisers.jl
+
+Flux re-exports some utility functions from [`Optimisers.jl`](https://github.com/FluxML/Optimisers.jl)
+and the complete `Optimisers` package under the `Flux.Optimisers` namespace.
+
+```@docs
+Optimisers.destructure
+Optimisers.trainable
 ```

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -107,7 +107,6 @@ Flux.outputsize
 
 ```@docs
 Flux.modules
-Flux.destructure
 Flux.nfan
 ```
 

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -59,7 +59,7 @@ Flux.f32
 
 Flux provides some utility functions to help you generate models in an automated fashion.
 
-[`outputsize`](@ref) enables you to calculate the output sizes of layers like [`Conv`](@ref)
+[`Flux.outputsize`](@ref) enables you to calculate the output sizes of layers like [`Conv`](@ref)
 when applied to input samples of a given size. This is achieved by passing a "dummy" array into
 the model that preserves size information without running any computation.
 `outputsize(f, inputsize)` works for all layers (including custom layers) out of the box.

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -54,7 +54,7 @@ Given a model or specific layers from a model, create a `Params` object pointing
 
 This can be used with the `gradient` function, see [Taking Gradients](@ref), or as input to the [`Flux.train!`](@ref Flux.train!) function.
 
-The behaviour of `params` on custom types can be customized using [`Functor.@functor`](@ref) or [`Flux.trainable`](@ref).
+The behaviour of `params` on custom types can be customized using [`Functors.@functor`](@ref) or [`Flux.trainable`](@ref).
 
 # Examples
 ```jldoctest

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -663,7 +663,7 @@ Embedding(1000 => 4)  # 4_000 parameters
 julia> vocab_idxs = [1, 722, 53, 220, 3];
 
 julia> x = Flux.onehotbatch(vocab_idxs, 1:vocab_size); summary(x)
-"1000×5 OneHotMatrix(::Vector{Int64}) with eltype Bool"
+"1000×5 OneHotMatrix(::Vector{UInt32}) with eltype Bool"
 
 julia> model(x) |> summary
 "4×5 Matrix{Float32}"

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -124,7 +124,7 @@ The out `y` will be a vector  of length `out`, or a batch with
 
 Keyword `bias=false` will switch off trainable bias for the layer.
 The initialisation of the weight matrix is `W = init(out, in)`, calling the function
-given to keyword `init`, with default [`glorot_uniform`](@doc Flux.glorot_uniform).
+given to keyword `init`, with default [`glorot_uniform`](@ref Flux.glorot_uniform).
 The weight matrix and/or the bias vector (of length `out`) may also be provided explicitly.
 
 # Examples
@@ -262,7 +262,7 @@ which constructs them, and the number to construct.
 
 Maxout over linear dense layers satisfies the univeral approximation theorem.
 See Goodfellow, Warde-Farley, Mirza, Courville & Bengio "Maxout Networks" 
-[https://arxiv.org/abs/1302.4389](1302.4389).
+[https://arxiv.org/abs/1302.4389](https://arxiv.org/abs/1302.4389).
 
 See also [`Parallel`](@ref) to reduce with other operators.
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -651,7 +651,7 @@ for a vocabulary of size `in`.
 
 This layer is often used to store word embeddings and retrieve them using indices. 
 The input to the layer can be either a vector of indexes
-or the corresponding [onehot encoding](@ref Flux.OneHotArray). 
+or the corresponding [`onehot encoding`](@ref Flux.onehotbatch). 
 
 # Examples
 ```jldoctest
@@ -662,7 +662,7 @@ Embedding(1000 => 4)  # 4_000 parameters
 
 julia> vocab_idxs = [1, 722, 53, 220, 3];
 
-julia> x = Flux.OneHotMatrix(vocab_idxs, vocab_size); summary(x)
+julia> x = Flux.onehotbatch(vocab_idxs, 1:vocab_size); summary(x)
 "1000×5 OneHotMatrix(::Vector{Int64}) with eltype Bool"
 
 julia> model(x) |> summary

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -91,8 +91,8 @@ Then, this gradient is used by optimizer `opt` to update the paramters:
 ```
     update!(opt, pars, grads)
 ```
-The optimiser should be from the [Flux.Optimise](@ref) module.
-Different optimisers can be combined using [Flux.Optimise.Optimiser](@ref).
+The optimiser should be from the `Flux.Optimise` module (see [Optimisers](@ref)).
+Different optimisers can be combined using [`Flux.Optimise.Optimiser`](@ref Flux.Optimiser).
 
 This training loop iterates through `data` once.
 You can use [`@epochs`](@ref) to do this several times, or 


### PR DESCRIPTION
## Changes/Additions
* fixed internal cross-references that currently redirects to a `404` page
* added missing docstrings in the manual (to fix the cross-references)

Related PRs - https://github.com/FluxML/Functors.jl/pull/42, https://github.com/JuliaML/MLUtils.jl/pull/95

## Leftover work
1. Warning: no docs found for `Flux.destructure` in `@docs` block in `src\utilities.md`
```@docs
Flux.modules
Flux.destructure
Flux.nfan
```
`destructure` is now imported from `Optimisers`. Should I add `Optimisers.jl` as a doc dependency? Adding a new dependency that has functions and structs named the same as those of `Flux` would also mean specifying the package in the docs. For example, changing this -
```
```@docs
Flux.Optimise.update!
Descent
Momentum
Nesterov
RMSProp
ADAM
RADAM
AdaMax
ADAGrad
ADADelta
AMSGrad
NADAM
ADAMW
OADAM
AdaBelief
\```
```
to this -
```
```@doc
Flux.Optimise.update!
Flux.Descent
Flux.Momentum
Flux.Nesterov
Flux.RMSProp
Flux.ADAM
Flux.RADAM
Flux.AdaMax
Flux.ADAGrad
Flux.ADADelta
Flux.AMSGrad
Flux.NADAM
Flux.ADAMW
Flux.OADAM
Flux.AdaBelief
\```
```
and so on. Could you please let me know if `Flux` plans to import all these optimisers from `Optimisers.jl`? If yes, then this would be a good idea.

2. Warning: no doc found for reference '[`Flux.trainable`]\(@\ref)' in `src\training\training.md`.
Again, this would require adding `Optimisers.jl` as a doc dependency.

### Missing docstrings
The logs also show a bunch of docstrings that do not appear in the manual. Most of them are a part of the internal API, but I have marked some of them which I think are user-facing. Should I add them in the manual?

- [ ] Flux.NilNumber.Nil
- [ ] Flux.Losses.xlogy :: Tuple{Any, Any}
- [ ] Flux.Losses.add_blanks :: Tuple{Any, Any}
- [ ] Flux.rng_from_array :: Tuple{AbstractArray}
- [ ] Flux.NilNumber.nil
- [X] Flux.GRUv3 :: Tuple
- [X] Flux.cpu :: Tuple{Any}
- [ ] Flux.zeros32 :: Tuple
- [ ] Flux.randn32 :: Tuple{Vararg{Integer}}
- [ ] Flux.Losses.ctc_loss :: Tuple{AbstractArray, Any}
- [ ] Flux.OneHotVector :: Tuple{Any, Any}
- [ ] Flux.Losses.logaddexp :: Tuple{Any, Any}
- [ ] Flux.hasaffine :: Tuple{Union{BatchNorm, GroupNorm, InstanceNorm, LayerNorm}}
- [X] Flux.gpu :: Tuple{Any}
- [ ] Flux.OneHotMatrix :: Tuple{Any, Any}
- [ ] Flux.Losses.xlogx :: Tuple{Any}
- [ ] Flux.create_bias :: Tuple{AbstractArray, Bool, Vararg{Integer}}
- [ ] Flux.OneHotArray

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
