### PR TITLE
Support Vararg Chain (Chain of Parallel)

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -493,6 +493,12 @@ julia> model2[:α](rand(10)) |> size
 
 julia> model2[:β] == model2[2]
 true
+
+julia> model3 = Chain(Parallel(+, Dense(5 => 4), Embedding(15=>4)),
+                      Dense(4 => 17));
+
+julia> model3(randn(5, 10), rand(1:15, 10)) |> size
+(17, 10)
 ```
 """
 struct Parallel{F, T<:Union{Tuple, NamedTuple}}

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -1,5 +1,5 @@
 using Test, Random
-import Flux: activations
+import Flux: activations, OneHotArray, OneHotMatrix, OneHotVector, onehotbatch, params, Zygote
 
 @testset "basic" begin
   @testset "helpers" begin
@@ -214,6 +214,11 @@ import Flux: activations
       input = randn(10, 2)
       @test size(Parallel((a, b) -> cat(a, b; dims=2), Dense(10, 10), identity)(input)) == (10, 4)
       @test size(Parallel(hcat, one = Dense(10, 10), two = identity)(input)) == (10, 4)
+    end
+
+    @testset "parallel chain" begin
+      inputs = (randn(2, 10), randn(3, 10))
+      @test size(Chain(Parallel(vcat, Dense(2, 5), identity), Dense(8, 4))(inputs...)) == (4, 10)
     end
 
     @testset "vararg input" begin


### PR DESCRIPTION
Closes #2100

As mentionned in https://github.com/FluxML/Flux.jl/issues/2100#issuecomment-1305399770, this will break any code using `Chain()` as the identity function. I need a decision whether this is acceptable, or if I should special-case it.

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
