### PR TITLE
Remove Flux.Data module

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -61,10 +61,6 @@ include("loading.jl")
 include("outputsize.jl")
 export @autosize
 
-include("data/Data.jl")
-using .Data
-
-
 include("losses/Losses.jl")
 using .Losses # TODO: stop importing Losses in Flux's namespace in v0.12
 

--- a/src/data/Data.jl
+++ b/src/data/Data.jl
@@ -1,6 +1,0 @@
-module Data
-
-using MLUtils
-export DataLoader
-
-end#module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -82,7 +82,7 @@ Base.@deprecate_binding ADAGrad AdaGrad
 Base.@deprecate_binding ADADelta AdaDelta
 
 # Remove sub-module Data, while making sure Flux.Data.DataLoader keeps working
-Base.@deprecate_binding Data Flux
+Base.@deprecate_binding Data Flux false "Sub-module Flux.Data has been removed. The only thing it contained may be accessed as Flux.DataLoader"
 
 @deprecate rng_from_array() default_rng_value()
 

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -81,6 +81,9 @@ Base.@deprecate_binding OADAM OAdam
 Base.@deprecate_binding ADAGrad AdaGrad
 Base.@deprecate_binding ADADelta AdaDelta
 
+# Remove sub-module Data, while making sure Flux.Data.DataLoader keeps working
+Base.@deprecate_binding Data Flux
+
 @deprecate rng_from_array() default_rng_value()
 
 #=


### PR DESCRIPTION
The contents of this was removed completely in Flux 0.13, except for MLUtils.DataLoader. The deprecation should let you still load this as if the module existed:
```julia
julia> Flux.Data
Flux

julia> Flux.Data.DataLoader(rand(Int8, 3,2)) |> collect
2-element Vector{Matrix{Int8}}:
 [11; 124; 119;;]
 [-4; -51; 111;;]
```