### PR TITLE
Fix test that is not broken anymore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,7 +49,7 @@ Preferences = "1"
 ProgressLogging = "0.1"
 Reexport = "1.0"
 SpecialFunctions = "2.1.2"
-Zygote = "0.6.49"
+Zygote = "0.6.67"
 cuDNN = "1"
 julia = "1.9"
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -421,7 +421,7 @@ end
 
   m1v = Chain([m1[1], m1[2]])  # vector of layers
   @test Zygote.hessian_dual(sum∘m1v, [1,2,3]) ≈ Zygote.hessian_dual(sum∘m1, [1,2,3])
-  @test_broken Zygote.hessian_dual(sum∘m1v, [1,2,3]) ≈ Zygote.hessian_reverse(sum∘m1v, [1,2,3])
+  @test Zygote.hessian_dual(sum∘m1v, [1,2,3]) ≈ Zygote.hessian_reverse(sum∘m1v, [1,2,3])
 
   # NNlib's softmax gradient writes in-place
   m2 = Chain(Dense(3,4,tanh), Dense(4,2), softmax)


### PR DESCRIPTION
It seems that Zygote 0.6.67 (i.e., https://github.com/FluxML/Zygote.jl/pull/1328) fixed one test that is currently marked as broken: https://github.com/FluxML/Zygote.jl/actions/runs/6650603568/job/18071017146?pr=1467#step:6:744