### PR TITLE
Some small printing upgrades

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.14.22"
+version = "0.14.23"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -64,6 +64,7 @@ function _applychain(layers::AbstractVector, x)  # type-unstable path, helps com
   end
   x
 end
+_show_pre_post(::Chain{<:AbstractVector}) = "Chain([", "])"  # internal method for show
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i])
 Base.getindex(c::Chain{<:NamedTuple}, i::AbstractArray) =

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -64,7 +64,6 @@ function _applychain(layers::AbstractVector, x)  # type-unstable path, helps com
   end
   x
 end
-_show_pre_post(::Chain{<:AbstractVector}) = "Chain([", "])"  # internal method for show
 
 Base.getindex(c::Chain, i::AbstractArray) = Chain(c.layers[i])
 Base.getindex(c::Chain{<:NamedTuple}, i::AbstractArray) =

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -29,7 +29,7 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
   else
     println(io, " "^indent, isnothing(name) ? "" : "$name = ", pre)
     if obj isa Chain{<:NamedTuple} || obj isa NamedTuple
-      # then we insert names -- can this be done more generically? 
+      # then we insert names -- can this be done more generically?
       for k in Base.keys(obj)
         _big_show(io, obj[k], indent+2, k)
       end
@@ -49,6 +49,16 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
     else
       println(io, " "^indent, post, ",")
     end
+  end
+end
+
+for Fix in (:Fix1, :Fix2)
+  pre = string(Fix, "(")
+  @eval function _big_show(io::IO, obj::Base.$Fix, indent::Int=0, name=nothing)
+    println(io, " "^indent, isnothing(name) ? "" : "$name = ", $pre)
+    _big_show(io, obj.f, indent+2)
+    _big_show(io, obj.x, indent+2)
+    println(io, " "^indent, ")", ",")
   end
 end
 

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -53,7 +53,6 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
 end
 
 _show_pre_post(obj) = string(nameof(typeof(obj)), "("), ")"
-# _show_pre_post(::Chain{<:AbstractVector}) = "Chain([", "])"  # has to be done elsewhere
 _show_pre_post(::AbstractVector) = "[", "]"
 _show_pre_post(::NamedTuple) = "(;", ")"
 

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -53,7 +53,7 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
 end
 
 _show_pre_post(obj) = string(nameof(typeof(obj)), "("), ")"
-_show_pre_post(::Chain{<:AbstractVector}) = "Chain([", "])"
+# _show_pre_post(::Chain{<:AbstractVector}) = "Chain([", "])"  # has to be done elsewhere
 _show_pre_post(::AbstractVector) = "[", "]"
 _show_pre_post(::NamedTuple) = "(;", ")"
 

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -110,9 +110,12 @@ end
 
 _layer_string(io::IO, layer) = sprint(show, layer, context=io)
 # _layer_string(::IO, a::AbstractArray) = summary(layer)  # sometimes too long e.g. CuArray
-_layer_string(::IO, a::AbstractArray) = Base.dims2string(size(a)) * " " * String(typeof(a).name.name)
-# _layer_string(::IO, a::Array{T}) where T = Base.dims2string(size(a)) * " Array{$T}"
-# _layer_string(::IO, a::AbstractArray{T}) where T = Base.dims2string(size(a)) * " AbstractArray{$T}"
+function _layer_string(::IO, a::AbstractArray)
+  full = string(typeof(a))
+  comma = findfirst(',', full)
+  short = isnothing(comma) ? full : full[1:comma] * "...}"
+  Base.dims2string(size(a)) * " " * short
+end
 
 function _big_finale(io::IO, m)
   ps = params(m)

--- a/test/layers/show.jl
+++ b/test/layers/show.jl
@@ -71,7 +71,13 @@ end
   # Functors@0.3 marks transposed matrices non-leaf, shouldn't affect printing:
   adjoint_chain = repr("text/plain", Chain([Dense([1 2; 3 4]')]))
   @test occursin("Dense(2 => 2)", adjoint_chain)
-  @test occursin("Chain([", adjoint_chain)
+  @test occursin("Chain(", adjoint_chain)
+  @test occursin("[", adjoint_chain)
+
+  # New printing of arrays, and Fix1
+  fix_chain = repr("text/plain", Chain(Base.Fix1(*, rand32(22,33)), softmax))
+  @test occursin("Fix1(", fix_chain)
+  @test occursin("22×33 Matrix{Float32}", fix_chain)
 end
 
 # Bug when no children, https://github.com/FluxML/Flux.jl/issues/2208


### PR DESCRIPTION
This is intended for https://github.com/FluxML/Fluxperimental.jl/pull/20 but probably a good idea anyway. Motivating example is something like this (where bigger arrays will print pages of numbers):
```julia
julia> struct Tmp2; x; y; end; Flux.@functor Tmp2

julia> Chain(Tmp2([Dense(2,3), randn(3,4)'], (x=1:3, y=Dense(3,4), z=rand(3))))
Chain(
  Tmp2(
    Array(
      Dense(2 => 3),                    # 9 parameters
      [0.351978391016603 0.6408681372462821 -1.326533184688648; 0.09481930831795712 
1.430103476272605 0.7250467613675332; 2.03372151428719 -0.015879812799495713 
1.9499692162118236; -1.6346846180722918 -0.8364610153059454 -1.2907265737483433],  # 12 parameters
    ),
    NamedTuple(
      1:3,                              # 3 parameters
      Dense(3 => 4),                    # 16 parameters
      [0.9666158193429335, 0.01613900990539574, 0.0205920186127464],  # 3 parameters
    ),
  ),
)                   # Total: 7 arrays, 43 parameters, 644 bytes.
```
Notice that `Array()` and `NamedTuple()` aren't actually valid syntax. Also that it prints whole arrays if they aren't inside a layer the way it expects. After this PR:
```julia
julia> Chain(Tmp2([Dense(2,3), randn(3,4)'], (x=1:3, y=Dense(3,4), z=rand(3))))
Chain(
  Tmp2(
    [
      Dense(2 => 3),                    # 9 parameters
      4×3 Adjoint,                      # 12 parameters
    ],
    (;
      x = 3-element UnitRange,          # 3 parameters
      y = Dense(3 => 4),                # 16 parameters
      z = 3-element Array,              # 3 parameters
    ),
  ),
)                   # Total: 7 arrays, 43 parameters, 644 bytes.
```