### PR TITLE
Add ability to filter `loadmodel!` recursion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,5 @@
 # Flux Release Notes
 
-## v0.13.5
-* `loadmodel!` now supports a [`filter` keyword argument](https://github.com/FluxML/Flux.jl/pull/2041)
-
 ## v0.13.4
 * Added [`PairwiseFusion` layer](https://github.com/FluxML/Flux.jl/pull/1983)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Flux Release Notes
 
+## v0.13.5
+* `loadmodel!` now supports a [`filter` keyword argument](https://github.com/FluxML/Flux.jl/pull/2041)
+
 ## v0.13.4
 * Added [`PairwiseFusion` layer](https://github.com/FluxML/Flux.jl/pull/1983)
 

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -81,7 +81,7 @@ however, attempting to copy a non-zero array to an inactive parameter will throw
 Likewise, copying a `src` value of `false` to any `dst` array is valid,
 but copying a `src` value of `true` will error.
 """
-function loadmodel!(dst, src; filter = Returns(true), cache = Base.IdSet())
+function loadmodel!(dst, src; filter = _ -> true, cache = Base.IdSet())
   ldsts = _filter_children(filter, functor(dst)[1])
   lsrcs = _filter_children(filter, functor(src)[1])
   (keys(ldsts) == keys(lsrcs)) ||

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -33,7 +33,7 @@ _filter_children(f, children::NamedTuple) =
 _filter_children(f, children) = filter(f, children)
 
 """
-    loadmodel!(dst, src; filter = _ -> true)
+    loadmodel!(dst, src)
 
 Copy all the parameters (trainable and non-trainable) from `src` into `dst`.
 
@@ -42,9 +42,6 @@ and calling `copyto!` on parameter arrays or throwing an error when there is a m
 Non-array elements (such as activation functions) are not copied and need not match.
 Zero bias vectors and `bias=false` are considered equivalent
 (see extended help for more details).
-
-Specify the predicate function `filter` to control what is recursed.
-A child node `x` in either `dst` and `src` is skipped when `filter(x) == false`.
 
 # Examples
 ```julia
@@ -66,19 +63,6 @@ false
 
 julia> iszero(dst[2].bias)
 true
-
-julia> src = Chain(Dense(5 => 2), Dropout(0.2), Dense(2 => 1))
-Chain(
-  Dense(5 => 2),                        # 12 parameters
-  Dropout(0.2),
-  Dense(2 => 1),                        # 3 parameters
-)                   # Total: 4 arrays, 15 parameters, 348 bytes.
-
-julia> Flux.loadmodel!(dst, src; filter = x -> !(x isa Dropout)) # skips loading Dropout
-Chain(
-  Dense(5 => 2, tanh),                  # 12 parameters
-  Dense(2 => 1),                        # 3 parameters
-)                   # Total: 4 arrays, 15 parameters, 316 bytes.
 ```
 
 # Extended help

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -28,6 +28,10 @@ _tie_check(dst, src) = true
 
 _bool_tie_check(dst, src) = true
 
+_filter_children(f, children::NamedTuple) =
+  NamedTuple(filter(kv -> f(kv[2]), pairs(children)))
+_filter_children(f, children) = filter(f, children)
+
 """
     loadmodel!(dst, src)
 
@@ -77,9 +81,9 @@ however, attempting to copy a non-zero array to an inactive parameter will throw
 Likewise, copying a `src` value of `false` to any `dst` array is valid,
 but copying a `src` value of `true` will error.
 """
-function loadmodel!(dst, src; cache = Base.IdSet())
-  ldsts, _ = functor(dst)
-  lsrcs, _ = functor(src)
+function loadmodel!(dst, src; filter = Returns(true), cache = Base.IdSet())
+  ldsts = _filter_children(filter, functor(dst)[1])
+  lsrcs = _filter_children(filter, functor(src)[1])
   (keys(ldsts) == keys(lsrcs)) ||
     throw(ArgumentError("Tried to load $src into $dst but the structures do not match."))
 
@@ -91,7 +95,7 @@ function loadmodel!(dst, src; cache = Base.IdSet())
       push!(cache, ldst)
       loadleaf!(ldst, lsrc, err)
     else # this isn't a leaf
-      loadmodel!(ldst, lsrc; cache = cache)
+      loadmodel!(ldst, lsrc; filter = filter, cache = cache)
     end
   end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -504,6 +504,42 @@ end
     # loading into tied weights with absent parameter is bad when the dst != zero
     m2[1].bias .= 1
     @test_throws ErrorException loadmodel!(m1, m2)
+
+    @testset "loadmodel! & filter" begin
+      m1 = Chain(Dense(10, 5), Dense(5, 2, relu))
+      m2 = Chain(Dense(10, 5), Dropout(0.2), Dense(5, 2))
+      m3 = Chain(Dense(10, 5), Dense(5, 2, relu))
+
+      # this will not error cause Dropout is skipped
+      loadmodel!(m1, m2; filter = x -> !(x isa Dropout))
+      @test m1[1].weight == m2[1].weight
+      @test m1[2].weight == m2[3].weight
+
+      # this will not error cause Dropout is skipped
+      loadmodel!(m2, m3; filter = x -> !(x isa Dropout))
+      @test m3[1].weight == m2[1].weight
+      @test m3[2].weight == m2[3].weight
+    end
+
+    @testset "loadmodel! & absent bias" begin
+      m0 = Chain(Dense(2 => 3; bias=false, init = Flux.ones32), Dense(3 => 1))
+      m1 = Chain(Dense(2 => 3; bias = Flux.randn32(3)), Dense(3 => 1))
+      m2 = Chain(Dense(Float32[1 2; 3 4; 5 6], Float32[7, 8, 9]), Dense(3 => 1))
+    
+      Flux.loadmodel!(m1, m2)
+      @test m1[1].bias == 7:9
+      @test sum(m1[1].weight) == 21
+    
+      # load from a model without bias -- should ideally recognise the `false` but `Params` doesn't store it
+      m1 = Flux.loadmodel!(m1, m0)
+      @test iszero(m1[1].bias)
+      @test sum(m1[1].weight) == 6  # written before error
+    
+      # load into a model without bias -- should it ignore the parameter which has no home, or error?
+      m0 = Flux.loadmodel!(m0, m2)
+      @test iszero(m0[1].bias)  # obviously unchanged
+      @test sum(m0[1].weight) == 21
+    end
   end
 
   @testset "destructure" begin
@@ -523,26 +559,6 @@ end
       @test ∇p ≈ destructure(∇m)[1]
     end
   end
-end
-
-@testset "loadmodel! & absent bias" begin
-  m0 = Chain(Dense(2 => 3; bias=false, init = Flux.ones32), Dense(3 => 1))
-  m1 = Chain(Dense(2 => 3; bias = Flux.randn32(3)), Dense(3 => 1))
-  m2 = Chain(Dense(Float32[1 2; 3 4; 5 6], Float32[7, 8, 9]), Dense(3 => 1))
-
-  Flux.loadmodel!(m1, m2)
-  @test m1[1].bias == 7:9
-  @test sum(m1[1].weight) == 21
-
-  # load from a model without bias -- should ideally recognise the `false` but `Params` doesn't store it
-  m1 = Flux.loadmodel!(m1, m0)
-  @test iszero(m1[1].bias)
-  @test sum(m1[1].weight) == 6  # written before error
-
-  # load into a model without bias -- should it ignore the parameter which has no home, or error?
-  m0 = Flux.loadmodel!(m0, m2)
-  @test iszero(m0[1].bias)  # obviously unchanged
-  @test sum(m0[1].weight) == 21
 end
 
 @testset "Train and test mode" begin


### PR DESCRIPTION
This adds a keyword predicate function `recursable` to `loadmodel!`. The leaves of the source and destination models are filtered like `filter(recursable, ldsts)` before recursing. This allows the user to specify leaves that should get skipped.

A common use-case for this feature is when you are trying to load weights to/from a model with some optional non-trainable layer. For example, ResNets might have `Dropout` layers. We want to load the saved weights from these models into an equivalently structured ResNet modulo `Dropout`. This happens in Metalhead.jl.

### PR Checklist

- [x] Tests are added
- [x] ~~Entry in NEWS.md~~
- [x] ~~Documentation, if applicable~~
