### PR TITLE
RFC: add a supertype to layers

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -44,6 +44,7 @@ include("functor.jl")
 # Pirate error to catch a common mistake.
 Functors.functor(::Type{<:MLUtils.DataLoader}, x) = error("`DataLoader` does not support Functors.jl, thus functions like `Flux.gpu` will not act on its contents.")
 
+include("layers/types.jl")
 include("layers/stateless.jl")
 include("layers/basic.jl")
 include("layers/conv.jl")

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -1,3 +1,20 @@
+
+abstract type AbstractLayer end
+"""
+    abstract type ContainerLayer <: AbstractLayer end
+    
+Supertype for layers such as `Chain` & `Parallel`.
+Not essential to Flux's functioning, but tells fancy `show` to unfold the contents.
+"""
+abstract type ContainerLayer <: AbstractLayer end
+"""
+    abstract type SimpleLayer <: AbstractLayer end
+    
+Supertype for layers such as `Dense` & `Conv`.
+Not essential to Flux's functioning, but tells `show` how to behave.
+"""
+abstract type SimpleLayer <: AbstractLayer end
+
 """
     Chain(layers...)
     Chain(name = layer, ...)
@@ -32,7 +49,7 @@ For large models, there is a special type-unstable path which can reduce compila
 times. This can be used by supplying a vector of layers `Chain([layer1, layer2, ...])`.
 This feature is somewhat experimental, beware!
 """
-struct Chain{T<:Union{Tuple, NamedTuple, AbstractVector}}
+struct Chain{T<:Union{Tuple, NamedTuple, AbstractVector}} <: ContainerLayer
   layers::T
 end
 
@@ -150,7 +167,7 @@ julia> Flux.params(d1)  # no trainable bias
 Params([[1.0 1.0 … 1.0 1.0; 1.0 1.0 … 1.0 1.0]])
 ```
 """
-struct Dense{F, M<:AbstractMatrix, B}
+struct Dense{F, M<:AbstractMatrix, B} <: SimpleLayer
   weight::M
   bias::B
   σ::F
@@ -223,7 +240,7 @@ julia> Flux.params(b)
 Params([[1 2 3 4]])
 ```
 """
-struct Scale{F, A<:AbstractArray, B}
+struct Scale{F, A<:AbstractArray, B} <: SimpleLayer
   scale::A
   bias::B
   σ::F
@@ -285,7 +302,7 @@ julia> Flux.outputsize(m3, (5, 11))
 (7, 11)
 ```
 """
-struct Maxout{T<:Tuple}
+struct Maxout{T<:Tuple} <: SimpleLayer
   layers::T
 end
 Maxout(layers...) = Maxout(layers)
@@ -333,7 +350,7 @@ true
 
 See also [`Parallel`](@ref), [`Maxout`](@ref).
 """
-struct SkipConnection{T,F}
+struct SkipConnection{T,F} <: ContainerLayer
   layers::T
   connection::F  #user can pass arbitrary connections here, such as (a,b) -> a + b
 end
@@ -397,7 +414,7 @@ julia> Flux.Bilinear(rand(4,8,16), false, tanh)  # first dim of weight is the ou
 Bilinear((8, 16) => 4, tanh; bias=false)  # 512 parameters
 ```
 """
-struct Bilinear{F,A,B}
+struct Bilinear{F,A,B} <: SimpleLayer
   weight::A
   bias::B
   σ::F
@@ -492,7 +509,7 @@ julia> model2[:β] == model2[2]
 true
 ```
 """
-struct Parallel{F, T<:Union{Tuple, NamedTuple}}
+struct Parallel{F, T<:Union{Tuple, NamedTuple}} <: ContainerLayer
   connection::F
   layers::T
 end
@@ -582,7 +599,7 @@ end
 
 A tuple of length N with the output of each fusion ((`y1`, `y2`, ..., `yN`) in the example above).
 """
-struct PairwiseFusion{F, T<:Union{Tuple, NamedTuple}}
+struct PairwiseFusion{F, T<:Union{Tuple, NamedTuple}} <: ContainerLayer
   connection::F
   layers::T
 end
@@ -672,7 +689,7 @@ julia> model(vocab_idxs) == model(x)
 true
 ```
 """
-struct Embedding{W}
+struct Embedding{W} <: SimpleLayer
   weight::W
 end
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -1,20 +1,4 @@
 
-abstract type AbstractLayer end
-"""
-    abstract type ContainerLayer <: AbstractLayer end
-    
-Supertype for layers such as `Chain` & `Parallel`.
-Not essential to Flux's functioning, but tells fancy `show` to unfold the contents.
-"""
-abstract type ContainerLayer <: AbstractLayer end
-"""
-    abstract type SimpleLayer <: AbstractLayer end
-    
-Supertype for layers such as `Dense` & `Conv`.
-Not essential to Flux's functioning, but tells `show` how to behave.
-"""
-abstract type SimpleLayer <: AbstractLayer end
-
 """
     Chain(layers...)
     Chain(name = layer, ...)
@@ -302,7 +286,7 @@ julia> Flux.outputsize(m3, (5, 11))
 (7, 11)
 ```
 """
-struct Maxout{T<:Tuple} <: SimpleLayer
+struct Maxout{T<:Tuple} <: ContainerLayer
   layers::T
 end
 Maxout(layers...) = Maxout(layers)

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -187,8 +187,6 @@ function convfilter(filter::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer};
   init(filter..., cin÷groups, cout)
 end
 
-@functor Conv
-
 conv_dims(c::Conv, x::AbstractArray) =
   DenseConvDims(x, c.weight; stride = c.stride, padding = c.pad, dilation = c.dilation, groups = c.groups)
 
@@ -306,8 +304,6 @@ function ConvTranspose(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ =
   weight = convfilter(k, reverse(ch); init, groups)                    
   ConvTranspose(weight, bias, σ; stride, pad, dilation, groups)
 end
-
-@functor ConvTranspose
 
 function conv_transpose_dims(c::ConvTranspose, x::AbstractArray)
   # Calculate size of "input", from ∇conv_data()'s perspective...
@@ -452,8 +448,6 @@ function CrossCor(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = iden
   weight = convfilter(k, ch, init = init)
   return CrossCor(weight, bias, σ; stride, pad, dilation)
 end
-
-@functor CrossCor
 
 function crosscor(x, w, ddims::DenseConvDims)
   ddims = DenseConvDims(ddims, F=true)

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -117,7 +117,7 @@ julia> Conv((5,5), 3 => 7; stride = 2, dilation = 4)(xs) |> size
 (42, 42, 7, 50)
 ```
 """
-struct Conv{N,M,F,A,V}
+struct Conv{N,M,F,A,V} <: SimpleLayer
   σ::F
   weight::A
   bias::V
@@ -252,7 +252,7 @@ julia> ConvTranspose((5,5), 3 => 7, stride=3, pad=SamePad())(xs) |> size
 (300, 300, 7, 50)
 ```
 """
-struct ConvTranspose{N,M,F,A,V}
+struct ConvTranspose{N,M,F,A,V} <: SimpleLayer
   σ::F
   weight::A
   bias::V
@@ -407,7 +407,7 @@ julia> CrossCor((5,5), 3 => 7, stride=3, pad=(2,0))(xs) |> size
 (34, 32, 7, 50)
 ```
 """
-struct CrossCor{N,M,F,A,V}
+struct CrossCor{N,M,F,A,V} <: SimpleLayer
   σ::F
   weight::A
   bias::V

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -103,7 +103,6 @@ function Dropout(p; dims=:, rng = rng_from_array())
   Dropout(p, dims, nothing, rng)
 end
 
-@functor Dropout
 function (a::Dropout)(x)
   _isactive(a) || return x
   return dropout(a.rng, x, a.p; dims=a.dims, active=true)
@@ -156,7 +155,6 @@ end
 AlphaDropout(p, active) = AlphaDropout(p, active, rng_from_array())
 AlphaDropout(p; rng = rng_from_array()) = AlphaDropout(p, nothing, rng)
 
-@functor AlphaDropout
 function (a::AlphaDropout)(x::AbstractArray{T}) where T
   _isactive(a) || return x
   p = a.p
@@ -219,8 +217,6 @@ function LayerNorm(size::Tuple{Vararg{Int}}, λ=identity; affine::Bool=true, ϵ:
 end
 LayerNorm(size::Integer...; kw...) = LayerNorm(Int.(size); kw...)
 LayerNorm(size_act...; kw...) = LayerNorm(Int.(size_act[1:end-1]), size_act[end]; kw...)
-
-@functor LayerNorm
 
 (a::LayerNorm)(x) = a.diag(normalise(x, dims=1:length(a.size), ϵ=a.ϵ))
 
@@ -348,8 +344,6 @@ function BatchNorm(chs::Int, λ=identity;
             nothing, chs)
 end
 
-@functor BatchNorm
-
 function (BN::BatchNorm)(x)
   @assert size(x, ndims(x)-1) == BN.chs
   N = ndims(x)
@@ -437,8 +431,6 @@ function InstanceNorm(chs::Int, λ=identity;
             nothing, chs)
 end
 
-@functor InstanceNorm
-
 function (l::InstanceNorm)(x)
   @assert ndims(x) > 2
   @assert size(x, ndims(x)-1) == l.chs
@@ -514,8 +506,6 @@ mutable struct GroupNorm{F,V,N,W} <: PartialTrainLayer{(:β, :γ)}
   active::Union{Bool, Nothing}
   chs::Int # number of channels
 end
-
-@functor GroupNorm
 
 function GroupNorm(chs::Int, G::Int, λ=identity;
               initβ=zeros32, initγ=ones32,

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -209,7 +209,7 @@ julia> isapprox(std(y, dims=1:3), ones(1, 1, 1, 2), atol=0.1) && std(y, dims=1:3
 true
 ```
 """
-struct LayerNorm{F,D,T,N}
+struct LayerNorm{F,D,T,N} <: SimpleLayer
   λ::F
   diag::D
   ϵ::T
@@ -322,7 +322,7 @@ julia> isapprox(std(m(xs)), 1, atol=0.1) && std(xs) != std(m(xs))
 true
 ```
 """
-mutable struct BatchNorm{F,V,N,W}
+mutable struct BatchNorm{F,V,N,W} <: SimpleLayer
   λ::F  # activation function
   β::V  # bias
   γ::V  # scale
@@ -412,7 +412,7 @@ julia> isapprox(std(y, dims=1:2), ones(1, 1, 3, 2), atol=0.2) && std(y, dims=1:2
 true
 ```
 """
-mutable struct InstanceNorm{F,V,N,W}
+mutable struct InstanceNorm{F,V,N,W} <: SimpleLayer
   λ::F  # activation function
   β::V  # bias
   γ::V  # scale
@@ -506,7 +506,7 @@ julia> isapprox(std(y[:, :, 3:4, 2]), 1, atol=0.1) && std(xs[:, :, 3:4, 2]) != s
 true
 ```
 """
-mutable struct GroupNorm{F,V,N,W}
+mutable struct GroupNorm{F,V,N,W} <: SimpleLayer
   G::Int  # number of groups
   λ::F  # activation function
   β::V  # bias

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -135,7 +135,6 @@ function (m::Recur)(x)
   return y
 end
 
-@functor Recur
 trainable(a::Recur) = (; cell = a.cell)  # can't use <: PartialTrainLayer
 
 Base.show(io::IO, m::Recur) = print(io, "Recur(", m.cell, ")")
@@ -206,8 +205,6 @@ function (m::RNNCell{F,A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T}
   h = σ.(Wi*x .+ Wh*h .+ b)
   return h, reshape_cell_output(h, x)
 end
-
-@functor RNNCell
 
 function Base.show(io::IO, l::RNNCell)
   print(io, "RNNCell(", size(l.Wi, 2), " => ", size(l.Wi, 1))
@@ -302,8 +299,6 @@ function (m::LSTMCell{A,V,<:NTuple{2,AbstractMatrix{T}}})((h, c), x::Union{Abstr
   return (h′, c′), reshape_cell_output(h′, x)
 end
 
-@functor LSTMCell
-
 Base.show(io::IO, l::LSTMCell) =
   print(io, "LSTMCell(", size(l.Wi, 2), " => ", size(l.Wi, 1)÷4, ")")
 
@@ -370,8 +365,6 @@ function (m::GRUCell{A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},O
   return h′, reshape_cell_output(h′, x)
 end
 
-@functor GRUCell
-
 Base.show(io::IO, l::GRUCell) =
   print(io, "GRUCell(", size(l.Wi, 2), " => ", size(l.Wi, 1)÷3, ")")
 
@@ -434,8 +427,6 @@ function (m::GRUv3Cell{A,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T}
   h′ = @. (1 - z) * h̃ + z * h
   return h′, reshape_cell_output(h′, x)
 end
-
-@functor GRUv3Cell
 
 Base.show(io::IO, l::GRUv3Cell) =
   print(io, "GRUv3Cell(", size(l.Wi, 2), " => ", size(l.Wi, 1)÷3, ")")

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -125,7 +125,7 @@ julia> rnn.state
  60
 ```
 """
-mutable struct Recur{T,S}
+mutable struct Recur{T,S} <: ContainerLayer
   cell::T
   state::S
 end
@@ -136,7 +136,7 @@ function (m::Recur)(x)
 end
 
 @functor Recur
-trainable(a::Recur) = (; cell = a.cell)
+trainable(a::Recur) = (; cell = a.cell)  # can't use <: PartialTrainLayer
 
 Base.show(io::IO, m::Recur) = print(io, "Recur(", m.cell, ")")
 
@@ -189,7 +189,7 @@ end
 
 # Vanilla RNN
 
-struct RNNCell{F,A,V,S}
+struct RNNCell{F,A,V,S} <: SimpleLayer  # or should it be PartialTrainLayer{(:Wi, :Wh, :b)}?
   σ::F
   Wi::A
   Wh::A
@@ -277,7 +277,7 @@ Recur(m::RNNCell) = Recur(m, m.state0)
 
 # LSTM
 
-struct LSTMCell{A,V,S}
+struct LSTMCell{A,V,S} <: SimpleLayer  # or should it be PartialTrainLayer{(:Wi, :Wh, :b)}?
   Wi::A
   Wh::A
   b::V
@@ -351,7 +351,7 @@ function _gru_output(gxs, ghs, bs)
   return r, z
 end
 
-struct GRUCell{A,V,S}
+struct GRUCell{A,V,S} <: SimpleLayer  # or should it be PartialTrainLayer{(:Wi, :Wh, :b)}?
   Wi::A
   Wh::A
   b::V

--- a/src/layers/types.jl
+++ b/src/layers/types.jl
@@ -1,0 +1,99 @@
+import Adapt, Functors, Optimisers
+
+"""
+    Flux.AbstractLayer
+    
+Supertype for all of Flux's built-in layers.
+
+Layer types are not essential to use your own `struct` with Flux.
+But they do simplify some common interactions:
+
+* Any `l::AbstractLayer` has a method for `Functors.functor`, 
+  thus you need not invoke `@functor`. Note that your `struct` should
+  have the default constructor. (Or something which similarly accepts all of
+  its fields as arguments. It is simplest not to write an inner constructor.)
+
+* Calling `Adapt.adapt` on any `l::AbstractLayer` will recurse using `Functors.fmap`,
+  ensuring that the identification between tied weights is perserved.
+
+* Subtypeing `PartialTrainLayer` marks only some fields as trainable,
+  by overloading `Optimisers.trainable`.
+
+* Some subtypes tell fancy `show` whether to unfold their contents: 
+  `l::ContainerLayer` behaves like `Chain`, while `l::SimpleLayer` behaves like `Dense`.
+"""
+abstract type AbstractLayer end
+
+if VERSION > v"1.9-"
+  function Functors.functor(::Type{T}, x) where {T<:AbstractLayer}
+    namedtuple(x), Splat(paramerterlesstype(T))  # avoids warnings: `splat(x)` is deprecated, use `Splat(x)` instead.
+  end
+else
+  function Functors.functor(::Type{T}, x) where {T<:AbstractLayer}
+    namedtuple(x), Base.splat(paramerterlesstype(T))
+  end
+end
+
+function namedtuple(x::T) where T
+  F = fieldnames(T)
+  NamedTuple{F}(map(sy -> getfield(x, sy), F))
+end
+#=
+@generated function namedtuple(x::T) where T  # doesn't help
+  F = fieldnames(T)
+  G = map(sy -> :(getfield(x, $(QuoteNode(sy)))), F)
+  :(NamedTuple{$F}(($(G...),)))
+end
+=#
+function paramerterlesstype(::Type{T}) where T
+  isstructtype(T) || throw(ArgumentError("paramerterlesstype(T) expects isstructtype(T), got $T"))
+  T.name.wrapper
+end
+
+Adapt.adapt_structure(to, layer::AbstractLayer) = fmap(x -> adapt(to, x), layer)
+
+"""
+    Flux.ContainerLayer <: AbstractLayer
+    
+Supertype for layers such as `Chain` & `Parallel`. Not essential to Flux's functioning, 
+but tells `show` to unfold the contents when this is the outermost struct.
+And (like any `AbstractLayer`) removes the need for `@functor`.
+"""
+abstract type ContainerLayer <: AbstractLayer end
+"""
+    Flux.SimpleLayer <: AbstractLayer
+    
+Supertype for layers such as `Dense` & `Conv`. Not essential to Flux's functioning, 
+but tells `show` how to behave. And (like any `AbstractLayer`) removes the need for `@functor`.
+"""
+abstract type SimpleLayer <: AbstractLayer end
+
+"""
+    Flux.PartialTrainLayer{which} <: SimpleLayer <: AbstractLayer
+
+Supertype for layers such as `BatchNorm` which contain arrays of numbers
+which are not to be optimised during training.
+
+`which` is a tuple of `Symbol`s, indicating the fields of the struct
+that that *do* contain trainable parameters. This is used by a method of
+`Optimisers.trainable`, instead of writing that yourself.
+
+Note that some fields (such as functions, integers, `nothing`) are never
+trainable, and do not need special attention. `Optimisers.trainable` is needed
+only to shield types which would otherwise be trainable, such as arrays of floats.
+
+Also (like any `AbstractLayer`) removes the need for `@functor`,
+and (like `SimpleLayer`) tells `show` not to unfold further.
+"""
+abstract type PartialTrainLayer{which} <: SimpleLayer end
+
+function Optimisers.trainable(layer::PartialTrainLayer{which}) where {which}
+  NamedTuple{which}(map(sy -> getfield(layer, sy), which))
+end
+
+"""
+    Flux.NoTrainLayer <: SimpleLayer <: AbstractLayer
+
+Supertype for layers which contain no trainable parameters.
+"""
+const NoTrainLayer = PartialTrainLayer{(;)}


### PR DESCRIPTION
This proposes to gives Flux's layer types various supertypes.

One reason to like this is that it simplifies the use of `show`. If you have the same supertype as `Chain`, you will be unfolded at top level like it is. No mystery functions to overload. Closes https://github.com/FluxML/Flux.jl/pull/1932, closes #2044

Edit: [568af9b](https://github.com/FluxML/Flux.jl/pull/2028/commits/568af9bafe045a933e92ccd17c1f7da2e86a4f41) goes further: We can define `functor` for this abstract type, eliminating the need to call `@functor`. (It's a pretty mysterious macro, and you can't `@macroexpand` it to have a look.) We can also define `trainable` for some abstract types; maybe that's also less mysterious.

Another is this: `Flux.gpu` and `CUDA.cu` both recursively move things, the latter via Adapt not Functors. Which means `cu` does not preserve tied weights. But if we can rely on the the shared arrays both living within a struct whose type we own (like Chain) then we can convert `cu` to something Functors-based at that boundary. (It's enough for one outer layer to do this -- using weird Dense-like layers marked only with `@functor` within a Chain is fine.)

Note that this supertype is entirely optional. The PR does not change the fact that `functor` is how Flux walks models, etc, and so it does not restrict how you can customise things. It only aims to make it easy to opt-in to the standard behaviours, without a zoo of weird macros. 