### PR TITLE
Attempt to write a type stable `rrule(Chain{Vector})`

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -9,7 +9,9 @@ using MacroTools: @forward
 using MLUtils
 import Optimisers: Optimisers, trainable, destructure  # before v0.13, Flux owned these functions
 
-using Zygote, ChainRulesCore
+using ChainRulesCore
+import ChainRulesCore: rrule, RuleConfig, HasReverseMode
+using Zygote
 using Zygote: Params, @adjoint, gradient, pullback, @nograd
 export gradient
 


### PR DESCRIPTION
Works for simple, shallow chains like `Chain([Base.Fix2(*, x) for x in 2:4])`, but falls apart for the more complex type [found in Metalhead 
](https://github.com/FluxML/Metalhead.jl/blob/v0.7.2/src/vit-based/vit.jl#L16-L23). Suggestions for how to get this working very much appreciated, I'm well beyond my comfort level when it comes to type inference whispering here.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
