### PR TITLE
Un-deprecate `track_stats` for InstanceNorm

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -432,10 +432,6 @@ function InstanceNorm(chs::Int, λ=identity;
                     affine=false, track_stats=false,
                     ϵ=1f-5, momentum=0.1f0)
 
-  if track_stats
-    Base.depwarn("`track_stats=true` will be removed from InstanceNorm in Flux 0.14. The default value is `track_stats=false`, which will work as before.", :InstanceNorm)
-  end
-
   β = affine ? initβ(chs) : nothing
   γ = affine ? initγ(chs) : nothing
   μ = track_stats ? zeros32(chs) : nothing


### PR DESCRIPTION
This is mea culpa on my part. Both the original [Instance Normalization paper](https://arxiv.org/abs/1607.08022) and the PyTorch implementation do allow for tracked stats. The GroupNorm part of https://github.com/FluxML/Flux.jl/issues/2006 still stands though.

### PR Checklist

- [N/A] Tests are added
- [N/A] Entry in NEWS.md
- [N/A] Documentation, if applicable
