### PR TITLE
fix various deprecation warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Flux Release Notes
 
+## v0.13.14
+* Fixed various deprecation warnings, from `Zygone.@nograd` and `Vararg`.
+
 ## v0.13.13
 * Added `f16` which changes precision to `Float16`, recursively.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.13.13"
+version = "0.13.14"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -11,7 +11,7 @@ import Optimisers: Optimisers, trainable, destructure  # before v0.13, Flux owne
 using Optimisers: freeze!, thaw!, adjust!
 
 using Zygote, ChainRulesCore
-using Zygote: Params, @adjoint, gradient, pullback, @nograd
+using Zygote: Params, @adjoint, gradient, pullback
 using Zygote.ForwardDiff: value
 export gradient
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -91,7 +91,7 @@ end
 # Allows caching of the parameters when params is called within gradient() to fix #2040.
 # @non_differentiable params(m...)  # https://github.com/FluxML/Flux.jl/pull/2054
 # That speeds up implicit use, and silently breaks explicit use. 
-# From @macroexpand Zygote.@nograd params(m...) and https://github.com/FluxML/Zygote.jl/pull/1248
+# From @macroexpand Zygote.@non_differentiable params(m...) and https://github.com/FluxML/Zygote.jl/pull/1248
 Zygote._pullback(::Zygote.Context{true}, ::typeof(params), m...) = params(m), _ -> nothing
 
 struct FluxCUDAAdaptor end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -50,7 +50,7 @@ end
 
 (c::Chain)(x) = _applychain(c.layers, x)
 
-@generated function _applychain(layers::Tuple{Vararg{<:Any,N}}, x) where {N}
+@generated function _applychain(layers::Tuple{Vararg{Any,N}}, x) where {N}
   symbols = vcat(:x, [gensym() for _ in 1:N])
   calls = [:($(symbols[i+1]) = layers[$i]($(symbols[i]))) for i in 1:N]
   Expr(:block, calls...)
@@ -627,7 +627,7 @@ function (m::PairwiseFusion)(x::T) where {T}
 end
 (m::PairwiseFusion)(xs...) = m(xs)
 
-@generated function applypairwisefusion(layers::Tuple{Vararg{<:Any,N}}, connection, x::T) where {N, T}
+@generated function applypairwisefusion(layers::Tuple{Vararg{Any,N}}, connection, x::T) where {N, T}
   y_symbols = [gensym() for _ in 1:(N + 1)]
   getinput(i) = T <: Tuple ? :(x[$i]) : :x
   calls = [:($(y_symbols[N + 1]) = $(getinput(1)))]

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -45,8 +45,10 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
 end
 
 _show_leaflike(x) = isleaf(x)  # mostly follow Functors, except for:
-_show_leaflike(::Tuple{Vararg{<:Number}}) = true         # e.g. stride of Conv
-_show_leaflike(::Tuple{Vararg{<:AbstractArray}}) = true  # e.g. parameters of LSTMcell
+
+# note the covariance of tuple, using <:T causes warning or error
+_show_leaflike(::Tuple{Vararg{Number}}) = true         # e.g. stride of Conv
+_show_leaflike(::Tuple{Vararg{AbstractArray}}) = true  # e.g. parameters of LSTMcell
 _show_leaflike(::Scale) = true                           # appears inside LayerNorm
 _show_leaflike(::AbstractArray{<:Number}) = true         # e.g. transposed arrays
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -625,14 +625,17 @@ true
 """
 modules(m) = [x for x in Functors.fcollect(m) if !isleaflike(x)]
 
-@nograd modules # TODO: is this correct? might fail with explicit parameters.
+@non_differentiable modules(::Any...) # TODO: is this correct? might fail with explicit parameters.
 function ChainRulesCore.rrule(::typeof(modules), m)
   modules(m), dm -> error("Flux.modules is not at present differentiable, sorry")
 end
 
 isleaflike(x) = Functors.isleaf(x)
-isleaflike(::Tuple{Vararg{<:Number}}) = true
-isleaflike(::Tuple{Vararg{<:AbstractArray{<:Number}}}) = true
+
+# these are, essentially, Tuple{Vararg{<:T}} using the special property
+# of tuples that they are type covariant.  Using <: here causes warning or error
+isleaflike(::Tuple{Vararg{Number}}) = true
+isleaflike(::Tuple{Vararg{AbstractArray{<:Number}}}) = true
 
 """
     patience(predicate, wait)


### PR DESCRIPTION
I have fixed some deprecation warnings which were driving me nuts.  There was a simple warning from a use of the deprecated macro `Zygote.@nograd`.  The rest were caused by a tricky issue with the use of `Vararg`.  When one writes a function signature with arguments like `::Tuple{Vararg{<:T}}` one gets the deprecation warning
```
WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
```
The solution is apparently to replace the `<:T` expressions with `T`, which is equivalent due to tuples being covariant.  This property of tuples is horribly obscure, so I've added comments explaining what is going on.

### PR Checklist

- [x] Tests are added (all changes on existing code, no new tests should be needed)
- [x] Entry in NEWS.md
- [x] Documentation, if applicable (not applicable)
