### PR TITLE
rename "AMD" backend to "AMDGPU"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,7 @@ steps:
       rocm: "*"
       rocmgpu: "*"
     commands: |
-      printf "[Flux]\ngpu_backend = \"AMD\"" > LocalPreferences.toml
+      printf "[Flux]\ngpu_backend = \"AMDGPU\"" > LocalPreferences.toml
     timeout_in_minutes: 60
     env:
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -51,17 +51,17 @@ true
 
 ## Selecting GPU backend
 
-Available GPU backends are: `CUDA`, `AMD` and `Metal`.
+Available GPU backends are: `CUDA`, `AMDGPU` and `Metal`.
 
 Flux relies on [Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl) for selecting default GPU backend to use.
 
 There are two ways you can specify it:
 
-- From the REPL/code in your project, call `Flux.gpu_backend!("AMD")` and restart (if needed) Julia session for the changes to take effect.
+- From the REPL/code in your project, call `Flux.gpu_backend!("AMDGPU")` and restart (if needed) Julia session for the changes to take effect.
 - In `LocalPreferences.toml` file in you project directory specify:
 ```toml
 [Flux]
-gpu_backend = "AMD"
+gpu_backend = "AMDGPU"
 ```
 
 Current GPU backend can be fetched from `Flux.GPU_BACKEND` variable:
@@ -296,7 +296,7 @@ julia> model.weight     # no change; model still lives on CPU
 ```
 Clearly, this means that the same code will work for any GPU backend and the CPU. 
 
-If the preference backend isn't available or isn't functional, then [`Flux.get_device`](@ref) looks for a CUDA, AMD or Metal backend, and returns a corresponding device (if the backend is available and functional). Otherwise, a CPU device is returned. In the below example, the GPU preference is `"CUDA"`:
+If the preference backend isn't available or isn't functional, then [`Flux.get_device`](@ref) looks for a CUDA, AMDGPU or Metal backend, and returns a corresponding device (if the backend is available and functional). Otherwise, a CPU device is returned. In the below example, the GPU preference is `"CUDA"`:
 
 ```julia-repl
 julia> using Flux;      # preference is CUDA, but CUDA.jl not loaded
@@ -330,7 +330,7 @@ CUDA.DeviceIterator() for 3 devices:
 Then, let's select the device with id `0`:
 
 ```julia-repl
-julia> device0 = Flux.get_device("CUDA", 0)        # the currently supported values for backend are "CUDA" and "AMD"
+julia> device0 = Flux.get_device("CUDA", 0)        # the currently supported values for backend are "CUDA" and "AMDGPU"
 (::Flux.FluxCUDADevice) (generic function with 1 method)
 
 ```
@@ -367,7 +367,7 @@ CuDevice(1): GeForce RTX 2080 Ti
 
 ```
 
-Due to a limitation in `Metal.jl`, currently this kind of data movement across devices is only supported for `CUDA` and `AMD` backends.
+Due to a limitation in `Metal.jl`, currently this kind of data movement across devices is only supported for `CUDA` and `AMDGPU` backends.
 
 !!! warning "Printing models after moving to a different device"
     
@@ -380,7 +380,7 @@ Due to a limitation in `Metal.jl`, currently this kind of data movement across d
 Flux.AbstractDevice
 Flux.FluxCPUDevice
 Flux.FluxCUDADevice
-Flux.FluxAMDDevice
+Flux.FluxAMDGPUDevice
 Flux.FluxMetalDevice
 Flux.supported_devices
 Flux.get_device

--- a/ext/FluxAMDGPUExt/FluxAMDGPUExt.jl
+++ b/ext/FluxAMDGPUExt/FluxAMDGPUExt.jl
@@ -17,16 +17,16 @@ const MIOPENFloat = AMDGPU.MIOpen.MIOPENFloat
 # Set to boolean on the first call to check_use_amdgpu
 const USE_AMDGPU = Ref{Union{Nothing, Bool}}(nothing)
 
-function (device::Flux.FluxAMDDevice)(x)
+function (device::Flux.FluxAMDGPUDevice)(x)
     if device.deviceID === nothing
         Flux.gpu(Flux.FluxAMDAdaptor(), x)
     else
         return Flux.gpu(Flux.FluxAMDAdaptor(AMDGPU.device_id(device.deviceID) - 1), x)  # subtracting 1, because device_id returns a positive integer
     end
 end
-Flux._get_device_name(::Flux.FluxAMDDevice) = "AMD"
-Flux._isavailable(::Flux.FluxAMDDevice) = true
-Flux._isfunctional(::Flux.FluxAMDDevice) = AMDGPU.functional()
+Flux._get_device_name(::Flux.FluxAMDGPUDevice) = "AMDGPU"
+Flux._isavailable(::Flux.FluxAMDGPUDevice) = true
+Flux._isfunctional(::Flux.FluxAMDGPUDevice) = AMDGPU.functional()
 
 function check_use_amdgpu()
     if !isnothing(USE_AMDGPU[])
@@ -55,7 +55,7 @@ include("conv.jl")
 
 function __init__()
     Flux.AMDGPU_LOADED[] = true
-    Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["AMD"]] = AMDGPU.functional() ? Flux.FluxAMDDevice(AMDGPU.device()) : Flux.FluxAMDDevice(nothing)
+    Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["AMDGPU"]] = AMDGPU.functional() ? Flux.FluxAMDGPUDevice(AMDGPU.device()) : Flux.FluxAMDGPUDevice(nothing)
 end
 
 # TODO

--- a/ext/FluxAMDGPUExt/FluxAMDGPUExt.jl
+++ b/ext/FluxAMDGPUExt/FluxAMDGPUExt.jl
@@ -3,7 +3,7 @@ module FluxAMDGPUExt
 import ChainRulesCore
 import ChainRulesCore: NoTangent
 import Flux
-import Flux: FluxCPUAdaptor, FluxAMDAdaptor, _amd, adapt_storage, fmap
+import Flux: FluxCPUAdaptor, FluxAMDGPUAdaptor, _amd, adapt_storage, fmap
 import Flux: DenseConvDims, Conv, ConvTranspose, conv, conv_reshape_bias
 import NNlib
 
@@ -19,9 +19,9 @@ const USE_AMDGPU = Ref{Union{Nothing, Bool}}(nothing)
 
 function (device::Flux.FluxAMDGPUDevice)(x)
     if device.deviceID === nothing
-        Flux.gpu(Flux.FluxAMDAdaptor(), x)
+        Flux.gpu(Flux.FluxAMDGPUAdaptor(), x)
     else
-        return Flux.gpu(Flux.FluxAMDAdaptor(AMDGPU.device_id(device.deviceID) - 1), x)  # subtracting 1, because device_id returns a positive integer
+        return Flux.gpu(Flux.FluxAMDGPUAdaptor(AMDGPU.device_id(device.deviceID) - 1), x)  # subtracting 1, because device_id returns a positive integer
     end
 end
 Flux._get_device_name(::Flux.FluxAMDGPUDevice) = "AMDGPU"

--- a/ext/FluxAMDGPUExt/batchnorm.jl
+++ b/ext/FluxAMDGPUExt/batchnorm.jl
@@ -1,10 +1,10 @@
 function (b::Flux.BatchNorm)(x::ROCArray{T}) where T <: MIOPENFloat
-    b.λ.(_amd_batchnorm(
+    b.λ.(_amdgpu_batchnorm(
         x, b.γ, b.β; μ=b.μ, σ²=b.σ², ϵ=b.ϵ,
         within_grad=NNlib.within_gradient(x)))
 end
 
-function _amd_batchnorm(x, γ, β; μ, σ², ϵ, within_grad::Bool)
+function _amdgpu_batchnorm(x, γ, β; μ, σ², ϵ, within_grad::Bool)
     if within_grad
         return AMDGPU.MIOpen.batchnorm_training(x, γ, β, μ, σ²; ϵ=Float64(ϵ), iteration=0) # TODO iteration
     else
@@ -13,9 +13,9 @@ function _amd_batchnorm(x, γ, β; μ, σ², ϵ, within_grad::Bool)
 end
 
 function ChainRulesCore.rrule(
-    ::typeof(_amd_batchnorm), x, γ, β; μ, σ², ϵ, within_grad::Bool,
+    ::typeof(_amdgpu_batchnorm), x, γ, β; μ, σ², ϵ, within_grad::Bool,
 )
-    y, μ_saved, ν_saved = _amd_batchnorm(x, γ, β; μ, σ², ϵ, within_grad)
+    y, μ_saved, ν_saved = _amdgpu_batchnorm(x, γ, β; μ, σ², ϵ, within_grad)
     function _batchnorm_pullback(Δ)
         dx, dγ, dβ = AMDGPU.MIOpen.∇batchnorm(Δ, x, γ, β, μ_saved, ν_saved)
         (NoTangent(), dx, dγ, dβ)

--- a/ext/FluxAMDGPUExt/functor.jl
+++ b/ext/FluxAMDGPUExt/functor.jl
@@ -106,10 +106,10 @@ function Adapt.adapt_structure(to::FluxCPUAdaptor, m::AMD_CONV)
         Adapt.adapt(to, m.bias), m.stride, m.pad, m.dilation, m.groups)
 end
 
-function Flux.get_device(::Val{:AMD}, id::Int)     # id should start from 0
+function Flux.get_device(::Val{:AMDGPU}, id::Int)     # id should start from 0
     old_id = AMDGPU.device_id(AMDGPU.device()) - 1     # subtracting 1 because ids start from 0
     AMDGPU.device!(AMDGPU.devices()[id + 1])           # adding 1 because ids start from 0
-    device = Flux.FluxAMDDevice(AMDGPU.device())
+    device = Flux.FluxAMDGPUDevice(AMDGPU.device())
     AMDGPU.device!(AMDGPU.devices()[old_id + 1])
     return device
 end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -202,6 +202,7 @@ ChainRulesCore.@non_differentiable _greek_ascii_depwarn(::Any...)
 # v0.14 deprecations
 @deprecate default_rng_value() Random.default_rng()
 
+Base.@deprecate_binding FluxAMDAdaptor FluxAMDGPUAdaptor
 
 # v0.15 deprecations
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -696,5 +696,9 @@ end
 
 # Fallback
 function get_device(::Val{D}, idx) where D
-    error("Unsupported backend: $(D). Try importing the corresponding package.")
+    if D ∈ (:CUDA, :AMDGPU, :Metal)
+        error("Unaivailable backend: $(D). Try importing the corresponding package with `using $D`.")
+    else
+        error("Unsupported backend: $(D). Supported backends are $(GPU_BACKENDS).")
+    end
 end

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -248,7 +248,7 @@ function gpu(x)
     @static if GPU_BACKEND == "CUDA"
         gpu(FluxCUDAAdaptor(), x)
     elseif GPU_BACKEND == "AMD"
-        @warning "\"AMD\" backend is deprecated. Please use \"AMDGPU\" instead."
+        @warn "\"AMD\" backend is deprecated. Please use \"AMDGPU\" instead." maxlog=1
         gpu(FluxAMDGPUAdaptor(), x)
     elseif GPU_BACKEND == "AMDGPU"
         gpu(FluxAMDGPUAdaptor(), x)
@@ -687,6 +687,10 @@ julia> cpu_device = Flux.get_device("CPU")
 ```
 """
 function get_device(backend::String, idx::Int = 0)
+    if backend == "AMD"
+        @warn "\"AMD\" backend is deprecated. Please use \"AMDGPU\" instead." maxlog=1
+        backend = "AMDGPU"
+    end
     if backend == "CPU"
         return FluxCPUDevice()
     else

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -247,7 +247,10 @@ CUDA.CuArray{Float32, 2, CUDA.Mem.DeviceBuffer}
 function gpu(x)
     @static if GPU_BACKEND == "CUDA"
         gpu(FluxCUDAAdaptor(), x)
-    elseif GPU_BACKEND == "AMDGPU" || GPU_BACKEND == "AMD" # "AMD" is deprecated
+    elseif GPU_BACKEND == "AMD"
+        @warning "\"AMD\" backend is deprecated. Please use \"AMDGPU\" instead."
+        gpu(FluxAMDGPUAdaptor(), x)
+    elseif GPU_BACKEND == "AMDGPU"
         gpu(FluxAMDGPUAdaptor(), x)
     elseif GPU_BACKEND == "Metal"
         gpu(FluxMetalAdaptor(), x)

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -248,7 +248,7 @@ function gpu(x)
     @static if GPU_BACKEND == "CUDA"
         gpu(FluxCUDAAdaptor(), x)
     elseif GPU_BACKEND == "AMDGPU" || GPU_BACKEND == "AMD" # "AMD" is deprecated
-        gpu(FluxAMDAdaptor(), x)
+        gpu(FluxAMDGPUAdaptor(), x)
     elseif GPU_BACKEND == "Metal"
         gpu(FluxMetalAdaptor(), x)
     elseif GPU_BACKEND == "CPU"
@@ -355,13 +355,13 @@ function _cuda end
 
 # AMDGPU extension. ########
 
-Base.@kwdef struct FluxAMDAdaptor
+Base.@kwdef struct FluxAMDGPUAdaptor
     id::Union{Nothing, Int} = nothing
 end
 
 const AMDGPU_LOADED = Ref{Bool}(false)
 
-function gpu(to::FluxAMDAdaptor, x)
+function gpu(to::FluxAMDGPUAdaptor, x)
     if AMDGPU_LOADED[]
         return _amd(to.id, x)
     else

--- a/test/ext_amdgpu/get_devices.jl
+++ b/test/ext_amdgpu/get_devices.jl
@@ -1,34 +1,34 @@
-amd_device = Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["AMD"]]
+amdgpu_device = Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["AMDGPU"]]
 
 # should pass, whether or not AMDGPU is functional
-@test typeof(amd_device) <: Flux.FluxAMDDevice
+@test typeof(amdgpu_device) <: Flux.FluxAMDGPUDevice
 
-@test typeof(amd_device.deviceID) <: AMDGPU.HIPDevice 
+@test typeof(amdgpu_device.deviceID) <: AMDGPU.HIPDevice 
 
 # testing get_device
 dense_model = Dense(2 => 3)     # initially lives on CPU
 weight = copy(dense_model.weight)           # store the weight
 bias = copy(dense_model.bias)               # store the bias
 
-amd_device = Flux.get_device()
+amdgpu_device = Flux.get_device()
 
-@test typeof(amd_device) <: Flux.FluxAMDDevice
-@test typeof(amd_device.deviceID) <: AMDGPU.HIPDevice
-@test Flux._get_device_name(amd_device) in Flux.supported_devices()
+@test typeof(amdgpu_device) <: Flux.FluxAMDGPUDevice
+@test typeof(amdgpu_device.deviceID) <: AMDGPU.HIPDevice
+@test Flux._get_device_name(amdgpu_device) in Flux.supported_devices()
 
 # correctness of data transfer
 x = randn(5, 5)
-cx = x |> amd_device
+cx = x |> amdgpu_device
 @test cx isa AMDGPU.ROCArray
-@test AMDGPU.device_id(AMDGPU.device(cx)) == AMDGPU.device_id(amd_device.deviceID)
+@test AMDGPU.device_id(AMDGPU.device(cx)) == AMDGPU.device_id(amdgpu_device.deviceID)
 
 # moving models to specific NVIDIA devices
 for id in 0:(length(AMDGPU.devices()) - 1)
-  current_amd_device = Flux.get_device("AMD", id)
-  @test typeof(current_amd_device.deviceID) <: AMDGPU.HIPDevice
-  @test AMDGPU.device_id(current_amd_device.deviceID) == id + 1
+  current_amdgpu_device = Flux.get_device("AMDGPU", id)
+  @test typeof(current_amdgpu_device.deviceID) <: AMDGPU.HIPDevice
+  @test AMDGPU.device_id(current_amdgpu_device.deviceID) == id + 1
 
-  global dense_model = dense_model |> current_amd_device
+  global dense_model = dense_model |> current_amdgpu_device
   @test dense_model.weight isa AMDGPU.ROCArray
   @test dense_model.bias isa AMDGPU.ROCArray
   @test AMDGPU.device_id(AMDGPU.device(dense_model.weight)) == id + 1

--- a/test/functors.jl
+++ b/test/functors.jl
@@ -4,7 +4,7 @@ if !(Flux.CUDA_LOADED[] || Flux.AMDGPU_LOADED[] || Flux.METAL_LOADED[])
 end
 
 @test typeof(Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["CUDA"]]) <: Nothing
-@test typeof(Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["AMD"]]) <: Nothing
+@test typeof(Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["AMDGPU"]]) <: Nothing
 @test typeof(Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["Metal"]]) <: Nothing
 @test typeof(Flux.DEVICES[][Flux.GPU_BACKEND_ORDER["CPU"]]) <: Flux.FluxCPUDevice
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,7 +87,7 @@ Random.seed!(0)
 
   if get(ENV, "FLUX_TEST_AMDGPU", "false") == "true"
     using AMDGPU
-    Flux.gpu_backend!("AMD")
+    Flux.gpu_backend!("AMDGPU")
 
     if AMDGPU.functional() && AMDGPU.functional(:MIOpen)
       @testset "AMDGPU" begin


### PR DESCRIPTION
Deprecate "AMD" in favor of "AMDGPU". 
"AMDGPU" is unambiguous and corresponds to the name of the related package, "AMD" instead could refer to either the cpu or the gpu. 

Additionally, this PR improves the error messages for `get_device`.  
