### PR TITLE
Speed up `show` for gpu models

### DIFF
--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -113,7 +113,10 @@ underscorise(n::Integer) =
   join(reverse(join.(reverse.(Iterators.partition(digits(n), 3)))), '_')
 
 function _nan_show(io::IO, x)
-  if !isempty(x) && _all(iszero, x)
+  if any(y -> y isa Zygote.AbstractGPUArray, x)
+    # These friendly warnings take 10-20 sec to compile the first time, for models on GPU. 
+    printstyled(io, " (on GPU)", color=:light_black)
+  elseif !isempty(x) && _all(iszero, x)
     printstyled(io, "  (all zero)", color=:cyan)
   elseif _any(isnan, x)
     printstyled(io, "  (some NaN)", color=:red)


### PR DESCRIPTION
The present `show` methods have about a 20s startup delay when the model is on the GPU. This comes from the checks like `any(isnan, x)` which print friendly warnings. Perhaps we should remove them, to save startup time?

This PR replaces them with an "(on GPU)" annotation, like so:
```
julia> m
Chain(
  Dense(2 => 3, σ),                     # 9 parameters
  Dense(3 => 2),                        # 8 parameters  (some NaN)
  NNlib.softmax,
)                   # Total: 4 arrays, 17 parameters, 324 bytes.

julia> m |> gpu
Chain(
  Dense(2 => 3, σ),                     # 9 parameters (on GPU)
  Dense(3 => 2),                        # 8 parameters (on GPU)
  NNlib.softmax,
)                   # Total: 4 arrays, 17 parameters, 576 bytes.
```
Maybe that ends up quite noisy for bigger models. For this reason I didn't make it some bright colour. 