### PR TITLE
fix doc of `PairwiseFusion`

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -579,8 +579,8 @@ x1 → layer1 → y1 ↘
 ... or written as:
 ```julia
 y1 = layer1(x1)
-y2 = layer2(connection(x2, y1))
-y3 = layer3(connection(x3, y2))
+y2 = layer2(connection(y1, x2))
+y3 = layer3(connection(y2, x3))
 ```
 
 2. With just one input, each layer receives the same `x` combined with the previous output.
@@ -589,7 +589,7 @@ y3 = layer3(connection(x3, y2))
 ```julia
 y[1] == layers[1](x)
 for i in 2:length(layers)
-    y[i] == connection(x, layers[i](y[i-1]))
+    y[i] == connection(layers[i](y[i-1]), x)
 end
 ```
 


### PR DESCRIPTION
according to the implementation: https://github.com/FluxML/Flux.jl/blob/24b1eb2f0c7de93e36d47833ae47a1b473f31f80/src/layers/basic.jl#L637, the `connection` of `PairwiseFusion` is called as `connection(y1, x2)` instead of `connection(x2, y1)`.