### PR TITLE
Print the state of Dropout etc.

### DIFF
--- a/docs/src/models/layers.md
+++ b/docs/src/models/layers.md
@@ -145,6 +145,7 @@ Several normalisation layers behave differently under training and inference (te
 The functions `Flux.trainmode!` and `Flux.testmode!` let you manually specify which behaviour you want. When called on a model, they will place all layers within the model into the specified mode.
 
 ```@docs
-Flux.testmode!
+testmode!(::Any)
+testmode!(::Any, ::Any)
 trainmode!
 ```

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -187,6 +187,23 @@ function update!(opt::Optimise.AbstractOptimiser, ::Params, grads::Union{Tuple, 
     """)
 end
 
+""" 
+    trainmode!(m, active)
+
+!!! warning
+    This two-argument method is deprecated.
+
+Possible values of  `active` are:
+- `true` for training, or 
+- `false` for testing, same as [`testmode!`](@ref)`(m)`
+- `:auto` or `nothing` for Flux to detect training automatically.
+"""
+function trainmode!(m, active::Bool)
+  Base.depwarn("trainmode!(m, active::Bool) is deprecated", :trainmode)
+  testmode!(m, !active)
+end
+
+
 # v0.14 deprecations
 
 # Enable these when 0.14 is released, and delete const ClipGrad = Optimise.ClipValue etc: 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -5,7 +5,7 @@ import Functors: Functors, @functor, functor, fmap, isleaf
 using SparseArrays: AbstractSparseArray
 
 """
-    testmode!(m, mode = true)
+    testmode!(m, inactive = true)
 
 Set a layer, or all layers in a model, to test mode.
 This disables the effect of [`Dropout`](@ref), and similar layers.
@@ -13,9 +13,9 @@ This disables the effect of [`Dropout`](@ref), and similar layers.
 _Note_: if you manually set a model into test mode, you need to manually place
 it back into train mode during training phase.
 
-Possible values of optional 2nd argument `mode` are:
+Possible values of optional 2nd argument `inactive` are:
 - `true` for testing
-- `false` for training, same as [`trainmode!`](@ref)
+- `false` for training, same as [`trainmode!`](@ref)`(m)`
 - `:auto` or `nothing` for Flux to detect training automatically.
 
 # Example
@@ -34,23 +34,23 @@ julia> trainmode!(d, :auto)  # back to default
 Dropout(0.3)
 ```
 """
-testmode!(m, mode = true) = (foreach(x -> testmode!(x, mode), trainable(m)); m)
+testmode!(m, inactive = true) = (foreach(x -> testmode!(x, inactive), trainable(m)); m)
 
 """
-    trainmode!(m, mode = true)
+    trainmode!(m, active = true)
 
 Set a layer, or all layers in a model, to training mode.
-Opposite to [`testmode!`](@ref) (i.e. `trainmode!(m, mode) == testmode!(m, !mode)`).
+Opposite to [`testmode!`](@ref) (i.e. `trainmode!(m, active) == testmode!(m, !active)`).
 
 _Note_: if you manually set a model into train mode, you need to manually place
 it into test mode during testing phase.
 
-Possible values of optional 2nd argument `mode` are:
+Possible values of optional 2nd argument `active` are:
 - `true` for training
 - `false` for testing
 - `:auto` or `nothing` for Flux to detect training automatically
 """
-trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
+trainmode!(m, active = true) = active isa Bool ? testmode!(m, !active) : testmode!(m, active)
 
 function params!(p::Params, x, seen = IdSet())
   if x isa AbstractArray{<:Number} && Functors.isleaf(x)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -49,7 +49,7 @@ trainmode!(m, ::Nothing) = testmode!(m, nothing)  # why do we have so much API?
     testmode!(model, inactive)
 
 This two-argument method is largely internal. It recurses into the `model`,
-and until a method like `testmode!(d::Dropout, mode)` alters the activity of a layer.
+and until a method like `testmode!(d::Dropout, inactive)` alters the activity of a layer.
 
 Possible values of  `inactive` are:
 - `true` for testing, i.e. `active=false`
@@ -57,7 +57,7 @@ Possible values of  `inactive` are:
 - `:auto` or `nothing` for Flux to detect training automatically.
 """
 function testmode!(m, mode)
-  if inactive isa Symbol && mode !== :auto
+  if mode isa Symbol && mode !== :auto
     throw(ArgumentError("testmode! accepts only the symbol :auto, got :$mode"))
   end
   foreach(x -> testmode!(x, mode), trainable(m))

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -7,32 +7,48 @@ using SparseArrays: AbstractSparseArray
 """
     testmode!(m, mode = true)
 
-Set a layer or model's test mode (see below).
-Using `:auto` mode will treat any gradient computation as training.
+Set a layer, or all layers in a model, to test mode.
+This disables the effect of [`Dropout`](@ref), and similar layers.
 
 _Note_: if you manually set a model into test mode, you need to manually place
 it back into train mode during training phase.
 
-Possible values include:
-- `false` for training
+Possible values of optional 2nd argument `mode` are:
 - `true` for testing
-- `:auto` or `nothing` for Flux to detect the mode automatically
+- `false` for training, same as [`trainmode!`](@ref)
+- `:auto` or `nothing` for Flux to detect training automatically.
+
+# Example
+
+```jldoctest
+julia> d = Dropout(0.3)
+Dropout(0.3)
+
+julia> testmode!(d)   # dropout is now always disabled
+Dropout(0.3, active=false)
+
+julia> trainmode!(d)  # dropout is now always enabled
+Dropout(0.3, active=true)
+
+julia> trainmode!(d, :auto)  # back to default
+Dropout(0.3)
+```
 """
 testmode!(m, mode = true) = (foreach(x -> testmode!(x, mode), trainable(m)); m)
 
 """
     trainmode!(m, mode = true)
 
-Set a layer of model's train mode (see below).
-Symmetric to [`testmode!`](@ref) (i.e. `trainmode!(m, mode) == testmode!(m, !mode)`).
+Set a layer, or all layers in a model, to training mode.
+Opposite to [`testmode!`](@ref) (i.e. `trainmode!(m, mode) == testmode!(m, !mode)`).
 
 _Note_: if you manually set a model into train mode, you need to manually place
 it into test mode during testing phase.
 
-Possible values include:
+Possible values of optional 2nd argument `mode` are:
 - `true` for training
 - `false` for testing
-- `:auto` or `nothing` for Flux to detect the mode automatically
+- `:auto` or `nothing` for Flux to detect training automatically
 """
 trainmode!(m, mode = true) = mode isa Bool ? testmode!(m, !mode) : testmode!(m, mode)
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -29,7 +29,7 @@ Dropout(0.3, active=false)
 julia> trainmode!(d)  # dropout is now always enabled
 Dropout(0.3, active=true)
 
-julia> trainmode!(d, :auto)  # back to default
+julia> testmode!(d, :auto)  # back to default
 Dropout(0.3)
 ```
 """

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -268,7 +268,7 @@ ChainRulesCore.@non_differentiable _track_stats!(::Any...)
 """
     BatchNorm(channels::Integer, λ=identity;
               initβ=zeros32, initγ=ones32,
-              affine = true, track_stats = true,
+              affine=true, track_stats=true, active=:auto,
               ϵ=1f-5, momentum= 0.1f0)
 
 [Batch Normalization](https://arxiv.org/abs/1502.03167) layer.

--- a/src/layers/normalise.jl
+++ b/src/layers/normalise.jl
@@ -1,8 +1,13 @@
 # Internal function, used only for layers defined in this file.
 _isactive(m, x) = isnothing(m.active) ? NNlib.within_gradient(x) : m.active
 
+# Internal function, used only in this file.
+_tidy_active(mode::Bool) = mode
+_tidy_active(::Nothing) = nothing
+_tidy_active(mode) = mode === :auto ? nothing : throw(ArgumentError("active = $(repr(mode)) is not accepted, must be true/false/nothing or :auto"))
+
 """
-    Dropout(p; [dims, rng])
+    Dropout(p; [dims, rng, active])
 
 Layer implementing [dropout](https://arxiv.org/abs/1207.0580) with the given probability.
 This is used as a regularisation, i.e. to reduce overfitting.
@@ -12,7 +17,8 @@ or else scales it by `1 / (1 - p)`, using the [`NNlib.dropout`](@ref) function.
 While testing, it has no effect.
 
 By default the mode will switch automatically, but it can also
-be controlled manually via [`Flux.testmode!`](@ref).
+be controlled manually via [`Flux.testmode!`](@ref),
+or by passing keyword `active=true` for training mode.
 
 By default every input is treated independently. With the `dims` keyword,
 instead it takes a random choice only along that dimension.
@@ -36,7 +42,11 @@ julia> m(ones(2, 7))  # test mode, no effect
  2.0  2.0  2.0  2.0  2.0  2.0  2.0
  2.0  2.0  2.0  2.0  2.0  2.0  2.0
 
-julia> Flux.trainmode!(m);  # equivalent to use within gradient
+julia> Flux.trainmode!(m)  # equivalent to use within gradient
+Chain(
+  Dense(2 => 3),                        # 9 parameters
+  Dropout(0.4, active=true),
+)
 
 julia> m(ones(2, 7))
 3×7 Matrix{Float64}:
@@ -63,9 +73,9 @@ mutable struct Dropout{F<:Real,D,R<:AbstractRNG}
 end
 Dropout(p::Real, dims, active) = Dropout(p, dims, active, default_rng_value())
 
-function Dropout(p::Real; dims=:, rng = default_rng_value())
+function Dropout(p::Real; dims=:, active = nothing, rng = default_rng_value())
   0 ≤ p ≤ 1 || throw(ArgumentError("Dropout expects 0 ≤ p ≤ 1, got p = $p"))
-  Dropout(p, dims, nothing, rng)
+  Dropout(p, dims, _tidy_active(active), rng)
 end
 
 @functor Dropout
@@ -74,16 +84,17 @@ trainable(a::Dropout) = (;)
 (a::Dropout)(x) = dropout(a.rng, x, a.p * _isactive(a, x); dims=a.dims)
 
 testmode!(m::Dropout, mode=true) =
-  (m.active = (isnothing(mode) || mode == :auto) ? nothing : !mode; m)
+  (m.active = isnothing(_tidy_active(mode)) ? nothing : !mode; m)
 
 function Base.show(io::IO, d::Dropout)
   print(io, "Dropout(", d.p)
-  d.dims != (:) && print(io, ", dims = $(repr(d.dims))")
+  d.dims != (:) && print(io, ", dims=", d.dims)
+  d.active == nothing || print(io, ", active=", d.active)
   print(io, ")")
 end
 
 """
-    AlphaDropout(p; rng = default_rng_value())
+    AlphaDropout(p; [rng, active])
 
 A dropout layer. Used in
 [Self-Normalizing Neural Networks](https://arxiv.org/abs/1706.02515).
@@ -114,11 +125,11 @@ mutable struct AlphaDropout{F,R<:AbstractRNG}
   rng::R
   function AlphaDropout(p, active, rng)
     @assert 0 ≤ p ≤ 1
-    new{typeof(p), typeof(rng)}(p, active, rng)
+    new{typeof(p), typeof(rng)}(p, _tidy_active(active), rng)
   end
 end
 AlphaDropout(p, active) = AlphaDropout(p, active, default_rng_value())
-AlphaDropout(p; rng = default_rng_value()) = AlphaDropout(p, nothing, rng)
+AlphaDropout(p; rng = default_rng_value(), active=nothing) = AlphaDropout(p, active, rng)
 
 @functor AlphaDropout
 trainable(a::AlphaDropout) = (;)
@@ -138,7 +149,7 @@ function (a::AlphaDropout)(x::AbstractArray{T}) where T
 end
 
 testmode!(m::AlphaDropout, mode=true) =
-  (m.active = (isnothing(mode) || mode == :auto) ? nothing : !mode; m)
+  (m.active = isnothing(_tidy_active(mode)) ? nothing : !mode; m)
 
 """
     LayerNorm(size..., λ=identity; affine=true, ϵ=1fe-5)
@@ -310,7 +321,7 @@ end
 
 function BatchNorm(chs::Int, λ=identity;
           initβ=zeros32, initγ=ones32,
-          affine=true, track_stats=true,
+          affine=true, track_stats=true, active=nothing,
           ϵ=1f-5, momentum=0.1f0)
 
   β = affine ? initβ(chs) : nothing
@@ -321,7 +332,7 @@ function BatchNorm(chs::Int, λ=identity;
   return BatchNorm(λ, β, γ,
             μ, σ², ϵ, momentum,
             affine, track_stats,
-            nothing, chs)
+            _tidy_active(active), chs)
 end
 
 @functor BatchNorm
@@ -335,12 +346,13 @@ function (BN::BatchNorm)(x::AbstractArray{T,N}) where {T,N}
 end
 
 testmode!(m::BatchNorm, mode=true) =
-  (m.active = (isnothing(mode) || mode == :auto) ? nothing : !mode; m)
+  (m.active = isnothing(_tidy_active(mode)) ? nothing : !mode; m)
 
 function Base.show(io::IO, l::BatchNorm)
   print(io, "BatchNorm($(l.chs)")
   (l.λ == identity) || print(io, ", $(l.λ)")
   hasaffine(l) || print(io,  ", affine=false")
+  l.active == nothing || print(io, ", active=", l.active)
   print(io, ")")
 end
 
@@ -399,7 +411,7 @@ end
 
 function InstanceNorm(chs::Int, λ=identity;
                     initβ=zeros32, initγ=ones32,
-                    affine=false, track_stats=false,
+                    affine=false, track_stats=false, active=nothing,
                     ϵ=1f-5, momentum=0.1f0)
 
   β = affine ? initβ(chs) : nothing
@@ -410,7 +422,7 @@ function InstanceNorm(chs::Int, λ=identity;
   return InstanceNorm(λ, β, γ,
             μ, σ², ϵ, momentum,
             affine, track_stats,
-            nothing, chs)
+            _tidy_active(active), chs)
 end
 
 @functor InstanceNorm
@@ -424,12 +436,13 @@ function (l::InstanceNorm)(x::AbstractArray{T,N}) where {T,N}
 end
 
 testmode!(m::InstanceNorm, mode=true) =
-  (m.active = (isnothing(mode) || mode == :auto) ? nothing : !mode; m)
+  (m.active = isnothing(_tidy_active(mode)) ? nothing : !mode; m)
 
 function Base.show(io::IO, l::InstanceNorm)
   print(io, "InstanceNorm($(l.chs)")
   l.λ == identity || print(io, ", $(l.λ)")
   hasaffine(l) || print(io,  ", affine=false")
+  l.active == nothing || print(io, ", active=", l.active)
   print(io, ")")
 end
 
@@ -495,7 +508,7 @@ trainable(gn::GroupNorm) = hasaffine(gn) ? (β = gn.β, γ = gn.γ) : (;)
 
 function GroupNorm(chs::Int, G::Int, λ=identity;
               initβ=zeros32, initγ=ones32,
-              affine=true, track_stats=false,
+              affine=true, track_stats=false, active=nothing,
               ϵ=1f-5, momentum=0.1f0)
 
 if track_stats
@@ -514,7 +527,7 @@ end
             μ, σ²,
             ϵ, momentum,
             affine, track_stats,
-            nothing, chs)
+            _tidy_active(active), chs)
 end
 
 function (gn::GroupNorm)(x::AbstractArray)
@@ -529,13 +542,14 @@ function (gn::GroupNorm)(x::AbstractArray)
 end
 
 testmode!(m::GroupNorm, mode = true) =
-  (m.active = (isnothing(mode) || mode == :auto) ? nothing : !mode; m)
+  (m.active = isnothing(_tidy_active(mode)) ? nothing : !mode; m)
 
 function Base.show(io::IO, l::GroupNorm)
   # print(io, "GroupNorm($(join(size(l.β), ", "))", ", ", l.G)
   print(io, "GroupNorm($(l.chs), $(l.G)")
   l.λ == identity || print(io, ", ", l.λ)
   hasaffine(l) || print(io,  ", affine=false")
+  l.active == nothing || print(io, ", active=", l.active)
   print(io, ")")
 end
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -1,5 +1,5 @@
 using Test, Random
-import Flux: activations
+using Flux: activations
 
 @testset "basic" begin
   @testset "helpers" begin
@@ -16,11 +16,11 @@ import Flux: activations
   end
 
   @testset "Chain" begin
-    @test_nowarn Chain(Dense(10, 5, σ), Dense(5, 2))(randn(10))
-    @test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn(10))
+    @test_nowarn Chain(Dense(10, 5, σ), Dense(5, 2))(randn32(10))
+    @test_throws DimensionMismatch Chain(Dense(10, 5, σ),Dense(2, 1))(randn32(10))
     # numeric test should be put into testset of corresponding layer
 
-    @test_nowarn Chain(first = Dense(10, 5, σ), second = Dense(5, 2))(randn(10))
+    @test_nowarn Chain(first = Dense(10, 5, σ), second = Dense(5, 2))(randn32(10))
     m = Chain(first = Dense(10, 5, σ), second = Dense(5, 2))
     @test m[:first] == m[1]
     @test m[1:2] == m
@@ -72,10 +72,10 @@ import Flux: activations
       @test_throws MethodError Dense(rand(5), rand(5), tanh)
     end
     @testset "dimensions" begin
-      @test  length(Dense(10, 5)(randn(10))) == 5
-      @test_throws DimensionMismatch Dense(10, 5)(randn(1))
-      @test_throws MethodError Dense(10, 5)(1) # avoid broadcasting
-      @test_throws MethodError Dense(10, 5).(randn(10)) # avoid broadcasting
+      @test  length(Dense(10 => 5)(randn32(10))) == 5
+      @test_throws DimensionMismatch Dense(10 => 5)(randn32(1))
+      @test_throws MethodError Dense(10 => 5)(1) # avoid broadcasting
+      @test_throws MethodError Dense(10 => 5).(randn32(10)) # avoid broadcasting
       @test size(Dense(10, 5)(randn(10))) == (5,)
       @test size(Dense(10, 5)(randn(10,2))) == (5,2)
       @test size(Dense(10, 5)(randn(10,2,3))) == (5,2,3)
@@ -333,7 +333,7 @@ import Flux: activations
     y = m(x)
     @test y isa Array{Float32, 3}
     @test size(y) == (embed_size, 3, 4)
-    x3 = onehotbatch(x, 1:1:vocab_size)
+    x3 = Flux.onehotbatch(x, 1:1:vocab_size)
     @test size(x3) == (vocab_size, 3, 4)
     y3 = m(x3)
     @test size(y3) == (embed_size, 3, 4)

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -79,9 +79,8 @@ evalwgrad(f, x...) = pullback(f, x...)[1]
     end
   end
 
-  @test Dropout(0.5; active=:auto).active === nothing
   @test Dropout(0.5; active=true).active === true
-  @test_throws ArgumentError Dropout(0.5; active=:something_else)
+  @test_throws Exception Dropout(0.5; active=:something_else)
 end
 
 @testset "AlphaDropout" begin
@@ -129,9 +128,8 @@ end
     end
   end
 
-  @test AlphaDropout(0.5; active=:auto).active === nothing
   @test AlphaDropout(0.5; active=true).active === true
-  @test_throws ArgumentError AlphaDropout(0.5; active=:something_else)
+  @test_throws Exception AlphaDropout(0.5; active=:something_else)
 end
 
 @testset "BatchNorm" begin
@@ -225,9 +223,8 @@ end
   @test length(Flux.params(BatchNorm(10, affine=true))) == 2
   @test length(Flux.params(BatchNorm(10, affine=false))) == 0
 
-  @test BatchNorm(5; active=:auto).active === nothing
   @test BatchNorm(5; active=true).active === true
-  @test_throws ArgumentError BatchNorm(5; active=:something_else)
+  @test_throws Exception BatchNorm(5; active=:something_else)
 end
 
 @testset "InstanceNorm" begin
@@ -360,9 +357,8 @@ end
   @test length(Flux.params(InstanceNorm(10, affine=true))) == 2
   @test length(Flux.params(InstanceNorm(10, affine=false))) == 0
 
-  @test InstanceNorm(5; active=:auto).active === nothing
   @test InstanceNorm(5; active=true).active === true
-  @test_throws ArgumentError InstanceNorm(5; active=:something_else)
+  @test_throws Exception InstanceNorm(5; active=:something_else)
 end
 
 @testset "LayerNorm" begin
@@ -487,9 +483,8 @@ end
     @test BN(x) ≈ GN(x)
   end
 
-  @test GroupNorm(5, 5; active=:auto).active === nothing
   @test GroupNorm(5, 5; active=true).active === true
-  @test_throws ArgumentError GroupNorm(5, 5; active=:something_else)
+  @test_throws Exception GroupNorm(5, 5; active=:something_else)
 end
 
 @testset "second derivatives" begin

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -29,7 +29,7 @@ evalwgrad(f, x...) = pullback(f, x...)[1]
     # Keyword active=false
     m2 = Dropout(0.9; active=false, rng_kwargs...)
     y2 = evalwgrad(m2, x)
-    @test count(a->a==0, y2) == 0
+    @test count(iszero, y2) == 0
 
     x = rand(Float32, 100)
     m = Chain(Dense(100,100),

--- a/test/layers/normalisation.jl
+++ b/test/layers/normalisation.jl
@@ -26,6 +26,11 @@ evalwgrad(f, x...) = pullback(f, x...)[1]
     y = evalwgrad(m, x)
     @test count(a->a==0, y) > 50
 
+    # Keyword active=false
+    m2 = Dropout(0.9; active=false, rng_kwargs...)
+    y2 = evalwgrad(m2, x)
+    @test count(a->a==0, y2) == 0
+
     x = rand(Float32, 100)
     m = Chain(Dense(100,100),
               Dropout(0.9; rng_kwargs...))
@@ -73,6 +78,10 @@ evalwgrad(f, x...) = pullback(f, x...)[1]
       @test cpu(m).rng === only(values(rng_kwargs))
     end
   end
+
+  @test Dropout(0.5; active=:auto).active === nothing
+  @test Dropout(0.5; active=true).active === true
+  @test_throws ArgumentError Dropout(0.5; active=:something_else)
 end
 
 @testset "AlphaDropout" begin
@@ -119,6 +128,10 @@ end
       @test cpu(m).rng === only(values(rng_kwargs))
     end
   end
+
+  @test AlphaDropout(0.5; active=:auto).active === nothing
+  @test AlphaDropout(0.5; active=true).active === true
+  @test_throws ArgumentError AlphaDropout(0.5; active=:something_else)
 end
 
 @testset "BatchNorm" begin
@@ -211,6 +224,10 @@ end
   @test length(Flux.params(BatchNorm(10))) == 2
   @test length(Flux.params(BatchNorm(10, affine=true))) == 2
   @test length(Flux.params(BatchNorm(10, affine=false))) == 0
+
+  @test BatchNorm(5; active=:auto).active === nothing
+  @test BatchNorm(5; active=true).active === true
+  @test_throws ArgumentError BatchNorm(5; active=:something_else)
 end
 
 @testset "InstanceNorm" begin
@@ -342,6 +359,10 @@ end
   @test length(Flux.params(InstanceNorm(10))) == 0
   @test length(Flux.params(InstanceNorm(10, affine=true))) == 2
   @test length(Flux.params(InstanceNorm(10, affine=false))) == 0
+
+  @test InstanceNorm(5; active=:auto).active === nothing
+  @test InstanceNorm(5; active=true).active === true
+  @test_throws ArgumentError InstanceNorm(5; active=:something_else)
 end
 
 @testset "LayerNorm" begin
@@ -465,6 +486,10 @@ end
       x = Float32.(reshape(collect(1:prod(sizes)), sizes))
     @test BN(x) ≈ GN(x)
   end
+
+  @test GroupNorm(5, 5; active=:auto).active === nothing
+  @test GroupNorm(5, 5; active=true).active === true
+  @test_throws ArgumentError GroupNorm(5, 5; active=:something_else)
 end
 
 @testset "second derivatives" begin


### PR DESCRIPTION
As discussed starting here https://github.com/FluxML/Flux.jl/pull/2150#issuecomment-1406875399 this prints an indication when layers like `Dropout` are set to train/test mode. But not in the default automatic state:
```julia
julia> m
Chain(
  Dense(2 => 3),                        # 9 parameters
  Dropout(0.4),
  BatchNorm(3),                         # 6 parameters, plus 6
)         # Total: 4 trainable arrays, 15 parameters,
          # plus 2 non-trainable, 6 parameters, summarysize 512 bytes.

julia> trainmode!(m)
Chain(
  Dense(2 => 3),                        # 9 parameters
  Dropout(0.4, active=true),
  BatchNorm(3, active=true),            # 6 parameters, plus 6
)         # Total: 4 trainable arrays, 15 parameters,
          # plus 2 non-trainable, 6 parameters, summarysize 513 bytes.
```
Adds the keyword printed to the constructor too. 

Needs tests.