### PR TITLE
Fix Conv transfer to AMDGPU

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [compat]
-AMDGPU = "0.4.8"
+AMDGPU = "0.4.13"
 Adapt = "3.0"
 CUDA = "3, 4"
 ChainRulesCore = "1.12"

--- a/ext/AMDGPUExt/functor.jl
+++ b/ext/AMDGPUExt/functor.jl
@@ -37,10 +37,10 @@ const FLUX_CONV{M} = Union{
 const CPU_CONV = FLUX_CONV{Array}
 const AMD_CONV = FLUX_CONV{ROCArray}
 
-_conv_basetype(c::C) where C <: Conv = Conv
-_conv_basetype(c::C) where C <: ConvTranspose = ConvTranspose
+_conv_basetype(::Conv) = Conv
+_conv_basetype(::ConvTranspose) = ConvTranspose
 
-Flux._isleaf(::AMD_CONV) = return true
+Flux._isleaf(::AMD_CONV) = true
 
 _exclude(x) = _isleaf(x)
 _exclude(::CPU_CONV) = true
@@ -64,7 +64,7 @@ end
 
 # Don't adapt again.
 
-Adapt.adapt_structure(to::FluxAMDAdaptor, m::AMD_CONV) = return m
+Adapt.adapt_structure(to::FluxAMDAdaptor, m::AMD_CONV) = m
 
 # GPU -> CPU
 

--- a/test/amd/basic.jl
+++ b/test/amd/basic.jl
@@ -46,10 +46,26 @@ end
     end
 end
 
+@testset "Chain(Conv)" begin
+    m = Chain(Conv((3, 3), 3 => 3)) |> f32
+    x = rand(Float32, 10, 10, 3, 2)
+    gpu_autodiff_test(m, x; atol=1f-3, checkgrad=false)
+
+    md = m |> gpu |> cpu
+    @test md[1].weight ≈ m[1].weight atol=1f-3
+
+    m = Chain(ConvTranspose((3, 3), 3 => 3)) |> f32
+    x = rand(Float32, 10, 10, 3, 2)
+    gpu_autodiff_test(m, x; atol=1f-3, checkgrad=false)
+
+    md = m |> gpu |> cpu
+    @test md[1].weight ≈ m[1].weight atol=1f-3
+end
+
 @testset "Cross-correlation" begin
     m = CrossCor((2, 2), 3 => 4) |> f32
     x = rand(Float32, 10, 10, 3, 2)
-    gpu_autodiff_test(m, x)
+    gpu_autodiff_test(m, x; atol=1f-3)
 end
 
 @testset "Restructure" begin

--- a/test/amd/runtests.jl
+++ b/test/amd/runtests.jl
@@ -1,19 +1,13 @@
-Flux.gpu_backend!("AMD")
-
-AMDGPU.allowscalar(false)
-
-# Extend test utils to AMDGPU.
-
 function check_grad(
-    g_gpu::ROCArray{Float32}, g_cpu::Array{Float32}, atol, rtol;
-    allow_nothing::Bool,
+    g_gpu::ROCArray{Float32}, g_cpu::Array{Float32};
+    atol, rtol, allow_nothing::Bool,
 )
     @test g_cpu ≈ collect(g_gpu) atol=atol rtol=rtol
 end
 
 function check_grad(
-    g_gpu::ROCArray{Float32}, g_cpu::Zygote.FillArrays.AbstractFill,
-    atol, rtol; allow_nothing::Bool,
+    g_gpu::ROCArray{Float32}, g_cpu::Zygote.FillArrays.AbstractFill;
+    atol, rtol, allow_nothing::Bool,
 )
     @test g_cpu ≈ collect(g_gpu) atol=atol rtol=rtol
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,9 +66,10 @@ Random.seed!(0)
 
   if get(ENV, "FLUX_TEST_AMDGPU", "false") == "true"
     using AMDGPU
-    AMDGPU.versioninfo()
+    Flux.gpu_backend!("AMD")
+    AMDGPU.allowscalar(false)
+
     if AMDGPU.functional() && AMDGPU.functional(:MIOpen)
-      @show AMDGPU.MIOpen.version()
       @testset "AMDGPU" begin
         include("amd/runtests.jl")
       end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -2,6 +2,7 @@ function check_grad(g_gpu, g_cpu;
             rtol=1e-4, atol=1e-4,
             allow_nothing::Bool=false)
     allow_nothing && return
+    @warn "Unsupported types in `check_grad`: $(typeof(g_gpu)), $(typeof(g_cpu))"
     @show g_gpu g_cpu
     @test false
 end


### PR DESCRIPTION
Previously only this flipped conv weights:
```julia
Conv((3, 3), 3 => 3) |> gpu
```
but not this (or anything more complex):
```julia
Chain(Conv((3, 3), 3 => 3)) |> gpu
```

To fix this, I modified `exclude` function passed to `fmap` both for `CPU -> GPU` & `GPU -> CPU` transfer (so that weights are flipped back).

- Update AMDGPU compat to latest to include MIOpen synchronization fix: https://github.com/JuliaGPU/AMDGPU.jl/pull/415

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
