### PR TITLE
Make BatchNorm twice-differentiable

### DIFF
--- a/src/cuda/cudnn.jl
+++ b/src/cuda/cudnn.jl
@@ -13,9 +13,9 @@ end
 
 function ChainRulesCore.rrule(::typeof(batchnorm), g, b, x, running_mean, running_var, momentum; kw...)
   y = batchnorm(g, b, x, running_mean, running_var, momentum; kw...) 
-  function batchnorm_pullback(Δ)
-    grad = ∇batchnorm(g, b, x, unthunk(Δ), running_mean, running_var, momentum; kw...)
-    (NoTangent(), grad..., NoTangent(), NoTangent(), NoTangent())
+  function batchnorm_pullback(Δ, σ²Δ)
+    grad, σ²grad = ∇batchnorm(g, b, x, unthunk(Δ), running_mean, running_var, momentum; kw...)
+    (NoTangent(), grad..., NoTangent(), NoTangent(), σ²grad..., NoTangent())
   end
   y, batchnorm_pullback
 end


### PR DESCRIPTION
Solves the 'BatchNorm not being twice-differentiable' problem first reported at https://discourse.julialang.org/t/compilation-error-in-zygote-flux-and-cuda-interaction/92571 and made into issue #2154. Relevant documentation update would be made at https://fluxml.ai/Flux.jl/stable/models/layers/#Flux.BatchNorm, however this is unnecessary.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
