### PR TITLE
Correct counting of shared parameters in `Base.show`.

### DIFF
--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -93,7 +93,8 @@ function _big_finale(io::IO, m)
   if length(ps) > 2
     pars = underscorise(sum(length, ps; init=0))
     bytes = Base.format_bytes(Base.summarysize(m))
-    noncnt = _childarray_sum(_->1, m) - length(ps)
+    unique_params = IdSet()
+    noncnt = _childarray_sum(x -> unique_param!(x, unique_params), m) - length(ps)
     if noncnt > 0
       nonparam = underscorise(_childarray_sum(length, m) - sum(length, ps; init=0))
       printstyled(io, " "^08, "# Total: ", length(ps), " trainable arrays, "; color=:light_black)
@@ -115,6 +116,15 @@ init=0)
 
 underscorise(n::Integer) =
   join(reverse(join.(reverse.(Iterators.partition(digits(n), 3)))), '_')
+
+function unique_param!(x::AbstractArray{<:Number}, idset::Base.IdSet)
+    if x in idset
+        0
+    else
+        push!(idset, x)
+        1
+    end
+end
 
 function _nan_show(io::IO, x)
   if !isempty(x) && _all(iszero, x)

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -71,7 +71,7 @@ for T in [
   end
 end
 
-function _layer_show(io::IO, layer, indent::Int=1, name=nothing)
+function _layer_show(io::IO, layer, indent::Int=0, name=nothing)
   _str = isnothing(name) ? "" : "$name = "
   str = _str * sprint(show, layer, context=io)
   print(io, " "^indent, str, indent==0 ? "" : ",")


### PR DESCRIPTION
This PR fixes the `show` function by correctly counting non-trainable parameters. The earlier counting code duplicated shared parameters in it's count (https://github.com/FluxML/Flux.jl/blob/ebcbbe495e45c68c84382b5ee0282fe9edf441b8/src/layers/show.jl#L96), and hence some shared trainable parameters were being counted as being non-trainable. The change is in the `_big_finale` function, where, instead of duplicating the counts, we use an `IdSet` to keep track of which parameters have been counted (and don't count a parameter twice).

As an example, now the following code shows the correct output: 

```julia
julia> using Flux;

julia> d = Dense(10 => 10);

julia> shared_layer = Chain(Embedding(10, 10), d, d)
Chain(
  Embedding(10 => 10),                  # 100 parameters
  Dense(10 => 10),                      # 110 parameters
  Dense(10 => 10),                      # 110 parameters
)                   # Total: 3 arrays, 210 parameters, 1.055 KiB.

julia> normal_layer = Chain(Embedding(10, 10), Dense(10 => 10), Dense(10 => 10))
Chain(
  Embedding(10 => 10),                  # 100 parameters
  Dense(10 => 10),                      # 110 parameters
  Dense(10 => 10),                      # 110 parameters
)                   # Total: 5 arrays, 320 parameters, 1.562 KiB.

```

TODO:

- [ ] Add tests.
- [ ] Add an example in the docs for shared parameters?

Closes #2321.