### PR TITLE
Fix bug that caused Flux.params(x) call to not be cached (Closes issue #2040)

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -36,7 +36,7 @@ Possible values include:
 """
 trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
 
-params!(p::Params, x::AbstractArray{<:Number}, seen = IdSet()) = Functors.isleaf(x) && push!(p, x)
+params!(p::Params, x::DenseArray{<:Number}, seen = IdSet()) = Functors.isleaf(x) && push!(p, x)
 
 function params!(p::Params, x, seen = IdSet())
   x in seen && return

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -36,16 +36,14 @@ Possible values include:
 """
 trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
 
+params!(p::Params, x::AbstractArray{<:Number}, seen = IdSet()) = Functors.isleaf(x) && push!(p, x)
+
 function params!(p::Params, x, seen = IdSet())
-  if x isa AbstractArray{<:Number} && Functors.isleaf(x)
-    return push!(p, x)
-  elseif x in seen
-    nothing
-  else
-    push!(seen, x)
-    for child in trainable(x)
-      params!(p, child, seen)
-    end
+  x in seen && return
+
+  push!(seen, x)
+  for child in trainable(x)
+    params!(p, child, seen)
   end
 end
 


### PR DESCRIPTION
Should this PR be accepted, it would close issue #2040 which was caused by constant recompilation causing massive slowdowns when using the GPU.

I am pretty sure that this has the exact same behaviour as in v0.13.5. I reverted to the v0.13.4 version of `params!()` and added a check for `isleaf(x)` when `x` is an `AbstractArray{<:Number}`.

Let me know if any changes need to be made.