### PR TITLE
Fix typos in 0.14 docs

### DIFF
--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -2,7 +2,7 @@
 
 Starting with v0.14, Flux doesn't force a specific GPU backend and the corresponding package dependencies on the users. 
 Thanks to the [package extension mechanism](
-https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)) introduced in julia v1.9, Flux conditionally load GPU specific code once a GPU package is made available (e.g. through `using CUDA`).
+https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions)) introduced in julia v1.9, Flux conditionally loads GPU specific code once a GPU package is made available (e.g. through `using CUDA`).
 
 NVIDIA GPU support requires the packages `CUDA.jl` and `cuDNN.jl` to be installed in the environment. In the julia REPL, type `] add CUDA, cuDNN` to install them. For more details see the [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) readme.
 
@@ -11,7 +11,7 @@ AMD GPU support is available since Julia 1.9 on systems with ROCm and MIOpen ins
 Metal GPU acceleration is available on Apple Silicon hardware. For more details refer to the [Metal.jl](https://github.com/JuliaGPU/Metal.jl) repository. Metal support in Flux is experimental and many features are not yet available.
 
 In order to trigger GPU support in Flux, you need to call `using CUDA`, `using AMDGPU` or `using Metal`
-in your code. Notice that for CUDA, explicitely loading also `cuDNN` is not required, but the package has to be installed in the environment. 
+in your code. Notice that for CUDA, explicitly loading also `cuDNN` is not required, but the package has to be installed in the environment. 
 
 
 !!! compat "Flux ≤ 0.13"

--- a/docs/src/training/reference.md
+++ b/docs/src/training/reference.md
@@ -41,7 +41,7 @@ Optimisers.thaw!
 
 Flux used to handle gradients, training, and optimisation rules quite differently.
 The new style described above is called "explicit" by Zygote, and the old style "implicit".
-Flux 0.13 and 0.14 are the transitional version which supports both; Flux 0.15 will remove the old.
+Flux 0.13 and 0.14 are the transitional versions which support both; Flux 0.15 will remove the old.
 
 !!! compat "How to upgrade"
     The blue-green boxes in the [training section](@ref man-training) describe


### PR DESCRIPTION
I was going through the doc changes for 0.14 and caught a few typos.
I made sure none of my changes were opinionated so hopefully this can get merged before #2284.
