### PR TITLE
Stop training on Inf/NaN loss

### DIFF
--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -105,8 +105,10 @@ The optimiser should be from the `Flux.Optimise` module (see [Optimisers](@ref))
 Different optimisers can be combined using [`Flux.Optimise.Optimiser`](@ref Flux.Optimiser).
 
 This training loop iterates through `data` once.
+It will stop with a `DomainError` if the loss is `NaN` or infinite.
+
 You can use [`@epochs`](@ref) to do this several times, or 
-use for instance `Iterators.repeat` to make a longer `data` iterator.
+use for instance `Itertools.ncycle` to make a longer `data` iterator.
 
 ## Callbacks
 
@@ -130,8 +132,7 @@ function train!(loss, ps::Params, data, opt::AbstractOptimiser; cb = () -> ())
         loss(batchmemaybe(d)...)
       end
       if !isfinite(l)
-        @warn "Loss is $l on item $i, stopping training"
-        break
+        throw(DomainError("Loss is $l on data item $i, stopping training"))
       end
       update!(opt, ps, gs)
       cb()

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -91,7 +91,7 @@ end
   m = Dense(1 => 1)
   m.weight .= 0
   CNT = 0
-  Flux.train!(Flux.params(m), 1:100, Descent(0.1)) do i
+  @test_throws DomainError Flux.train!(Flux.params(m), 1:100, Descent(0.1)) do i
     CNT += 1
     (i == 51 ? NaN32 : 1f0) * sum(m([1.0]))
   end

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -87,6 +87,18 @@ end
   Flux.train!(loss, Flux.params(r), (r,), Descent())
 end
 
+@testset "Stop on NaN" begin
+  m = Dense(1 => 1)
+  m.weight .= 0
+  CNT = 0
+  Flux.train!(Flux.params(m), 1:100, Descent(0.1)) do i
+    CNT += 1
+    i > 50 ? NaN32 : sum(m([1.0]))
+  end
+  @test m.weight[1] ≈ -5  # did not corrupt weights
+  @test CNT == 51  # stopped early
+end
+
 @testset "ExpDecay" begin
 
   @testset "Sanity Check" begin

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -93,7 +93,7 @@ end
   CNT = 0
   Flux.train!(Flux.params(m), 1:100, Descent(0.1)) do i
     CNT += 1
-    i == 51 ? NaN32 : sum(m([1f0]))
+    (i == 51 ? NaN32 : 1f0) * sum(m([1.0]))
   end
   @test CNT == 51  # stopped early
   @test m.weight[1] ≈ -5  # did not corrupt weights

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -93,10 +93,10 @@ end
   CNT = 0
   Flux.train!(Flux.params(m), 1:100, Descent(0.1)) do i
     CNT += 1
-    i > 50 ? NaN32 : sum(m([1.0]))
+    i == 51 ? NaN32 : sum(m([1f0]))
   end
-  @test m.weight[1] ≈ -5  # did not corrupt weights
   @test CNT == 51  # stopped early
+  @test m.weight[1] ≈ -5  # did not corrupt weights
 end
 
 @testset "ExpDecay" begin


### PR DESCRIPTION
Closes #1981, by altering `train!` so that when it encounters an infinite / NaN loss, it ~~prints a warning~~ throws an error, and stops. It stops before updating the model, because such an update will usually make everything NaN.

Not sure it should stop, in fact. Maybe it should skip that datapoint & continue?

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
