### PR TITLE
Safer gradients (by copying before mutating) & less piracy (by removing ArrayInterface)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.13.7"
+version = "0.13.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
@@ -27,7 +26,6 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Adapt = "3.0"
-ArrayInterface = "3.1, 4, 5, 6"
 CUDA = "3"
 ChainRulesCore = "1.12"
 Functors = "0.3"

--- a/src/optimise/Optimise.jl
+++ b/src/optimise/Optimise.jl
@@ -1,7 +1,6 @@
 module Optimise
 
 using LinearAlgebra
-import ArrayInterface
 
 export train!, update!,
 	Descent, Adam, Momentum, Nesterov, RMSProp,

--- a/src/optimise/train.jl
+++ b/src/optimise/train.jl
@@ -13,8 +13,8 @@ As a result, the parameters are mutated and the optimizer's internal state may c
 The gradient could be mutated as well.
 """
 function update!(opt::AbstractOptimiser, x, x̄)
-  x̄r = ArrayInterface.restructure(x, x̄) # address some cases where Zygote's
-                                          # output are not mutable, see #1510 
+  x̄r = copyto!(similar(x̄), x̄)  # Flux.Optimise assumes it can mutate the gradient. This is not
+                               # safe due to aliasing, nor guaranteed to be possible, e.g. Fill.
   x .-= apply!(opt, x, x̄r)
 end
 


### PR DESCRIPTION
#1613 added a check to work around the fact that Zygote may return an immutable array as a gradient, and Flux.Optimise likes to mutate them. However, such mutation isn't actually safe, as there is no guarantee that arrays in the gradient do not alias each other. So this PR inserts a copy instead.

#1613 also added a dep on ArrayInterface. This was supposed to provide a safe function for turning immutable arrays into mutable ones. But in reality, ArrayInterface is pretty experimental, and its piracy causes the following problem, noticed today:
```
using Flux, StaticArrays; setindex((@SMatrix [1 0 ; 1 1]), 5, 1, 1)

ERROR: MethodError: setindex(::SMatrix{2, 2, Int64, 4}, ::Int64, ::Int64, ::Int64) is ambiguous. Candidates:
 setindex(a::StaticArray, x, inds...) in StaticArrays at /home/jonathan/.julia/packages/StaticArrays/PUoe1/src/deque.jl:198
 setindex(x::AbstractMatrix, v, i::Int64, j::Int64) in ArrayInterface at /home/jonathan/.julia/packages/ArrayInterface/R0AhD/src/ArrayInterface.jl:199
```
Flux does commit some piracy, but should aim to commit less. And especially not in wildly unrelated functions it has no reason to be anywhere near. 

The extra copy here may cost some speed. We could instead preserve (legacy, unsafe) behaviour in 99% of cases by just testing `Union{Array, CuArray}`. Deleting Flux.Optimise soon should be a goal. 