### PR TITLE
Adding tooling for `JuliaFormatter`.

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,6 @@
+indent = 4
+margin = 80
+always_for_in = true
+whitespace_typedefs = true
+whitespace_ops_in_indices = true
+remove_extra_newlines = false

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,1 @@
+julia --color=yes dev/flux_format.jl --verbose .

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-julia --color=yes dev/flux_format.jl --verbose .
+julia --color=yes dev/flux_format.jl .

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 julia --color=yes dev/flux_format.jl --verbose .

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    branches:
+      - main
+      - trying
+      - staging
+    tags: '*'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  format:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.4.0
+      with:
+        access_token: ${{ github.token }}
+
+    - uses: actions/checkout@v2.2.0
+
+    - uses: dorny/paths-filter@v2.9.1
+      id: filter
+      with:
+        filters: |
+          julia_file_change:
+            - added|modified: '**.jl'
+
+    - uses: julia-actions/setup-julia@latest
+      if: steps.filter.outputs.julia_file_change == 'true'
+      with:
+        version: 1.9
+
+    - name: Apply JuliaFormatter
+      if: steps.filter.outputs.julia_file_change == 'true'
+      run: |
+        julia --color=yes dev/flux_format.jl --verbose .
+
+    - name: Check formatting diff
+      if: steps.filter.outputs.julia_file_change == 'true'
+      run: |
+        git diff --color=always --exit-code

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -1,9 +1,7 @@
 on:
   push:
     branches:
-      - main
-      - trying
-      - staging
+      - master
     tags: '*'
   pull_request:
     types:
@@ -17,11 +15,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.4.0
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v2.2.0
 
     - uses: dorny/paths-filter@v2.9.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,3 +155,19 @@ The following table shows how the Flux code is organized:
 | paper  | Paper that describes Flux |
 | src    |  Source for Flux  |
 | test   |  Test suites  |
+
+### Julia Formatter
+
+Flux also uses it's own formatting style (see `dev/flux_format.jl`), with the style defined in the `.JuliaFormatter.toml` config file. All contributors must make sure to conform to this formatting style. To do this, run the following setup file on your local repository:
+
+```julia
+julia dev/setup.jl
+```
+
+This will setup the tooling environment (defined in the `dev/` directory), and will set up a hook to run the formatter before any changes are committed. You can also manually format the codebase by running
+
+```julia
+julia dev/flux_format.jl --verbose .
+```
+
+Flux's CI will also test whether any changes you make conform to this formatting style whenever any pull request is made.

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -1,4 +1,3 @@
 [deps]
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -1,2 +1,4 @@
 [deps]
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"

--- a/dev/flux_format.jl
+++ b/dev/flux_format.jl
@@ -1,6 +1,5 @@
 using Pkg
-Pkg.activate(@__DIR__)
-Pkg.instantiate()
+Pkg.activate(@__DIR__)      # no need to instantiate here
 
 using JuliaFormatter
 

--- a/dev/flux_format.jl
+++ b/dev/flux_format.jl
@@ -1,5 +1,6 @@
 using Pkg
-Pkg.activate(@__DIR__)      # no need to instantiate here
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
 
 using JuliaFormatter
 

--- a/dev/flux_format.jl
+++ b/dev/flux_format.jl
@@ -30,7 +30,7 @@ for (index, arg) in enumerate(ARGS)
         push!(indices_to_remove, index)
     elseif arg in ["-h", "--help"] 
         opt = :help 
-        push!(indices_to_remove)
+        push!(indices_to_remove, index)
     else
         error("Option $arg is not supported.")
     end

--- a/dev/flux_format.jl
+++ b/dev/flux_format.jl
@@ -1,0 +1,56 @@
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
+
+using JuliaFormatter
+
+help = """
+Usage: flux_format.jl [flags] [FILE/PATH]...
+
+Formats the given julia files using the Flux formatting options.
+If paths are given instead, it will format all *.jl files under
+the paths. If nothing is given, all changed julia files are formatted.
+
+    -v, --verbose
+        Print the name of the files being formatted with relevant details.
+
+    -h, --help
+        Print this help message.
+"""
+
+options = Dict{Symbol, Bool}()
+indices_to_remove = []      # used to delete options once processed
+
+for (index, arg) in enumerate(ARGS)
+    if arg[1] != '-'
+        continue
+    end
+    if arg in ["-v", "--verbose"]
+        opt = :verbose
+        push!(indices_to_remove, index)
+    elseif arg in ["-h", "--help"] 
+        opt = :help 
+        push!(indices_to_remove)
+    else
+        error("Option $arg is not supported.")
+    end
+    options[opt] = true
+end
+
+# remove options from args
+deleteat!(ARGS, indices_to_remove)
+
+# print help message if asked
+if haskey(options, :help)
+    write(stdout, help)
+    exit(0)
+end
+
+# otherwise format files
+if isempty(ARGS)
+    filenames = readlines(`git ls-files "*.jl"`)
+else
+    filenames = ARGS
+end
+
+format(filenames; options...)

--- a/dev/flux_format.jl
+++ b/dev/flux_format.jl
@@ -53,4 +53,5 @@ else
     filenames = ARGS
 end
 
+write(stdout, "Formatting in progress.\n")
 format(filenames; options...)

--- a/dev/setup.jl
+++ b/dev/setup.jl
@@ -1,3 +1,8 @@
+# instantiate the environment
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
+
 # setup the custom git hook
 using Git
 

--- a/dev/setup.jl
+++ b/dev/setup.jl
@@ -1,0 +1,9 @@
+# setup the custom git hook
+using Git
+
+# set the local hooks path
+const git = Git.git()
+run(`$git config --local core.hooksPath .githooks/`)
+
+# set file permission for hook
+Base.Filesystem.chmod(".githooks", 0o777; recursive = true)


### PR DESCRIPTION
This PR is to add some format tooling to Flux. A new environment is created in the `dev` folder, which will contain all dependencies required for the tooling (currently it only contains `JuliaFormatter.jl`). A new config file for `JuliaFormatter` is added, along with a script to run `JuliaFormatter` (`dev/flux_format.jl`). Along with this, a new `JuliaFormatter` CI has been added as well. Much of this is inspired from the workflow in [ClimaCore.jl](https://github.com/CliMA/ClimaCore.jl).

TODO: 

- [x] Implement a pre-commit hook which runs the formatting script before each commit.
- [x] Do we need to add docs for this?
- [x] Do we add this to our test suite?

Closes #2298.

cc @ToucheSir @CarloLucibello @darsnack 