### PR TITLE
Speed-up normalization layers

### DIFF
--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -225,12 +225,14 @@ function _norm_layer_forward(
   end
 
   eps = convert(float(T), l.ϵ)
-  o = _norm_layer_forward(x, μ, σ², eps)
-  hasaffine(l) || return l.λ.(o)
+  hasaffine(l) || return l.λ.(_norm_layer_forward(x, μ, σ², eps))
 
   γ = reshape(l.γ, affine_shape)
   β = reshape(l.β, affine_shape)
-  return l.λ.(γ .* o .+ β)
+
+  scale = γ ./ sqrt.(σ² .+ eps)
+  bias = -scale .* μ .+ β
+  l.λ.(scale .* x .+ bias)
 end
 
 @inline _norm_layer_forward(x, μ, σ², ϵ) = (x .- μ) ./ sqrt.(σ² .+ ϵ)

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -27,8 +27,8 @@ true
 """
 @inline function normalise(x::AbstractArray; dims=ndims(x), ϵ=ofeltype(x, 1e-5))
   μ = mean(x, dims=dims)
-  σ² = var(x, dims=dims, mean=μ, corrected=false)
-  return @. (x - μ) / sqrt(σ² + ϵ)
+  σ = std(x, dims=dims, mean=μ, corrected=false)
+  return @. (x - μ) / (σ + ϵ)
 end
 
 """

--- a/src/layers/stateless.jl
+++ b/src/layers/stateless.jl
@@ -27,8 +27,8 @@ true
 """
 @inline function normalise(x::AbstractArray; dims=ndims(x), ϵ=ofeltype(x, 1e-5))
   μ = mean(x, dims=dims)
-  σ = std(x, dims=dims, mean=μ, corrected=false)
-  return @. (x - μ) / (σ + ϵ)
+  σ² = var(x, dims=dims, mean=μ, corrected=false)
+  return @. (x - μ) / sqrt(σ² + ϵ)
 end
 
 """


### PR DESCRIPTION
- Speed-up other normalization layers, by re-arranging expression a bit.

```math
y = \frac{x - E[x]}{\sqrt{Var[x] + \epsilon}} * \gamma + \beta
  = \frac{\gamma}{\sqrt{Var[x] + \epsilon}} * (x - E[x]) + \beta
```
```math
scale = \frac{\gamma}{\sqrt{Var[x] + \epsilon}}
```
```math
bias = -scale * E[x] + \beta
```
```math
y = scale * x + bias
```

```julia
julia> using BenchmarkTools, Flux

julia> gn = GroupNorm(128, 32);

julia> x = rand(Float32, 256, 256, 128, 16);

julia> @benchmark gn(x)
```

**Before:**

```julia
julia> @benchmark gn(x)
BenchmarkTools.Trial: 9 samples with 1 evaluation.
 Range (min … max):  545.960 ms … 576.558 ms  ┊ GC (min … max): 0.27% … 6.13%
 Time  (median):     575.436 ms               ┊ GC (median):    6.13%
 Time  (mean ± σ):   570.931 ms ±  10.306 ms  ┊ GC (mean ± σ):  5.27% ± 2.01%

                                                              █  
  ▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▇▇▇█ ▁
  546 ms           Histogram: frequency by time          577 ms <

 Memory estimate: 1.00 GiB, allocs estimate: 32.
```

**This PR:**

```julia
julia> @benchmark gn(x)
BenchmarkTools.Trial: 23 samples with 1 evaluation.
 Range (min … max):  202.554 ms … 221.089 ms  ┊ GC (min … max): 0.34% … 7.94%
 Time  (median):     219.391 ms               ┊ GC (median):    7.99%
 Time  (mean ± σ):   218.166 ms ±   4.402 ms  ┊ GC (mean ± σ):  7.34% ± 2.20%

                                                        ▆█▂      
  ▄▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄███▄▁▁▄ ▁
  203 ms           Histogram: frequency by time          221 ms <

 Memory estimate: 512.03 MiB, allocs estimate: 35.
```

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
