### PR TITLE
[ISSUE 1939] Update workflow, to only generate coverage for a specific entry 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,21 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - name: "Run test without coverage report"
+        uses: julia-actions/julia-runtest@v1
+        if: matrix.version != '1' || matrix.os != 'ubuntu-latest'
+        with:
+          coverage: false
+
+      - name: "Run test with coverage report"
+        uses: julia-actions/julia-runtest@v1
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+      - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+      - uses: codecov/codecov-action@v2
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        with:
+          file: lcov.info
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,17 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: "Run test without coverage report"
         uses: julia-actions/julia-runtest@v1
-        if: matrix.version != '1' || matrix.os != 'ubuntu-latest'
+        if: ${{ !contains(fromJson('["1", "1.6"]'), matrix.version) || matrix.os != 'ubuntu-latest' }}
         with:
           coverage: false
 
       - name: "Run test with coverage report"
         uses: julia-actions/julia-runtest@v1
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        if: contains(fromJson('["1", "1.6"]'), matrix.version) && matrix.os == 'ubuntu-latest'
       - uses: julia-actions/julia-processcoverage@v1
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        if: contains(fromJson('["1", "1.6"]'), matrix.version) && matrix.os == 'ubuntu-latest'
       - uses: codecov/codecov-action@v2
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        if: contains(fromJson('["1", "1.6"]'), matrix.version) && matrix.os == 'ubuntu-latest'
         with:
           file: lcov.info
 


### PR DESCRIPTION
Close #1939 

Add the same condition like [FluxML/Zygote.jl](https://github.com/FluxML/Zygote.jl/blob/master/.github/workflows/ci.yml#L59-L64).

I test workflow in my fork repo:

### 1. push (actually I check this on some other branch)

1. [Julia 1 && Ubuntu-latest](https://github.com/skyleaworlder/Flux.jl/actions/runs/3711165261/jobs/6291322964)

<img width="440" alt="image" src="https://user-images.githubusercontent.com/45269589/208067490-28885440-b788-48cc-abb2-5f1f8b0605d7.png">

2. [Others](https://github.com/skyleaworlder/Flux.jl/actions/runs/3711165261/jobs/6291322890)

<img width="427" alt="image" src="https://user-images.githubusercontent.com/45269589/208067584-6549456e-2f1e-47d4-ade3-9ed2dca65460.png">

### 2. PR

1. [Julia 1 && Ubuntu-latest](https://github.com/skyleaworlder/Flux.jl/actions/runs/3711656883/jobs/6292321286)

<img width="452" alt="image" src="https://user-images.githubusercontent.com/45269589/208068447-fa316162-af12-428b-b502-6e8fedb92e14.png">

3. [Others](https://github.com/skyleaworlder/Flux.jl/actions/runs/3711656883/jobs/6292321172)

<img width="442" alt="image" src="https://user-images.githubusercontent.com/45269589/208068315-e3ab8642-aefa-4a4a-9f0a-54aeaf34bb30.png">

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
