### PR TITLE
Run only GPU tests on buildkite.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,6 +24,7 @@ steps:
       cuda: "*"
     env:
       JULIA_CUDA_USE_BINARYBUILDER: "true"
+      FLUX_TEST_CPU: "false"
     timeout_in_minutes: 60
 
   # - label: "GPU nightly"
@@ -57,6 +58,7 @@ steps:
     timeout_in_minutes: 60
     env:
       FLUX_TEST_METAL: 'true'
+      FLUX_TEST_CPU: "false"
     matrix:
       setup:
         julia:
@@ -83,6 +85,7 @@ steps:
       JULIA_AMDGPU_HIP_MUST_LOAD: "1"
       JULIA_AMDGPU_DISABLE_ARTIFACTS: "1"
       FLUX_TEST_AMDGPU: true
+      FLUX_TEST_CPU: "false"
       JULIA_NUM_THREADS: 4
 env:
   SECRET_CODECOV_TOKEN: "fAV/xwuaV0l5oaIYSAXRQIor8h7yHdlrpLUZFwNVnchn7rDk9UZoz0oORG9vlKLc1GK2HhaPRAy+fTkJ3GM/8Y0phHh3ANK8f5UsGm2DUTNsnf6u9izgnwnoRTcsWu+vSO0fyYrxBvBCoJwljL+yZbDFz3oE16DP7HPIzxfQagm+o/kMEszVuoUXhuLXXH0LxT6pXl214qjqs04HfMRmKIIiup48NB6fBLdhGlQz64MdMNHBfgDa/fafB7eNvn0X6pEOxysoy6bDQLUhKelOXgcDx1UsTo34Yiqr+QeJPAeKcO//PWurwQhPoUoHfLad2da9DN4uQk4YQLqAlcIuAA==;U2FsdGVkX1+mRXF2c9soCXT7DYymY3msM+vrpaifiTp8xA+gMpbQ0G63WY3tJ+6V/fJcVnxYoKZVXbjcg8fl4Q=="

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,53 +11,65 @@ using cuDNN
 # ENV["FLUX_TEST_AMDGPU"] = "true"
 ENV["FLUX_TEST_CUDA"] = "true"
 # ENV["FLUX_TEST_METAL"] = "true"
+# ENV["FLUX_TEST_CPU"] = "false"
 
 include("test_utils.jl")
 
 Random.seed!(0)
 
 @testset verbose=true "Flux.jl" begin
+  if get(ENV, "FLUX_TEST_CPU", "true") == "true"
+    @testset "Utils" begin
+      include("utils.jl")
+    end
 
-  @testset "Utils" begin
-    include("utils.jl")
-  end
+    @testset "Loading" begin
+      include("loading.jl")
+    end
 
-  @testset "Loading" begin
-    include("loading.jl")
-  end
+    @testset "Optimise / Train" begin
+      include("optimise.jl")
+      include("train.jl")
+    end
 
-  @testset "Optimise / Train" begin
-    include("optimise.jl")
-    include("train.jl")
-  end
+    @testset "Data" begin
+      include("data.jl")
+    end
 
-  @testset "Data" begin
-    include("data.jl")
-  end
+    @testset "Losses" begin
+      include("losses.jl")
+      include("ctc.jl")
+    end
 
-  @testset "Losses" begin
-    include("losses.jl")
-    include("ctc.jl")
-  end
+    @testset "Layers" begin
+      include("layers/attention.jl")
+      include("layers/basic.jl")
+      include("layers/normalisation.jl")
+      include("layers/stateless.jl")
+      include("layers/recurrent.jl")
+      include("layers/conv.jl")
+      include("layers/upsample.jl")
+      include("layers/show.jl")
+    end
 
-  @testset "Layers" begin
-    include("layers/attention.jl")
-    include("layers/basic.jl")
-    include("layers/normalisation.jl")
-    include("layers/stateless.jl")
-    include("layers/recurrent.jl")
-    include("layers/conv.jl")
-    include("layers/upsample.jl")
-    include("layers/show.jl")
-  end
+    @testset "outputsize" begin
+      using Flux: outputsize
+      include("outputsize.jl")
+    end
 
-  @testset "outputsize" begin
-    using Flux: outputsize
-    include("outputsize.jl")
-  end
+    @testset "functors" begin
+      include("functors.jl")
+    end
 
-  @testset "functors" begin
-    include("functors.jl")
+    @static if VERSION == v"1.9"
+      using Documenter
+      @testset "Docs" begin
+        DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive=true)
+        doctest(Flux)
+      end
+    end
+  else
+      @info "Skipping CPU tests."
   end
 
   if get(ENV, "FLUX_TEST_CUDA", "false") == "true"
@@ -105,11 +117,4 @@ Random.seed!(0)
     @info "Skipping Metal tests, set FLUX_TEST_METAL=true to run them."
   end
 
-  @static if VERSION == v"1.9"
-    using Documenter
-    @testset "Docs" begin
-      DocMeta.setdocmeta!(Flux, :DocTestSetup, :(using Flux); recursive=true)
-      doctest(Flux)
-    end
-  end
 end


### PR DESCRIPTION
This PR adds a new boolean environment variable `FLUX_TEST_CPU` (which is true by default). If this flag is true, then CPU tests are run, otherwise they are skipped. CPU tests from buildkite are thus removed easily.

Closes #2271.