### PR TITLE
gpu(::DataLoader), take II

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # Flux Release Notes
 
-* `DataLoader(...) |> gpu` will now produce a special iterator, instead of an error.
+## 0.13.16
+* `DataLoader(...) |> gpu` will now produce a special iterator, moving each batch as needed,
+  instead of giving an error.
 
 ## v0.13.15
 * Added [MultiHeadAttention](https://github.com/FluxML/Flux.jl/pull/2146) layer.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Flux Release Notes
 
+* `DataLoader(...) |> gpu` will now produce a special iterator, instead of an error.
+
 ## v0.13.15
 * Added [MultiHeadAttention](https://github.com/FluxML/Flux.jl/pull/2146) layer.
 * `f16, f32, f64` now specifically target floating point arrays (i.e. integers arrays and other types are preserved).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.13.15"
+version = "0.13.16"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -125,6 +125,7 @@ julia> x |> cpu
 ```@docs
 cpu
 gpu
+gpu(::Flux.DataLoader)
 ```
 
 ## Common GPU Workflows

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -475,7 +475,7 @@ function Base.showarg(io::IO, e::DeviceIterator, toplevel)
     print(io, ")")
 end
 
-Base.show(io::IO, e::DataLoader) = Base.showarg(io, e, false)
+Base.show(io::IO, e::DeviceIterator) = Base.showarg(io, e, false)
 
 function Base.show(io::IO, m::MIME"text/plain", e::DeviceIterator)
     if Base.haslength(e)

--- a/test/amd/basic.jl
+++ b/test/amd/basic.jl
@@ -101,3 +101,16 @@ end
         gpu_autodiff_test(bn, x; atol=1f-3, allow_nothing=true)
     end
 end
+
+@testset "gpu(::DataLoader)" begin
+    X = randn(Float64, 3, 33)
+    pre1 = Flux.DataLoader(X |> Flux.gpu; batchsize=13, shuffle=false)
+    post1 = Flux.DataLoader(X; batchsize=13, shuffle=false) |> Flux.gpu
+    for epoch in 1:2
+        for (p, q) in zip(pre1, post1)
+            @test p isa ROCArray{Float32}
+            @test q isa ROCArray{Float32}
+            @test p ≈ q
+        end
+    end
+end

--- a/test/cuda/dataloader.jl
+++ b/test/cuda/dataloader.jl
@@ -1,0 +1,79 @@
+using Flux, CUDA, Test
+CUDA.allowscalar(false)
+
+@testset "Flux.DeviceIterator" begin
+  # Adapted from https://github.com/JuliaGPU/CUDA.jl/blob/master/test/iterator.jl
+  batch_count = 10
+  max_batch_items = 3
+  max_ndims = 3
+  sizes = 20:50
+  rand_shape = () -> rand(sizes, rand(1:max_ndims))
+  batches = [[rand(Float32, rand_shape()...) for _ in 1:rand(1:max_batch_items)]
+                                     for _ in 1:batch_count]
+
+  cubatches = Flux.DeviceIterator(Flux.FluxCUDAAdaptor(), batch for batch in batches) # ensure generators are accepted
+  global previous_cubatch = missing
+  for (batch, cubatch) in zip(batches, cubatches)
+    global previous_cubatch
+    @test ismissing(previous_cubatch) || all(x -> x.storage === nothing, previous_cubatch)
+    @test batch == Array.(cubatch)
+    @test all(x -> x isa CuArray, cubatch)
+    previous_cubatch = cubatch
+  end
+
+  @test Base.IteratorSize(typeof(cubatches)) isa Base.HasShape{1}
+  @test length(cubatches) == length(batch for batch in batches)
+  @test axes(cubatches) == axes(batch for batch in batches)
+  @test Base.IteratorEltype(typeof(cubatches)) isa Base.EltypeUnknown
+  @test eltype(cubatches) == eltype(batch for batch in batches) == Any
+  @test Base.IteratorEltype(typeof(Flux.DeviceIterator(Flux.FluxCUDAAdaptor(), batches))) isa Base.HasEltype
+  @test eltype(Flux.DeviceIterator(Flux.FluxCUDAAdaptor(), batches)) == eltype(batches)  # Vector
+
+  # Also check recursion into NamedTuple, and that it converts to Float32
+  it_nt = Flux.DeviceIterator(Flux.FluxCUDAAdaptor(), (x=Float64[i,i/2], y=i) for i in 1:4)
+  @test first(it_nt).x isa CuArray{Float32}
+  batch1, state = iterate(it_nt)
+  @test batch1.x == cu([1,1/2])
+  batch2, _ = iterate(it_nt, state)
+  @test batch2.x == cu([2,2/2])
+  @test batch1.x.storage === nothing  # unsafe_free! has worked inside
+
+  it_vec = Flux.DeviceIterator(Flux.FluxCUDAAdaptor(), [[i,i/2], [i/3, i/4]] for i in 1:4)
+  @test first(it_vec)[1] isa CuArray{Float32}
+end
+
+# This is the only documented way to use DeviceIterator
+@testset "gpu(::DataLoader)" begin
+  X = randn(Float64, 3, 33)
+  pre1 = Flux.DataLoader(X |> gpu; batchsize=13, shuffle=false)
+  post1 = Flux.DataLoader(X; batchsize=13, shuffle=false) |> gpu
+  @test pre1 isa Flux.DataLoader
+  p1 = first(pre1)
+  @test post1 isa Flux.DeviceIterator
+  q1 = first(post1)
+  for epoch in 1:2
+    for (p, q) in zip(pre1, post1)
+      @test p isa CuArray{Float32}
+      @test q isa CuArray{Float32}
+      @test p ≈ q
+    end
+  end
+  @test p1.storage !== nothing
+  @test q1.storage === nothing  # this memory has been freed
+
+  Y = Flux.onehotbatch(rand(0:2, 33), 0:2)
+  pre2 = Flux.DataLoader((x=X, y=Y) |> gpu; batchsize=7, shuffle=false)
+  post2 = Flux.DataLoader((x=X, y=Y); batchsize=7, shuffle=false) |> gpu
+  q2 = first(post2)
+  for (p, q) in zip(pre2, post2)
+    @test p.x == q.x
+    @test_skip p.y == q.y  # https://github.com/FluxML/OneHotArrays.jl/issues/28 -- MethodError: getindex(::OneHotArrays.OneHotMatrix{UInt32, CuArray{UInt32, 1, CUDA.Mem.DeviceBuffer}}, ::Int64, ::Int64) is ambiguous
+  end
+  q2.x.storage === nothing
+  q2.y.indices.storage === nothing
+
+  @test collect(pre2) isa Vector{NamedTuple{(:x, :y)}}
+  @test_broken collect(post2) isa Vector{NamedTuple{(:x, :y)}}  # collect makes no sense, but check eltype?
+
+  @test_throws Exception gpu(((x = Flux.DataLoader(X), y = Y),))
+end

--- a/test/cuda/dataloader.jl
+++ b/test/cuda/dataloader.jl
@@ -72,8 +72,8 @@ end
   q2.x.storage === nothing
   q2.y.indices.storage === nothing
 
-  @test collect(pre2) isa Vector{NamedTuple{(:x, :y)}}
-  @test_broken collect(post2) isa Vector{NamedTuple{(:x, :y)}}  # collect makes no sense, but check eltype?
+  @test collect(pre2) isa Vector{<:NamedTuple{(:x, :y)}}
+  @test_broken collect(post2) isa Vector{<:NamedTuple{(:x, :y)}}  # collect makes no sense, but check eltype?
 
   @test_throws Exception gpu(((x = Flux.DataLoader(X), y = Y),))
 end

--- a/test/cuda/runtests.jl
+++ b/test/cuda/runtests.jl
@@ -3,12 +3,13 @@ using Zygote
 using Zygote: pullback
 using Random, LinearAlgebra, Statistics
 
-@info "Testing GPU Support"
+@info "Testing CUDA GPU Support"
 CUDA.allowscalar(false)
 
 include("cuda.jl")
 include("losses.jl")
 include("layers.jl")
+include("dataloader.jl")
 
 if CUDA.functional()
   @info "Testing Flux/CUDNN"


### PR DESCRIPTION
Closes https://github.com/FluxML/Flux.jl/pull/2186 , by replacing CuIterator with much the same thing, but owned by Flux.

The advantage of this is that we can control exactly what it does, to match `gpu(x)`. This means converting to Float32, and also working with AMDGPU arrays (and whatever we add next).

Needs tests.

### PR Checklist

- [x] Tests are added
- [x] Entry in NEWS.md
- [x] Documentation, if applicable
