### PR TITLE
Add `@autosize`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Flux Release Notes
 
+## v0.13.7
+* Added [`@autosize` macro](https://github.com/FluxML/Flux.jl/pull/2078)
+
 ## v0.13.4
 * Added [`PairwiseFusion` layer](https://github.com/FluxML/Flux.jl/pull/1983)
 

--- a/docs/src/outputsize.md
+++ b/docs/src/outputsize.md
@@ -27,7 +27,7 @@ The function `outputsize` works by passing a "dummy" array into the model, which
 It should work for all layers, including custom layers, out of the box.
 
 An example of how to automate model building is this:
-```jldoctest; output = false
+```jldoctest; output = false, setup = :(using Flux)
 """
     make_model(width, height, [inchannels, nclasses; layer_config])
 

--- a/docs/src/outputsize.md
+++ b/docs/src/outputsize.md
@@ -27,7 +27,7 @@ The function `outputsize` works by passing a "dummy" array into the model, which
 It should work for all layers, including custom layers, out of the box.
 
 An example of how to automate model building is this:
-```julia
+```jldoctest; output = false
 """
     make_model(width, height, [inchannels, nclasses; layer_config])
 
@@ -57,6 +57,10 @@ end
 m = make_model(28, 28, 3, layer_config = [9, 17, 33, 65])
 
 Flux.outputsize(m, (28, 28, 3, 42)) == (10, 42) == size(m(randn(Float32, 28, 28, 3, 42)))
+
+# output
+
+true
 ```
 
 Alternatively, using the macro, the definition of `make_model` could end with:

--- a/docs/src/outputsize.md
+++ b/docs/src/outputsize.md
@@ -5,17 +5,18 @@ of arrays that layers will recieve, without doing any computation.
 This is especially useful for convolutional models, where the same [`Conv`](@ref) layer
 accepts any size of image, but the next layer may not. 
 
-The higher-level one is a macro [`@autosize`](@ref) which acts on the code defining the layers,
-and replaces each appearance of `_` with the relevant size. A simple example might be:
+The higher-level tool is a macro [`@autosize`](@ref) which acts on the code defining the layers,
+and replaces each appearance of `_` with the relevant size. This simple example returns a model
+with `Dense(845 => 10)` as the last layer:
 
 ```julia
 @autosize (28, 28, 1, 32) Chain(Conv((3, 3), _ => 5, relu, stride=2), Flux.flatten, Dense(_ => 10))
 ```
 
-The size may be provided at runtime, like `@autosize (sz..., 1, 32) Chain(Conv(`..., but all the
+The input size may be provided at runtime, like `@autosize (sz..., 1, 32) Chain(Conv(`..., but all the
 layer constructors containing `_` must be explicitly written out -- the macro sees the code as written.
 
-This relies on a lower-level function [`outputsize`](@ref Flux.outputsize), which you can also use directly:
+This macro relies on a lower-level function [`outputsize`](@ref Flux.outputsize), which you can also use directly:
 
 ```julia
 c = Conv((3, 3), 1 => 5, relu, stride=2)
@@ -53,7 +54,9 @@ function make_model(width, height, inchannels = 1, nclasses = 10;
   return Chain(conv_layers..., Flux.flatten, last_layer)
 end
 
-make_model(28, 28, 3, layer_config = [8, 17, 33, 65])
+m = make_model(28, 28, 3, layer_config = [9, 17, 33, 65])
+
+Flux.outputsize(m, (28, 28, 3, 42)) == (10, 42) == size(m(randn(Float32, 28, 28, 3, 42)))
 ```
 
 Alternatively, using the macro, the definition of `make_model` could end with:

--- a/docs/src/outputsize.md
+++ b/docs/src/outputsize.md
@@ -1,47 +1,72 @@
 # Shape Inference
 
-To help you generate models in an automated fashion, [`Flux.outputsize`](@ref) lets you 
-calculate the size returned produced by layers for a given size input.
-This is especially useful for layers like [`Conv`](@ref).
+Flux has some tools to help generate models in an automated fashion, by inferring the size
+of arrays that layers will recieve, without doing any computation. 
+This is especially useful for convolutional models, where the same [`Conv`](@ref) layer
+accepts any size of image, but the next layer may not. 
 
-It works by passing a "dummy" array into the model that preserves size information without running any computation.
-`outputsize(f, inputsize)` works for all layers (including custom layers) out of the box.
-By default, `inputsize` expects the batch dimension,
-but you can exclude the batch size with `outputsize(f, inputsize; padbatch=true)` (assuming it to be one).
+The higher-level one is a macro [`@autosize`](@ref) which acts on the code defining the layers,
+and replaces each appearance of `_` with the relevant size. A simple example might be:
 
-Using this utility function lets you automate model building for various inputs like so:
+```julia
+@autosize (28, 28, 1, 32) Chain(Conv((3, 3), _ => 5, relu, stride=2), Flux.flatten, Dense(_ => 10))
+```
+
+The size may be provided at runtime, like `@autosize (sz..., 1, 32) Chain(Conv(`..., but all the
+layer constructors containing `_` must be explicitly written out -- the macro sees the code as written.
+
+This relies on a lower-level function [`outputsize`](@ref Flux.outputsize), which you can also use directly:
+
+```julia
+c = Conv((3, 3), 1 => 5, relu, stride=2)
+Flux.outputsize(c, (28, 28, 1, 32))  # returns (13, 13, 5, 32)
+```
+
+The function `outputsize` works by passing a "dummy" array into the model, which propagates through very cheaply.
+It should work for all layers, including custom layers, out of the box.
+
+An example of how to automate model building is this:
 ```julia
 """
-    make_model(width, height, inchannels, nclasses;
-               layer_config = [16, 16, 32, 32, 64, 64])
+    make_model(width, height, [inchannels, nclasses; layer_config])
 
-Create a CNN for a given set of configuration parameters.
-
-# Arguments
-- `width`: the input image width
-- `height`: the input image height
-- `inchannels`: the number of channels in the input image
-- `nclasses`: the number of output classes
-- `layer_config`: a vector of the number of filters per each conv layer
+Create a CNN for a given set of configuration parameters. Arguments:
+- `width`, `height`: the input image size in pixels
+- `inchannels`: the number of channels in the input image, default `1`
+- `nclasses`: the number of output classes, default `10`
+- Keyword `layer_config`: a vector of the number of filters per layer, default `[16, 16, 32, 64]`
 """
-function make_model(width, height, inchannels, nclasses;
-                    layer_config = [16, 16, 32, 32, 64, 64])
-  # construct a vector of conv layers programmatically
-  conv_layers = [Conv((3, 3), inchannels => layer_config[1])]
-  for (infilters, outfilters) in zip(layer_config, layer_config[2:end])
-    push!(conv_layers, Conv((3, 3), infilters => outfilters))
+function make_model(width, height, inchannels = 1, nclasses = 10;
+                    layer_config = [16, 16, 32, 64])
+  # construct a vector of layers:
+  conv_layers = []
+  push!(conv_layers, Conv((5, 5), inchannels => layer_config[1], relu, pad=SamePad()))
+  for (inch, outch) in zip(layer_config, layer_config[2:end])
+    push!(conv_layers, Conv((3, 3), inch => outch, sigmoid, stride=2))
   end
 
-  # compute the output dimensions for the conv layers
-  # use padbatch=true to set the batch dimension to 1
-  conv_outsize = Flux.outputsize(conv_layers, (width, height, nchannels); padbatch=true)
+  # compute the output dimensions after these conv layers:
+  conv_outsize = Flux.outputsize(conv_layers, (width, height, inchannels); padbatch=true)
 
-  # the input dimension to Dense is programatically calculated from
-  #  width, height, and nchannels
-  return Chain(conv_layers..., Dense(prod(conv_outsize) => nclasses))
+  # use this to define appropriate Dense layer:
+  last_layer = Dense(prod(conv_outsize) => nclasses)
+  return Chain(conv_layers..., Flux.flatten, last_layer)
+end
+
+make_model(28, 28, 3, layer_config = [8, 17, 33, 65])
+```
+
+Alternatively, using the macro, the definition of `make_model` could end with:
+
+```
+  # compute the output dimensions & construct appropriate Dense layer:
+  return @autosize (width, height, inchannels, 1) Chain(conv_layers..., Flux.flatten, Dense(_ => nclasses))
 end
 ```
 
+### Listing
+
 ```@docs
+Flux.@autosize
 Flux.outputsize
 ```

--- a/docs/src/outputsize.md
+++ b/docs/src/outputsize.md
@@ -35,7 +35,7 @@ Create a CNN for a given set of configuration parameters. Arguments:
 - `width`, `height`: the input image size in pixels
 - `inchannels`: the number of channels in the input image, default `1`
 - `nclasses`: the number of output classes, default `10`
-- Keyword `layer_config`: a vector of the number of filters per layer, default `[16, 16, 32, 64]`
+- Keyword `layer_config`: a vector of the number of channels per layer, default `[16, 16, 32, 64]`
 """
 function make_model(width, height, inchannels = 1, nclasses = 10;
                     layer_config = [16, 16, 32, 64])

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -55,6 +55,7 @@ include("layers/show.jl")
 include("loading.jl")
 
 include("outputsize.jl")
+export @autosize
 
 include("data/Data.jl")
 using .Data

--- a/src/outputsize.jl
+++ b/src/outputsize.jl
@@ -261,16 +261,6 @@ function _underscoredepth(ex::Expr)
 end
 _underscoredepth(ex) = Int(ex == :_)
 
-#=
-
-@autosize (3,) Chain(one = Dense(_ => 4), two = softmax)  # needs kw
-@autosize (3, 45) Maxout(() -> Dense(_ => 6, tanh), 2)    # needs ->, block
-
-# here Parallel gets two inputs, no problem:
-@autosize (3,) Chain(SkipConnection(Dense(_ => 4), Parallel(vcat, Dense(_ => 5), Dense(_ => 6))), Flux.Scale(_))
-
-=#
-
 function _makefun(ex)
   T = Meta.isexpr(ex, :call) ? ex.args[1] : Type
   @gensym x s

--- a/test/outputsize.jl
+++ b/test/outputsize.jl
@@ -142,16 +142,81 @@ end
   m = LayerNorm(32)
   @test outputsize(m, (32, 32, 3, 16)) == (32, 32, 3, 16)
   @test outputsize(m, (32, 32, 3); padbatch=true) == (32, 32, 3, 1)
+  m2 = LayerNorm(3, 2)
+  @test outputsize(m2, (3, 2)) == (3, 2) == size(m2(randn(3, 2)))
+  @test outputsize(m2, (3,)) == (3, 2) == size(m2(randn(3, 2)))
 
   m = BatchNorm(3)
   @test outputsize(m, (32, 32, 3, 16)) == (32, 32, 3, 16)
   @test outputsize(m, (32, 32, 3); padbatch=true) == (32, 32, 3, 1)
+  @test_throws Exception m(randn(Float32, 32, 32, 5, 1))
+  @test_throws DimensionMismatch outputsize(m, (32, 32, 5, 1))
 
   m = InstanceNorm(3)
   @test outputsize(m, (32, 32, 3, 16)) == (32, 32, 3, 16)
   @test outputsize(m, (32, 32, 3); padbatch=true) == (32, 32, 3, 1)
+  @test_throws Exception m(randn(Float32, 32, 32, 5, 1))
+  @test_throws DimensionMismatch outputsize(m, (32, 32, 5, 1))
 
   m = GroupNorm(16, 4)
   @test outputsize(m, (32, 32, 16, 16)) == (32, 32, 16, 16)
   @test outputsize(m, (32, 32, 16); padbatch=true) == (32, 32, 16, 1)
+  @test_throws Exception m(randn(Float32, 32, 32, 15, 4))
+  @test_throws DimensionMismatch outputsize(m, (32, 32, 15, 4))
+end
+
+@testset "autosize macro" begin
+  m = @autosize (3,) Dense(_ => 4)
+  @test randn(3) |> m |> size == (4,)
+
+  m = @autosize (3, 1) Chain(Dense(_ => 4), Dense(4 => 10), softmax)
+  @test randn(3, 5) |> m |> size == (10, 5)
+  
+  m = @autosize (2, 3, 4, 5) Dense(_ => 10)  # goes by first dim, not 2nd-last
+  @test randn(2, 3, 4, 5) |> m |> size == (10, 3, 4, 5)
+  
+  m = @autosize (9,) Dense(_ => div(_,2))
+  @test randn(9) |> m |> size == (4,)
+
+  m = @autosize (3,) Chain(one = Dense(_ => 4), two = softmax)  # needs kw
+  @test randn(3) |> m |> size == (4,)
+
+  m = @autosize (3, 45) Maxout(() -> Dense(_ => 6, tanh), 2)    # needs ->, block
+  @test randn(3, 45) |> m |> size == (6, 45)
+
+  # here Parallel gets two inputs, no problem:
+  m = @autosize (3,) Chain(SkipConnection(Dense(_ => 4), Parallel(vcat, Dense(_ => 5), Dense(_ => 6))), Flux.Scale(_))
+  @test randn(3) |> m |> size == (11,)
+  
+  # like Dense, LayerNorm goes by the first dimension:
+  m = @autosize (3, 4, 5) LayerNorm(_)
+  @test rand(3, 6, 7) |> m |> size == (3, 6, 7)
+
+  m = @autosize (3, 3, 10) LayerNorm(_, _)  # does not check that sizes match
+  @test rand(3, 3, 10) |> m |> size == (3, 3, 10)
+  
+  m = @autosize (3,) Flux.Bilinear(_ => 10)
+  @test randn(3) |> m |> size == (10,)
+
+  m = @autosize (3, 1) Flux.Bilinear(_ => 10)
+  @test randn(3, 4) |> m |> size == (10, 4)
+  
+  @test_throws Exception @eval @autosize (3,) Flux.Bilinear((_,3) => 10)
+  
+  # first docstring example
+  m = @autosize (3, 1) Chain(Dense(_ => 2, sigmoid), BatchNorm(_, affine=false))
+  @test randn(3, 4) |> m |> size == (2, 4)
+  
+  # evil docstring example
+  img = [28, 28];
+  m = @autosize (img..., 1, 32) Chain(              # size is only needed at runtime
+         Chain(c = Conv((3,3), _ => 5; stride=2, pad=SamePad()),
+               p = MeanPool((3,3)),
+               b = BatchNorm(_),
+               f = Flux.flatten),
+         Dense(_ => _÷4, relu, init=Flux.rand32),   # can calculate output size _÷4
+         SkipConnection(Dense(_ => _, relu), +),
+         Dense(_ => 10),
+      ) |> gpu                                      # moves to GPU after initialisation
+  @test randn(Float32, img..., 1, 32) |> gpu |> m |> size == (10, 32)
 end


### PR DESCRIPTION
The macro replaces `_` with an inferred input size:
```julia
julia> @autosize (2,3,4) Chain(Dense(_ => 5, tanh), Flux.flatten, Maxout(() -> Dense(_ => 3), 2))
Chain(
  Dense(2 => 5, tanh),                  # 15 parameters
  Flux.flatten,
  Maxout(
    Dense(15 => 3),                     # 48 parameters
    Dense(15 => 3),                     # 48 parameters
  ),
)                   # Total: 6 arrays, 111 parameters, 892 bytes.

julia> ans(rand(2,3,4)) |> size
(3, 4)
```

### PR Checklist

- [x] Tests are added
- [x] Entry in NEWS.md
- [x] Documentation, if applicable
