### PR TITLE
[CI] Separate julia-nightly from common matrix generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,24 +13,29 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.6' # Replace this with the minimum Julia version that your package supports.
           - '1'
-          - 'nightly'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+        os: [ubuntu-latest]
+        arch: [x64]
+        allow_failure: [false]
         include:
+          - os: ubuntu-latest
+            version: 'nightly'
+            arch: x64
+            allow_failure: true
           - os: windows-latest
             version: '1'
             arch: x64
+            allow_failure: false
           - os: macOS-latest
             version: '1'
             arch: x64
+            allow_failure: false
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
About #2237 

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable

### Screenshot

The corresponding run is  [here](https://github.com/skyleaworlder/Flux.jl/actions/runs/4901856571).

<img width="618" alt="image" src="https://user-images.githubusercontent.com/45269589/236632328-476f28ad-8ffc-406c-9eee-08b4999dff7f.png">

