### PR TITLE
fix: make `gpu(x)` return unmodified `x` when GPU backends aren't loaded

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -341,6 +341,7 @@ function gpu(::FluxCUDAAdaptor, x)
         `CUDA.jl` must be loaded to access it.
         Add `using CUDA` or `import CUDA` to your code.
         """ maxlog=1
+        return x
     end
 end
 
@@ -361,6 +362,7 @@ function gpu(::FluxAMDAdaptor, x)
         `AMDGPU.jl` must be loaded to access it.
         Add `using AMDGPU` or `import AMDGPU` to your code.
         """ maxlog=1
+        return x
     end
 end
 
@@ -380,6 +382,7 @@ function gpu(::FluxMetalAdaptor, x)
         The Metal functionality is being called but
         `Metal.jl` must be loaded to access it.
         """ maxlog=1
+        return x
     end
 end
 

--- a/test/functors.jl
+++ b/test/functors.jl
@@ -1,10 +1,4 @@
 x = rand(Float32, 10, 10)
-if Flux.CUDA_LOADED[]
-    @test x !== gpu(x)
-elseif Flux.AMD_LOADED[]
-    @test x !== gpu(x)
-elseif Flux.METAL_LOADED[]
-    @test x !== gpu(x)
-else
+if !(Flux.CUDA_LOADED[] || Flux.AMD_LOADED[] || Flux.METAL_LOADED[])
     @test x === gpu(x)
 end

--- a/test/functors.jl
+++ b/test/functors.jl
@@ -1,0 +1,10 @@
+x = rand(Float32, 10, 10)
+if Flux.CUDA_LOADED[]
+    @test x !== gpu(x)
+elseif Flux.AMD_LOADED[]
+    @test x !== gpu(x)
+elseif Flux.METAL_LOADED[]
+    @test x !== gpu(x)
+else
+    @test x === gpu(x)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,9 @@ Random.seed!(0)
     include("outputsize.jl")
   end
 
+  @testset "functors" begin
+    include("functors.jl")
+  end
 
   if get(ENV, "FLUX_TEST_CUDA", "false") == "true"
     using CUDA


### PR DESCRIPTION
Fixes #2294 

It seems a simple `gpu(x)` on a cpu-only machine isn't tested.
Can someone point me to where the tests run on a machine without a gpu so I can add that?


### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
