### PR TITLE
Some fast paths + type fixes

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -172,6 +172,9 @@ function (a::Dense)(x::AbstractVecOrMat)
   return σ.(a.weight * x .+ a.bias)
 end
 
+(a::Dense{typeof(identity), <:AbstractMatrix, Bool})(x::AbstractVecOrMat) =
+  a.weight * x  # fast path, no broadcast
+
 (a::Dense)(x::AbstractArray) = 
   reshape(a(reshape(x, size(x,1), :)), :, size(x)[2:end]...)
 
@@ -245,6 +248,9 @@ function (a::Scale)(x::AbstractArray)
   σ = NNlib.fast_act(a.σ, x)  # replaces tanh => tanh_fast, etc
   σ.(a.scale .* x .+ a.bias)
 end
+
+(a::Scale{typeof(identity), <:AbstractArray, Bool})(x::AbstractArray) =
+  a.scale .* x
 
 function Base.show(io::IO, l::Scale)
   print(io, "Scale(", join(size(l.scale), ", "))

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -162,6 +162,7 @@ end
 
 function Dense((in, out)::Pair{<:Integer, <:Integer}, σ = identity;
                init = glorot_uniform, bias = true)
+  σ isa Number && throw(ArgumentError("can't use $σ as an activation function!"))
   Dense(init(out, in), bias, σ)
 end
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -204,6 +204,15 @@ function (c::Conv{<:Any,<:Any,typeof(identity),<:AbstractArray,Bool})(x::Abstrac
   conv(x, c.weight, cdims)  # fast path, no broadcast
 end
 
+function (c::Conv{<:Any,<:Any,<:Any,<:AbstractArray{Float32}})(x::AbstractArray{<:Union{Float64,Integer}})
+  _warn_32_64(c, x)  # warning about a slow path
+  c(convert(AbstractArray{Float32}, x))
+end
+function (c::Conv{<:Any,<:Any,typeof(identity),<:AbstractArray{Float32},Bool})(x::AbstractArray{<:Union{Float64,Integer}})
+  _warn_32_64(c, x)
+  c(convert(AbstractArray{Float32}, x))
+end
+
 _channels_in(l::Conv) = size(l.weight, ndims(l.weight)-1) * l.groups
 _channels_out(l::Conv) = size(l.weight, ndims(l.weight))
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -199,6 +199,10 @@ function (c::Conv)(x::AbstractArray)
   cdims = conv_dims(c, x)
   σ.(conv(x, c.weight, cdims) .+ conv_reshape_bias(c))
 end
+function (c::Conv{<:Any,<:Any,typeof(identity),<:AbstractArray,Bool})(x::AbstractArray)
+  cdims = conv_dims(c, x)
+  conv(x, c.weight, cdims)  # fast path, no broadcast
+end
 
 _channels_in(l::Conv) = size(l.weight, ndims(l.weight)-1) * l.groups
 _channels_out(l::Conv) = size(l.weight, ndims(l.weight))
@@ -331,6 +335,10 @@ function (c::ConvTranspose)(x::AbstractArray)
   σ = NNlib.fast_act(c.σ, x)
   cdims = conv_transpose_dims(c, x)
   σ.(∇conv_data(x, c.weight, cdims) .+ conv_reshape_bias(c))
+end
+function (c::ConvTranspose{<:Any,<:Any,typeof(identity),<:AbstractArray,Bool})(x::AbstractArray)
+  cdims = conv_transpose_dims(c, x)
+  ∇conv_data(x, c.weight, cdims)  # fast path, no broadcast
 end
 
 function Base.show(io::IO, l::ConvTranspose)
@@ -469,6 +477,10 @@ function (c::CrossCor)(x::AbstractArray)
   σ = NNlib.fast_act(c.σ, x)
   cdims = crosscor_dims(c, x)
   σ.(crosscor(x, c.weight, cdims) .+ conv_reshape_bias(c))
+end
+function (c::CrossCor{<:Any,<:Any,typeof(identity),<:AbstractArray,Bool})(x::AbstractArray)
+  cdims = crosscor_dims(c, x)
+  crosscor(x, c.weight, cdims)  # fast path, no broadcast
 end
 
 function Base.show(io::IO, l::CrossCor)

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -200,10 +200,11 @@ end
 RNNCell((in, out)::Pair, σ=tanh; init=Flux.glorot_uniform, initb=zeros32, init_state=zeros32) =
   RNNCell(σ, init(out, in), init(out, out), initb(out), init_state(out,1))
 
-function (m::RNNCell{F,I,H,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {F,I,H,V,T}
+function (m::RNNCell{F,I,H,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{<:AbstractFloat},OneHotArray}) where {F,I,H,V,T}
   Wi, Wh, b = m.Wi, m.Wh, m.b
   σ = NNlib.fast_act(m.σ, x)
-  h = σ.(Wi*x .+ Wh*h .+ b)
+  xT = _match_eltype(m, T, x)::AbstractArray{T}  # any AbstractFloat is so converted
+  h = σ.(Wi*xT .+ Wh*h .+ b)
   return h, reshape_cell_output(h, x)
 end
 
@@ -305,9 +306,10 @@ function LSTMCell((in, out)::Pair;
   return cell
 end
 
-function (m::LSTMCell{I,H,V,<:NTuple{2,AbstractMatrix{T}}})((h, c), x::Union{AbstractVecOrMat{T},OneHotArray}) where {I,H,V,T}
+function (m::LSTMCell{I,H,V,<:NTuple{2,AbstractMatrix{T}}})((h, c), x::Union{AbstractVecOrMat{<:AbstractFloat},OneHotArray}) where {I,H,V,T}
   b, o = m.b, size(h, 1)
-  g = muladd(m.Wi, x, muladd(m.Wh, h, b))
+  xT = _match_eltype(m, T, x)::AbstractArray{T}
+  g = muladd(m.Wi, xT, muladd(m.Wh, h, b))
   input, forget, cell, output = multigate(g, o, Val(4))
   c′ = @. sigmoid_fast(forget) * c + sigmoid_fast(input) * tanh_fast(cell)
   h′ = @. sigmoid_fast(output) * tanh_fast(c′)
@@ -376,9 +378,10 @@ end
 GRUCell((in, out)::Pair; init = glorot_uniform, initb = zeros32, init_state = zeros32) =
   GRUCell(init(out * 3, in), init(out * 3, out), initb(out * 3), init_state(out,1))
 
-function (m::GRUCell{I,H,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {I,H,V,T}
+function (m::GRUCell{I,H,V,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{<:AbstractFloat},OneHotArray}) where {I,H,V,T}
   Wi, Wh, b, o = m.Wi, m.Wh, m.b, size(h, 1)
-  gxs, ghs, bs = multigate(Wi*x, o, Val(3)), multigate(Wh*h, o, Val(3)), multigate(b, o, Val(3))
+  xT = _match_eltype(m, T, x)::AbstractArray{T}
+  gxs, ghs, bs = multigate(Wi*xT, o, Val(3)), multigate(Wh*h, o, Val(3)), multigate(b, o, Val(3))
   r, z = _gru_output(gxs, ghs, bs)
   h̃ = @. tanh_fast(gxs[3] + r * ghs[3] + bs[3])
   h′ = @. (1 - z) * h̃ + z * h
@@ -444,9 +447,10 @@ GRUv3Cell((in, out)::Pair; init = glorot_uniform, initb = zeros32, init_state = 
   GRUv3Cell(init(out * 3, in), init(out * 2, out), initb(out * 3),
             init(out, out), init_state(out,1))
 
-function (m::GRUv3Cell{I,H,V,HH,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{T},OneHotArray}) where {I,H,V,HH,T}
+function (m::GRUv3Cell{I,H,V,HH,<:AbstractMatrix{T}})(h, x::Union{AbstractVecOrMat{<:AbstractFloat},OneHotArray}) where {I,H,V,HH,T}
   Wi, Wh, b, Wh_h̃, o = m.Wi, m.Wh, m.b, m.Wh_h̃, size(h, 1)
-  gxs, ghs, bs = multigate(Wi*x, o, Val(3)), multigate(Wh*h, o, Val(2)), multigate(b, o, Val(3))
+  xT = _match_eltype(m, T, x)::AbstractArray{T}
+  gxs, ghs, bs = multigate(Wi*xT, o, Val(3)), multigate(Wh*h, o, Val(2)), multigate(b, o, Val(3))
   r, z = _gru_output(gxs, ghs, bs)
   h̃ = tanh_fast.(gxs[3] .+ (Wh_h̃ * (r .* h)) .+ bs[3])
   h′ = @. (1 - z) * h̃ + z * h

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -89,6 +89,16 @@ import Flux: activations
       @test Dense(10, 2, identity, init = ones)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
       @test Dense(10, 2, identity, init = ones, bias = false)([ones(10,1) 2*ones(10,1)]) == [10 20; 10 20]
     end
+    @testset "fast paths, type fixes, ambiguities" begin
+      d1 = Dense(2 => 3)
+      d2 = Dense(d1.weight, false)
+      x1 = randn(Float32, 2, 4)
+      @test d1(x1) ≈ d2(x1) ≈ d1.weight * x1
+      x2 = Float64.(x1)
+      @test d1(x2) ≈ d2(x2) ≈ d1.weight * x2
+      x3 = rand(-5:5, 2, 4)
+      @test d1(x3) ≈ d2(x3) ≈ d1.weight * x3
+    end
   end
 
   @testset "Scale" begin

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -96,8 +96,14 @@ import Flux: activations
       @test d1(x1) ≈ d2(x1) ≈ d1.weight * x1
       x2 = Float64.(x1)
       @test d1(x2) ≈ d2(x2) ≈ d1.weight * x2
+      @test d1(x2) isa Array{Float32}
+      @test d2(x2) isa Array{Float32}
       x3 = rand(-5:5, 2, 4)
       @test d1(x3) ≈ d2(x3) ≈ d1.weight * x3
+      x4 = rand(Bool, 2, 4)
+      @test d1(x4) ≈ d2(x4) ≈ d1.weight * x4
+      x5 = Flux.onehotbatch(rand(Bool, 5), (true, false))
+      @test d1(x5) ≈ d2(x5) ≈ d1.weight * x5
     end
   end
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -65,6 +65,7 @@ import Flux: activations
 
       @test_throws MethodError Dense(10, 10.5)
       @test_throws MethodError Dense(10, 10.5, tanh)
+      @test_throws ArgumentError Dense(3 => 4, false)
       @test_throws DimensionMismatch Dense(3,4; bias=rand(5))
       @test_throws DimensionMismatch Dense(rand(4,3), rand(5))
       @test_throws MethodError Dense(rand(5))

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -166,11 +166,11 @@ end
   end
 
   # with activation function
-  let m = BatchNorm(2, sigmoid), x = [1.0 3.0 5.0;
-                                      2.0 4.0 6.0]
+  let m = BatchNorm(2, sigmoid)
+    x = Float32[1.0 3.0 5.0; 2.0 4.0 6.0]
     y = m(x)
     @test isapprox(y, sigmoid.((x .- m.μ) ./ sqrt.(m.σ² .+ m.ϵ)), atol = 1.0e-7)
-    @inferred m(x)
+    @inferred m(x)  # fails when x::Matrix{Float64}, do we care?
   end
 
   let m = trainmode!(BatchNorm(2)), x = reshape(Float32.(1:6), 3, 2, 1)

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -93,9 +93,10 @@ end
 @testset "RNN-input-state-eltypes" begin
   @testset for R in [RNN, GRU, LSTM, GRUv3]
     m = R(3 => 5)
-    x = rand(Float64, 3, 1)
+    x = rand(Float64, 3, 1)  # Float64 input is now converted
     Flux.reset!(m)
-    @test_throws MethodError m(x)
+    @test m(x) isa Array{Float32}
+    @test m.state isa Array{Float32}
   end
 end
 


### PR DESCRIPTION
This adds fast paths for some layers with neither bias nor a nonlinearity:

```julia
julia> using Flux

julia> @btime $(Dense(100 => 100; bias=false))($(randn(Float32, 100, 100)));
  min 6.917 μs, mean 243.044 μs (4 allocations, 78.22 KiB)  # before
  min 4.931 μs, mean 103.005 μs (2 allocations, 39.11 KiB)  # after

julia> @btime $(BatchNorm(3))($(randn(Float32, 100, 3, 100)));
  min 38.125 μs, mean 752.368 μs (19 allocations, 235.19 KiB)
  min 28.167 μs, mean 410.862 μs (18 allocations, 118.02 KiB)

julia> @btime $(Conv((3,3),3=>3,bias=false))($(randn(Float32, 28, 28, 3, 100)));
  min 313.708 μs, mean 5.634 ms (57 allocations, 1.83 MiB)
  min 272.875 μs, mean 2.885 ms (54 allocations, 1.06 MiB)
```

Zygote knows to ignore `identity.(x .+ false)`, so the only real gradient change is to BatchNorm.

```julia
julia> @btime gradient((m,x) -> sum(abs2, m(x)), $(Dense(100 => 100; bias=false)),$(randn(Float32, 100, 100)));
  min 18.625 μs, mean 562.410 μs (31 allocations, 157.92 KiB)  # before
  min 18.792 μs, mean 594.045 μs (31 allocations, 157.44 KiB)  # after, just noise

julia> @btime gradient((m,x) -> sum(abs2, m(x)), $(BatchNorm(3)),$(randn(Float32, 100, 3, 100)));
  min 166.833 μs, mean 5.930 ms (571 allocations, 1.51 MiB)
  min 160.583 μs, mean 4.740 ms (586 allocations, 1.17 MiB)  # after, real improvement?

julia> @btime gradient((m,x) -> sum(abs2, m(x)), $(Conv((3,3),3=>3,bias=false)),$(randn(Float32, 28, 28, 3, 100)));
  min 2.503 ms, mean 12.723 ms (163 allocations, 3.09 MiB)
  min 2.472 ms, mean 13.070 ms (163 allocations, 3.09 MiB)  # after, just noise
```