### PR TITLE
Fix typo in docs/src/tutorials/2021-01-26-mlp.md

### DIFF
--- a/docs/src/tutorials/2021-01-26-mlp.md
+++ b/docs/src/tutorials/2021-01-26-mlp.md
@@ -90,7 +90,7 @@ Note that we use the functions [Dense](https://fluxml.ai/Flux.jl/stable/models/l
 
 ## Loss functions
 
-Now, we define the loss function `loss_all`. It expects a DataLoader object and the `model` function we defined aboved as arguments. Notice that this function iterates through the `dataloader` object in mini-batches and uses the function [logitcrossentropy](https://fluxml.ai/Flux.jl/stable/models/losses/#Flux.Losses.logitcrossentropy) to compute the difference between the predicted and actual values. 
+Now, we define the loss function `loss_all`. It expects a DataLoader object and the `model` function we defined above as arguments. Notice that this function iterates through the `dataloader` object in mini-batches and uses the function [logitcrossentropy](https://fluxml.ai/Flux.jl/stable/models/losses/#Flux.Losses.logitcrossentropy) to compute the difference between the predicted and actual values. 
 
 ```julia
 function loss_all(dataloader, model)


### PR DESCRIPTION
Noticed a typo while going through the documentation example at https://fluxml.ai/Flux.jl/stable/tutorials/2021-01-26-mlp/
In the Loss functions section: changed **'aboved'** to **'above'**.

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation
