### PR TITLE
mark `stop`, `skip`, `@epochs` as deprecated

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -38,6 +38,9 @@ struct SkipException <: Exception end
 Call `Flux.skip()` in a callback to indicate when a callback condition is met.
 This will trigger the train loop to skip the current data point and not update with the calculated gradient.
 
+!!! note
+    `Flux.skip()` will be removed from Flux 0.14
+
 # Examples
 ```julia
 cb = function ()
@@ -60,6 +63,9 @@ struct StopException <: Exception end
 
 Call `Flux.stop()` in a callback to indicate when a callback condition is met.
 This will trigger the train loop to stop and exit.
+
+!!! note
+    `Flux.stop()` will be removed from Flux 0.14. It should be replaced with `break` in an ordinary `for` loop.
 
 # Examples
 ```julia
@@ -144,6 +150,9 @@ end
 
 Run `body` `N` times. Mainly useful for quickly doing multiple epochs of
 training in a REPL.
+
+!!! note
+    The macro `@epochs` will be removed from Flux 0.14. Please just write an ordinary `for` loop.
 
 # Examples
 ```julia

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -146,7 +146,7 @@ Run `body` `N` times. Mainly useful for quickly doing multiple epochs of
 training in a REPL.
 
 # Examples
-```jldoctest
+```julia
 julia> Flux.@epochs 2 println("hello")
 [ Info: Epoch 1
 hello

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -50,7 +50,6 @@ end
 """
 function skip()
   Base.depwarn("""Flux.skip() will be removed from Flux 0.14.
-                  It never worked as described, 
                   and should be replaced with `continue` in an ordinary `for` loop.""", :skip)
   throw(SkipException())
 end
@@ -165,7 +164,7 @@ hello
 """
 macro epochs(n, ex)
   Base.depwarn("""The macro `@epochs` will be removed from Flux 0.14.
-                  Just write an ordinary for loop.""", Symbol("@epochs"), force=true)
+                  As an alternative, you can write a simple `for i in 1:epochs` loop.""", Symbol("@epochs"), force=true)
   :(@progress for i = 1:$(esc(n))
       @info "Epoch $i"
       $(esc(ex))

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -46,6 +46,9 @@ end
 ```
 """
 function skip()
+  Base.depwarn("""Flux.skip() will be removed from Flux 0.14.
+                  It never worked as described, 
+                  and should be replaced with `continue` in an ordinary `for` loop.""", :skip)
   throw(SkipException())
 end
 
@@ -66,6 +69,8 @@ end
 ```
 """
 function stop()
+  Base.depwarn("""Flux.stop() will be removed from Flux 0.14.
+                  It should be replaced with `break` in an ordinary `for` loop.""", :stop)
   throw(StopException())
 end
 
@@ -150,6 +155,8 @@ hello
 ```
 """
 macro epochs(n, ex)
+  Base.depwarn("""The macro `@epochs` will be removed from Flux 0.14.
+                  Just write an ordinary for loop.""", Symbol("@epochs"), force=true)
   :(@progress for i = 1:$(esc(n))
       @info "Epoch $i"
       $(esc(ex))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -621,7 +621,7 @@ julia> loss() = rand();
 julia> trigger = Flux.patience(() -> loss() < 1, 3);
 
 
-julia> for i in 1:10 begin
+julia> for i in 1:10
          @info "Epoch \$i"
          trigger() && break
        end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -621,7 +621,8 @@ julia> loss() = rand();
 julia> trigger = Flux.patience(() -> loss() < 1, 3);
 
 
-julia> Flux.@epochs 10 begin
+julia> for i in 1:10 begin
+         @info "Epoch \$i"
          trigger() && break
        end
 [ Info: Epoch 1
@@ -658,7 +659,8 @@ julia> loss = let l = 0
 julia> es = Flux.early_stopping(loss, 3);
 
 
-julia> Flux.@epochs 10 begin
+julia> for i in 1:10
+         @info "Epoch \$i"
          es() && break
        end
 [ Info: Epoch 1
@@ -699,7 +701,8 @@ julia> f = let v = 10
 julia> trigger = Flux.plateau(f, 3; init_score=10, min_dist=18);
 
 
-julia> Flux.@epochs 10 begin
+julia> for i in 1:10
+         @info "Epoch \$i"
          trigger() && break
        end
 [ Info: Epoch 1


### PR DESCRIPTION
Replaces #1913 with the simpler plan to remove these from Flux 0.14.

Closes #1913