### PR TITLE
tiny change to docstring of gpu function

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -202,7 +202,7 @@ function gpu_backend!(backend::String)
 end
 
 """
-    gpu(x)
+    gpu(m)
 
 Copies `m` to the current GPU device (using current GPU backend), if one is available.
 If no GPU is available, it does nothing (but prints a warning the first time).


### PR DESCRIPTION
Changed the docstring signature of the `gpu` function from `gpu(x)` to `gpu(m)` to conform with `cpu` and to fit the accompanying sentence in the docstring.

> This is my first open source PR ever... forgive me for it being so tiny... gotta start somewhere.  Cheers to Flux being cool

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
