### PR TITLE
RFC: add `gpu(::DataLoader)`

### DIFF
--- a/test/cuda/cuda.jl
+++ b/test/cuda/cuda.jl
@@ -178,3 +178,10 @@ end
   @test cpu(xgpu) isa Vector{A2116} 
   @test cpu(gpu([CartesianIndex(1)])) isa Vector{CartesianIndex{1}}
 end
+
+@testset "gpu(::DataLoader)" begin
+  dl = Flux.DataLoader((x = ones32(2,10),), batchsize=3)
+  @test first(dl) isa NamedTuple{(:x,), Tuple{Matrix{Float32}}}
+  @test gpu(dl) isa CuIterator
+  @test first(gpu(dl)) isa NamedTuple{(:x,), <:Tuple{CuArray}}
+end


### PR DESCRIPTION
A common pattern in the model zoo is to copy individual batches to the GPU by hand. This proposes instead making it easy to wrap a `DataLoader` in a `CuIterator`, if CUDA is available, and otherwise do nothing. Then this pair should be all you need:
```
data |> gpu
model |> gpu
```

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
