### PR TITLE
Make params non-differentiable (Closes #2040 & #2048)

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -88,7 +88,7 @@ function params(m...)
   return ps
 end
 
-# Allows caching of the parameters when params is called within gradient()
+# Allows caching of the parameters when params is called within gradient() to fix #2040.
 @non_differentiable params(m...)
 
 struct FluxCUDAAdaptor end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -88,6 +88,9 @@ function params(m...)
   return ps
 end
 
+# Allows caching of the parameters when params is called within gradient()
+@non_differentiable params(m...)
+
 struct FluxCUDAAdaptor end
 adapt_storage(to::FluxCUDAAdaptor, x) = CUDA.cu(x)
 adapt_storage(to::FluxCUDAAdaptor, x::Zygote.FillArrays.AbstractFill) = CUDA.cu(collect(x))


### PR DESCRIPTION
This is the new pull request I mentioned in #2048 to allow `params()` calls from within `gradient()` to be cached by making `params()` non-differentiable. This would close issue #2040, and supersede pull request #2048.

Might be worth turning on downstream test like in the other pr.
