### PR TITLE
allow non-tuple data in the new train!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]

--- a/src/train.jl
+++ b/src/train.jl
@@ -57,7 +57,7 @@ end
 Uses a `loss` function and training `data` to improve the `model`'s parameters
 according to a particular optimisation rule `opt`. Iterates through `data` once,
 evaluating for each `d in data` either `loss(model, d...)` if `d isa Tuple`,
-or else   `loss(model, d)` for other `d`.
+or else `loss(model, d)` for other `d`.
 
 For example, with these definitions...
 ```

--- a/src/train.jl
+++ b/src/train.jl
@@ -61,7 +61,7 @@ or else   `loss(model, d)` for other `d`.
 
 For example, with these definitions...
 ```
-data = [(x1, y1), (x2, y2), (x3, y3)]  
+data = [(x1, y1), (x2, y2), (x3, y3)]
 
 loss3(m, x, y) = norm(m(x) .- y)        # the model is the first argument
 

--- a/src/train.jl
+++ b/src/train.jl
@@ -89,12 +89,9 @@ It adds only a few features to the loop above:
       (This is to move away from Zygote's "implicit" parameter handling, with `Grads`.)
     * Instead of `loss` being a function which accepts only the data,
       now it must also accept the `model` itself, as the first argument.
-    * If `data` iterates over tuples, these will be splatted when passed to `loss`.
-      If you want to avoid the splatting, you can pass `((d,) for d in data)` instead.
     * `opt` should be the result of [`Flux.setup`](@ref). Using an optimiser
       such as `Adam()` without this step should give you a warning.
-    * Callback functions are not supported.
-      But any code can be included in the above `for` loop.
+    * Callback functions now receive a named tuple as input.
 """
 function train!(loss, model, data, opt; cb = x -> nothing)
   cb = runall(cb)

--- a/src/train.jl
+++ b/src/train.jl
@@ -95,7 +95,6 @@ It adds only a few features to the loop above:
 """
 function train!(loss, model, data, opt; cb = x -> nothing)
   cb = runall(cb)
-  @show cb
   @withprogress for (i,d) in enumerate(data)
     d_splat = d isa Tuple ? d : (d,)
     l, gs = Zygote.withgradient(m -> loss(m, d_splat...), model)

--- a/test/train.jl
+++ b/test/train.jl
@@ -51,12 +51,7 @@ end
     end
     @test CNT == 51  # stopped early
     @test m1.weight[1] ≈ -5  # did not corrupt weights
-  end
-
-  @testset "deprecated callback style" begin
-    m1 = Dense(1 => 1)
-    cb = () -> println("this should not be printed")
-    Flux.train!((args...,) -> 1, m1, [(1,2)], Descent(0.1); cb)
+    
   end
 
   @testset "single callback" begin
@@ -91,6 +86,7 @@ end
     @test i1 == length(data)
     @test i2 == sum(1:length(data))
   end
+
 end
 
 @testset "Explicit Flux.update! features" begin

--- a/test/train.jl
+++ b/test/train.jl
@@ -30,6 +30,14 @@ using Random
     Flux.train!(loss, model, ((rand(10),) for _ in 1: 10^5), opt)
     @test loss(model, rand(10, 10)) < 0.01
   end
+
+  @testset "non-tuple data" begin
+    loss(m, x) = Flux.Losses.mse(w*x, m.weight*x .+ m.bias)
+    model = (weight=copy(w2), bias=zeros(10))
+    opt = Flux.setup(AdamW(), model)
+    Flux.train!(loss, model, (rand(10) for _ in 1: 10^5), opt)
+    @test loss(model, rand(10, 10)) < 0.01
+  end
 end
 
 @testset "Explicit Flux.train! features" begin

--- a/test/train.jl
+++ b/test/train.jl
@@ -59,10 +59,8 @@ end
     Flux.train!((args...,) -> 1, m1, [(1,2)], Descent(0.1); cb)
   end
 
-
-  @testset "callback" begin
+  @testset "single callback" begin
     m1 = Dense(1 => 1)
-    i = 0 
     data = [rand(1) for _ in 1:5]
     res = []
     cb = x -> push!(res, x)
@@ -80,6 +78,18 @@ end
       @test haskey(x, :data)
       @test x.opt === opt
     end
+  end
+
+  @testset "multiple callbacks" begin
+    m1 = Dense(1 => 1)
+    i1, i2 = 0, 0
+    data = [rand(1) for _ in 1:5]
+    cb1 = res -> i1 += 1
+    cb2 = res -> i2 += res.step
+    opt = Flux.setup(AdamW(), m1)
+    Flux.train!((m, x) -> sum(m(x)), m1, data, opt; cb = [cb1, cb2])
+    @test i1 == length(data)
+    @test i2 == sum(1:length(data))
   end
 end
 

--- a/test/train.jl
+++ b/test/train.jl
@@ -53,40 +53,6 @@ end
     @test m1.weight[1] ≈ -5  # did not corrupt weights
     
   end
-
-  @testset "single callback" begin
-    m1 = Dense(1 => 1)
-    data = [rand(1) for _ in 1:5]
-    res = []
-    cb = x -> push!(res, x)
-    opt = Flux.setup(AdamW(), m1)
-    Flux.train!((m, x) -> sum(m(x)), m1, data, opt; cb)
-
-    @test length(res) == length(data)
-    for (i,x) in enumerate(res)
-      @test x isa NamedTuple
-      @test x.step == i
-      @test haskey(x, :loss)
-      @test x.gradient.weight isa Matrix
-      @test x.gradient.bias isa Vector
-      @test x.model === m1
-      @test haskey(x, :data)
-      @test x.opt === opt
-    end
-  end
-
-  @testset "multiple callbacks" begin
-    m1 = Dense(1 => 1)
-    i1, i2 = 0, 0
-    data = [rand(1) for _ in 1:5]
-    cb1 = res -> i1 += 1
-    cb2 = res -> i2 += res.step
-    opt = Flux.setup(AdamW(), m1)
-    Flux.train!((m, x) -> sum(m(x)), m1, data, opt; cb = [cb1, cb2])
-    @test i1 == length(data)
-    @test i2 == sum(1:length(data))
-  end
-
 end
 
 @testset "Explicit Flux.update! features" begin

--- a/test/train.jl
+++ b/test/train.jl
@@ -30,14 +30,6 @@ using Random
     Flux.train!(loss, model, ((rand(10),) for _ in 1: 10^5), opt)
     @test loss(model, rand(10, 10)) < 0.01
   end
-
-  @testset "non-tuple data" begin
-    loss(m, x) = Flux.Losses.mse(w*x, m.weight*x .+ m.bias)
-    model = (weight=copy(w2), bias=zeros(10))
-    opt = Flux.setup(AdamW(), model)
-    Flux.train!(loss, model, (rand(10) for _ in 1: 10^5), opt)
-    @test loss(model, rand(10, 10)) < 0.01
-  end
 end
 
 @testset "Explicit Flux.train! features" begin
@@ -51,7 +43,20 @@ end
     end
     @test CNT == 51  # stopped early
     @test m1.weight[1] ≈ -5  # did not corrupt weights
-    
+  end
+
+  @testset "non-tuple data" begin
+    loss(m, x) = Flux.Losses.mse(w*x, m.weight*x .+ m.bias)
+    model = (weight=copy(w2), bias=zeros(10))
+    opt = Flux.setup(AdamW(), model)
+    Flux.train!(loss, model, (rand(10) for _ in 1: 10^5), opt)
+    @test loss(model, rand(10, 10)) < 0.01
+  end
+
+  @testset "callbacks give helpful error" begin
+    m1 = Dense(1 => 1)
+    cb = () -> println("this should not be printed")
+    @test_throws ErrorException Flux.train!((args...,) -> 1, m1, [(1,2)], Descent(0.1); cb)
   end
 end
 


### PR DESCRIPTION
Follow up to #2082 with ~two~ changes to the new `train!`:
- allows for non-tuple elements in the data iterators (same as the `batchmemaybe` function of the old `train!`)
according to  https://github.com/FluxML/Flux.jl/pull/2082#issuecomment-1319559519
- ~support callbacks~

I can factor out the second change if deemed controversial. Edit: removed the callback addition.

