### PR TITLE
Mark `track_stats=true` as deprecated

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -529,6 +529,10 @@ function GroupNorm(chs::Int, G::Int, λ=identity;
               affine=true, track_stats=false,
               ϵ=1f-5, momentum=0.1f0)
 
+if track_stats
+  @warn("`track_stats=true` will be removed. Please use `track_stats=false` instead")
+end
+
   chs % G == 0 || error("The number of groups ($(G)) must divide the number of channels ($chs)")
 
   β = affine ? initβ(chs) : nothing

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -432,7 +432,7 @@ function InstanceNorm(chs::Int, λ=identity;
                     ϵ=1f-5, momentum=0.1f0)
 
   if track_stats
-    @warn("`track_stats=true` will be removed. Please use `track_stats=false` instead")
+    Base.depwarn("`track_stats=true` will be removed from InstanceNorm in Flux 0.14. The default value is `track_stats=false`, which will work as before.", :InstanceNorm)
   end
 
   β = affine ? initβ(chs) : nothing
@@ -534,7 +534,7 @@ function GroupNorm(chs::Int, G::Int, λ=identity;
               ϵ=1f-5, momentum=0.1f0)
 
 if track_stats
-  @warn("`track_stats=true` will be removed. Please use `track_stats=false` instead")
+  Base.depwarn("`track_stats=true` will be removed from GroupNorm in Flux 0.14. The default value is `track_stats=false`, which will work as before.", :GroupNorm)
 end
 
   chs % G == 0 || error("The number of groups ($(G)) must divide the number of channels ($chs)")

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -431,6 +431,10 @@ function InstanceNorm(chs::Int, λ=identity;
                     affine=false, track_stats=false,
                     ϵ=1f-5, momentum=0.1f0)
 
+  if track_stats
+    @warn("`track_stats=true` will be removed. Please use `track_stats=false` instead")
+  end
+
   β = affine ? initβ(chs) : nothing
   γ = affine ? initγ(chs) : nothing
   μ = track_stats ? zeros32(chs) : nothing


### PR DESCRIPTION
First job of  the issue #2006. 
`track_stats`  will be removed next breaking Flux release.
First job is only focus to warn that `track_stats` arguments.