### PR TITLE
Add an example to the readme?

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <div align="center">
 
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://fluxml.github.io/Flux.jl/stable/) [![](https://img.shields.io/badge/chat-on%20slack-yellow.svg)](https://julialang.org/slack/) [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac) [![DOI](https://joss.theoj.org/papers/10.21105/joss.00602/status.svg)](https://doi.org/10.21105/joss.00602)
-
+<br/>
 [![][action-img]][action-url] [![][codecov-img]][codecov-url]
 
 </div>
@@ -17,6 +17,7 @@
 
 Flux is an elegant approach to machine learning. It's a 100% pure-Julia stack, and provides lightweight abstractions on top of Julia's native GPU and AD support. Flux makes the easy things easy while remaining fully hackable.
 
+Works best with [Julia 1.8](https://julialang.org/downloads/) or later. This will install everything (including CUDA) and solve the XOR problem:
 ```julia
 using Flux
 
@@ -33,6 +34,6 @@ Flux.train!(loss, Flux.params(model), data, optim)
 all((model(x) .> 0.5) .== y)
 ```
 
-See the [documentation](https://fluxml.github.io/Flux.jl/) or the [model zoo](https://github.com/FluxML/model-zoo/) for examples.
+See the [documentation](https://fluxml.github.io/Flux.jl/) for details, the [website](https://fluxml.ai/tutorials.html) for tutorials, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples.
 
 If you use Flux in your research, please [cite](CITATION.bib) our work.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <div align="center">
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://fluxml.github.io/Flux.jl/stable/) [![](https://img.shields.io/badge/chat-on%20slack-yellow.svg)](https://julialang.org/slack/) [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac) [![DOI](https://joss.theoj.org/papers/10.21105/joss.00602/status.svg)](https://doi.org/10.21105/joss.00602)
+[![](https://img.shields.io/badge/Documentation-stable-blue.svg)](https://fluxml.github.io/Flux.jl/stable/) [![DOI](https://joss.theoj.org/papers/10.21105/joss.00602/status.svg)](https://doi.org/10.21105/joss.00602) [![Flux Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Flux)](https://pkgs.genieframework.com?packages=Flux)
 <br/>
-[![][action-img]][action-url] [![][codecov-img]][codecov-url]
+[![][action-img]][action-url] [![][codecov-img]][codecov-url] [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
 </div>
 
@@ -34,6 +34,6 @@ Flux.train!(loss, Flux.params(model), data, optim)  # updates model & optim
 all((model(x) .> 0.5) .== y)  # usually 100% accuracy.
 ```
 
-See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples.
+See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples. Ask questions on the [Julia discourse](https://discourse.julialang.org/) or [slack](https://discourse.julialang.org/t/announcing-a-julia-slack/4866).
 
 If you use Flux in your research, please [cite](CITATION.bib) our work.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Flux is an elegant approach to machine learning. It's a 100% pure-Julia stack, and provides lightweight abstractions on top of Julia's native GPU and AD support. Flux makes the easy things easy while remaining fully hackable.
 
-Works best with [Julia 1.8](https://julialang.org/downloads/) or later. This will install everything (including CUDA) and solve the XOR problem:
+Works best with [Julia 1.8](https://julialang.org/downloads/) or later. Pasting this in at the Julia prompt will install everything (including CUDA) and solve the XOR problem:
 ```julia
 using Flux
 
@@ -34,6 +34,6 @@ Flux.train!(loss, Flux.params(model), data, optim)
 all((model(x) .> 0.5) .== y)
 ```
 
-See the [documentation](https://fluxml.github.io/Flux.jl/) for details, the [website](https://fluxml.ai/tutorials.html) for tutorials, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples.
+See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples.
 
 If you use Flux in your research, please [cite](CITATION.bib) our work.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ x = hcat(digits.(0:3, base=2, pad=2)...) |> gpu  # let's solve the XOR problem!
 y = Flux.onehotbatch(xor.(eachrow(x)...), 0:1) |> gpu
 data = ((Float32.(x), y) for _ in 1:100)  # an iterator making Tuples
 
-model = Chain(Dense(2 => 3, sigmoid), BatchNorm(3), Dense(3 => 2), softmax) |> gpu
+model = Chain(Dense(2 => 3, sigmoid), BatchNorm(3), Dense(3 => 2)) |> gpu
 optim = Adam(0.1, (0.7, 0.95))
-loss(x, y) = Flux.crossentropy(model(x), y)
+loss(x, y) = Flux.logitcrossentropy(model(x), y)
 
 Flux.train!(loss, Flux.params(model), data, optim)  # updates model & optim
 
-all((model(x) .> 0.5) .== y)  # usually 100% accuracy.
+all((softmax(model(x)) .> 0.5) .== y)  # usually 100% accuracy.
 ```
 
 See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples. Ask questions on the [Julia discourse](https://discourse.julialang.org/) or [slack](https://discourse.julialang.org/t/announcing-a-julia-slack/4866).

--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@
 
 Flux is an elegant approach to machine learning. It's a 100% pure-Julia stack, and provides lightweight abstractions on top of Julia's native GPU and AD support. Flux makes the easy things easy while remaining fully hackable.
 
-Works best with [Julia 1.8](https://julialang.org/downloads/) or later. Pasting this in at the Julia prompt will install everything (including CUDA) and solve the XOR problem:
+Works best with [Julia 1.8](https://julialang.org/downloads/) or later. Here's a simple example to try it out:
 ```julia
-using Flux
+using Flux  # should install everything for you, including CUDA
 
-x = hcat(digits.(0:3, base=2, pad=2)...) |> gpu
+x = hcat(digits.(0:3, base=2, pad=2)...) |> gpu  # let's solve the XOR problem!
 y = Flux.onehotbatch(xor.(eachrow(x)...), 0:1) |> gpu
-data = ((Float32.(x), y) for _ in 1:100)
+data = ((Float32.(x), y) for _ in 1:100)  # an iterator making Tuples
 
 model = Chain(Dense(2 => 3, sigmoid), BatchNorm(3), Dense(3 => 2), softmax) |> gpu
 optim = Adam(0.1, (0.7, 0.95))
 loss(x, y) = Flux.crossentropy(model(x), y)
 
-Flux.train!(loss, Flux.params(model), data, optim)
+Flux.train!(loss, Flux.params(model), data, optim)  # updates model & optim
 
-all((model(x) .> 0.5) .== y)
+all((model(x) .> 0.5) .== y)  # usually 100% accuracy.
 ```
 
 See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ data = ((Float32.(x), y) for _ in 1:100)  # an iterator making Tuples
 
 model = Chain(Dense(2 => 3, sigmoid), BatchNorm(3), Dense(3 => 2)) |> gpu
 optim = Adam(0.1, (0.7, 0.95))
-loss(x, y) = Flux.logitcrossentropy(model(x), y)
+mloss(x, y) = Flux.logitcrossentropy(model(x), y)  # closes over model
 
-Flux.train!(loss, Flux.params(model), data, optim)  # updates model & optim
+Flux.train!(mloss, Flux.params(model), data, optim)  # updates model & optim
 
 all((softmax(model(x)) .> 0.5) .== y)  # usually 100% accuracy.
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 <img width="400px" src="https://raw.githubusercontent.com/FluxML/fluxml.github.io/master/logo.png"/>
 </p>
 
-[![][action-img]][action-url] [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://fluxml.github.io/Flux.jl/stable/) [![](https://img.shields.io/badge/chat-on%20slack-yellow.svg)](https://julialang.org/slack/) [![DOI](https://joss.theoj.org/papers/10.21105/joss.00602/status.svg)](https://doi.org/10.21105/joss.00602) [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac) [![][codecov-img]][codecov-url]
+<div align="center">
+
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://fluxml.github.io/Flux.jl/stable/) [![](https://img.shields.io/badge/chat-on%20slack-yellow.svg)](https://julialang.org/slack/) [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac) [![DOI](https://joss.theoj.org/papers/10.21105/joss.00602/status.svg)](https://doi.org/10.21105/joss.00602)
+
+[![][action-img]][action-url] [![][codecov-img]][codecov-url]
+
+</div>
 
 [action-img]: https://github.com/FluxML/Flux.jl/workflows/CI/badge.svg
 [action-url]: https://github.com/FluxML/Flux.jl/actions
@@ -12,7 +18,19 @@
 Flux is an elegant approach to machine learning. It's a 100% pure-Julia stack, and provides lightweight abstractions on top of Julia's native GPU and AD support. Flux makes the easy things easy while remaining fully hackable.
 
 ```julia
-] add Flux
+using Flux
+
+x = hcat(digits.(0:3, base=2, pad=2)...) |> gpu
+y = Flux.onehotbatch(xor.(eachrow(x)...), 0:1) |> gpu
+data = ((Float32.(x), y) for _ in 1:100)
+
+model = Chain(Dense(2 => 3, sigmoid), BatchNorm(3), Dense(3 => 2), softmax) |> gpu
+optim = Adam(0.1, (0.7, 0.95))
+loss(x, y) = Flux.crossentropy(model(x), y)
+
+Flux.train!(loss, Flux.params(model), data, optim)
+
+all((model(x) .> 0.5) .== y)
 ```
 
 See the [documentation](https://fluxml.github.io/Flux.jl/) or the [model zoo](https://github.com/FluxML/model-zoo/) for examples.


### PR DESCRIPTION
This proposes to add a very simple Flux model to the readme. Almost the simplest thing I could think of, which actually works. 

It's nice to see code right away. I guess it won't make sense if you've never seen a neural network, but if you've ever tried any demo elsewhere, this should look familiar, and point out the main features. Including (I hope) that batch dims are last, that the model is a mutable object, how to move to GPU, what arguments `train!` needs (and in what order). 

Without BatchNorm this works 90% of the time, with default Adam() too just 80%. So the post-1969 details are doing something.

On Julia 1.7+, just pasting this in will install everything including CUDA. ~~Maybe it should say that. I didn't want to put too many words.~~ Now it does.