### PR TITLE
fix cpu(x) for immutable arrays

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -130,6 +130,9 @@ function ChainRulesCore.rrule(::typeof(Adapt.adapt_storage), to::FluxCPUAdaptor,
   adapt_storage(to, x), dx -> (NoTangent(), NoTangent(), adapt_storage(FluxCUDAAdaptor(), unthunk(dx)))
 end
 
+# The following rrules for adapt are here to avoid double wrapping issues
+# as seen in https://github.com/FluxML/Flux.jl/pull/2117#discussion_r1027321801
+
 ChainRulesCore.rrule(::typeof(adapt), a::FluxCPUAdaptor, x::AnyCuArray) =
   adapt(a, x), Δ -> (NoTangent(), NoTangent(), adapt(FluxCUDAAdaptor(), unthunk(Δ)))
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -134,10 +134,10 @@ ChainRulesCore.rrule(::typeof(adapt), a::FluxCPUAdaptor, x::AnyCuArray) =
   adapt(a, x), Δ -> (NoTangent(), NoTangent(), adapt(FluxCUDAAdaptor(), unthunk(Δ)))
 
 ChainRulesCore.rrule(::typeof(adapt), a::FluxCPUAdaptor, x::AbstractArray) =
-  adapt(a, x), Δ -> (NoTangent(), NoTangent(), unthunk(Δ))
+  adapt(a, x), Δ -> (NoTangent(), NoTangent(), Δ)
 
 ChainRulesCore.rrule(::typeof(adapt), a::FluxCUDAAdaptor, x::AnyCuArray) =
-  adapt(a, x), Δ -> (NoTangent(), NoTangent(), unthunk(Δ))
+  adapt(a, x), Δ -> (NoTangent(), NoTangent(), Δ)
 
 ChainRulesCore.rrule(::typeof(adapt), a::FluxCUDAAdaptor, x::AbstractArray) =
   adapt(a, x), Δ -> (NoTangent(), NoTangent(), adapt(FluxCPUAdaptor(), unthunk(Δ)))

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -154,7 +154,7 @@ julia> typeof(m_cpu.W)
 Matrix{Float32}
 ```
 """
-cpu(x) = fmap(x -> adapt(FluxCPUAdaptor(), x), x)
+cpu(x) = fmap(x -> adapt(FluxCPUAdaptor(), x), x, exclude = _isleaf)
 
 _isbitsarray(::AbstractArray{<:Number}) = true
 _isbitsarray(::AbstractArray{T}) where T = isbitstype(T)

--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -176,5 +176,5 @@ end
   xgpu = gpu(x) 
   @test xgpu isa CuVector{A2116}
   @test cpu(xgpu) isa Vector{A2116} 
-  @test cpu(gpu([CartesianIndex(1)])) isa Vector{CartesianIndex}
+  @test cpu(gpu([CartesianIndex(1)])) isa Vector{CartesianIndex{1}}
 end

--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -165,4 +165,16 @@ end
   @test gpu(g2) isa CuArray
   @test gpu(g2) ≈ cu(Vector(g2))
   @test parent(gpu(g3)) isa CuArray
+
+
+  #Issue #2116  
+  struct A2116
+    x::Int
+    y::Int
+  end
+  x = [A2116(1,1), A2116(2,2)]
+  xgpu = gpu(x) 
+  @test xgpu isa CuVector{A2116}
+  @test cpu(xgpu) isa Vector{A2116} 
+  @test cpu(gpu([CartesianIndex(1)])) isa Vector
 end

--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -176,5 +176,5 @@ end
   xgpu = gpu(x) 
   @test xgpu isa CuVector{A2116}
   @test cpu(xgpu) isa Vector{A2116} 
-  @test cpu(gpu([CartesianIndex(1)])) isa Vector
+  @test cpu(gpu([CartesianIndex(1)])) isa Vector{CartesianIndex}
 end

--- a/test/cuda/runtests.jl
+++ b/test/cuda/runtests.jl
@@ -1,7 +1,7 @@
 using Flux, Test, CUDA
 using Zygote
 using Zygote: pullback
-using Random
+using Random, LinearAlgebra, Statistics
 
 @info "Testing GPU Support"
 CUDA.allowscalar(false)


### PR DESCRIPTION
Fix #2116 and more generally fix the conversion from  `CuArray{T}`  where `T` is immutable. 

Are there any counterindications for doing this?
