### PR TITLE
Remove type restrictions on normalization layers' scale and bias

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -322,10 +322,10 @@ julia> isapprox(std(m(xs)), 1, atol=0.1) && std(xs) != std(m(xs))
 true
 ```
 """
-mutable struct BatchNorm{F,V,U,N,W}
+mutable struct BatchNorm{F,B,S,N,W}
   λ::F  # activation function
-  β::V  # bias
-  γ::U  # scale
+  β::B  # bias
+  γ::S  # scale
   μ::W     # moving mean
   σ²::W    # moving var
   ϵ::N
@@ -412,10 +412,10 @@ julia> isapprox(std(y, dims=1:2), ones(1, 1, 3, 2), atol=0.2) && std(y, dims=1:2
 true
 ```
 """
-mutable struct InstanceNorm{F,V,U,N,W}
+mutable struct InstanceNorm{F,B,S,N,W}
   λ::F  # activation function
-  β::V  # bias
-  γ::U  # scale
+  β::B  # bias
+  γ::S  # scale
   μ::W  # moving mean
   σ²::W  # moving var
   ϵ::N
@@ -510,11 +510,11 @@ julia> isapprox(std(y[:, :, 3:4, 2]), 1, atol=0.1) && std(xs[:, :, 3:4, 2]) != s
 true
 ```
 """
-mutable struct GroupNorm{F,V,U,N,W}
+mutable struct GroupNorm{F,B,S,N,W}
   G::Int  # number of groups
   λ::F  # activation function
-  β::V  # bias
-  γ::U  # scale
+  β::B  # bias
+  γ::S  # scale
   μ::W     # moving mean
   σ²::W    # moving std
   ϵ::N

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -322,10 +322,10 @@ julia> isapprox(std(m(xs)), 1, atol=0.1) && std(xs) != std(m(xs))
 true
 ```
 """
-mutable struct BatchNorm{F,V,N,W}
+mutable struct BatchNorm{F,V,U,N,W}
   λ::F  # activation function
   β::V  # bias
-  γ::V  # scale
+  γ::U  # scale
   μ::W     # moving mean
   σ²::W    # moving var
   ϵ::N
@@ -412,10 +412,10 @@ julia> isapprox(std(y, dims=1:2), ones(1, 1, 3, 2), atol=0.2) && std(y, dims=1:2
 true
 ```
 """
-mutable struct InstanceNorm{F,V,N,W}
+mutable struct InstanceNorm{F,V,U,N,W}
   λ::F  # activation function
   β::V  # bias
-  γ::V  # scale
+  γ::U  # scale
   μ::W  # moving mean
   σ²::W  # moving var
   ϵ::N
@@ -510,11 +510,11 @@ julia> isapprox(std(y[:, :, 3:4, 2]), 1, atol=0.1) && std(xs[:, :, 3:4, 2]) != s
 true
 ```
 """
-mutable struct GroupNorm{F,V,N,W}
+mutable struct GroupNorm{F,V,U,N,W}
   G::Int  # number of groups
   λ::F  # activation function
   β::V  # bias
-  γ::V  # scale
+  γ::U  # scale
   μ::W     # moving mean
   σ²::W    # moving std
   ϵ::N


### PR DESCRIPTION
Right now, the normalization scale and bias are required to be the same type. This is an unnecessary restriction that isn't there for the weight and biases of other layers.

### PR Checklist

- [x] ~~Tests are added~~
- [x] ~~Entry in NEWS.md~~
- [x] ~~Documentation, if applicable~~
