### PR TITLE
Use stable API for AMDGPU RNG conversion

### DIFF
--- a/ext/FluxAMDGPUExt/functor.jl
+++ b/ext/FluxAMDGPUExt/functor.jl
@@ -40,8 +40,7 @@ end
 adapt_storage(::FluxAMDGPUAdaptor, x::Zygote.FillArrays.AbstractFill) =
     ROCArray(collect(x))
 adapt_storage(::FluxAMDGPUAdaptor, x::Zygote.OneElement) = ROCArray(collect(x))
-adapt_storage(::FluxAMDGPUAdaptor, x::Random.TaskLocalRNG) =
-    AMDGPU.rocRAND.default_rng()
+adapt_storage(::FluxAMDGPUAdaptor, x::Random.TaskLocalRNG) = AMDGPU.rocrand_rng()
 adapt_storage(::FluxAMDGPUAdaptor, x::AMDGPU.rocRAND.RNG) = x
 adapt_storage(::FluxAMDGPUAdaptor, x::AbstractRNG) = error("""
     Cannot map RNG of type $(typeof(x)) to AMDGPU.

--- a/test/ext_amdgpu/basic.jl
+++ b/test/ext_amdgpu/basic.jl
@@ -86,6 +86,13 @@ end
     @test parent(Flux.gpu(g3)) isa ROCMatrix{Float32}
 end
 
+@testset "cpu and gpu on RNGs" begin
+    crng = Random.default_rng()
+    grng = gpu(rng)
+    @test grng isa AMDGPU.rocRAND.RNG
+    @test cpu(grng) === crng
+end
+
 @testset "Flux.onecold gpu" begin
     y = Flux.onehotbatch(ones(3), 1:10) |> Flux.gpu
     l = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']


### PR DESCRIPTION
The function we were calling is no longer available in the `AMDGPU.rocRAND` module. `rocrand_rng` has been around for years and is also more explicit.

Also adds tests so we can catch changes like this in future.

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
