### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This allows us to get updates for GitHub actions automatically. After merging this, we should also enable other Dependabot actions in "Settings -> Code security and analysis -> Dependabot alerts" and "... -> Dependabot security updates".

After merging this, Dependabot will prepare PRs with updates of the versions of GitHub actions we use such as.
