### PR TITLE
Hotfix for new OneElement on GPU

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,6 @@ steps:
       queue: "juliagpu"
       cuda: "*"
     env:
-      JULIA_CUDA_USE_BINARYBUILDER: "true"
       FLUX_TEST_CUDA: "true"
       FLUX_TEST_CPU: "false"
     timeout_in_minutes: 60

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.14.8"
+version = "0.14.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/FluxCUDAExt/functor.jl
+++ b/ext/FluxCUDAExt/functor.jl
@@ -29,6 +29,10 @@ adapt_storage(to::FluxCUDAAdaptor, x::AbstractRNG) =
 
 # TODO: figure out the correct design for OneElement
 adapt_storage(to::FluxCUDAAdaptor, x::Zygote.OneElement) = CUDA.cu(collect(x))
+# Patch for GPU support until we can make OneElement smarter
+if isdefined(Zygote.ChainRules, :OneElement)
+    adapt_storage(to::FluxCUDAAdaptor, x::Zygote.ChainRules.OneElement) = CUDA.cu(collect(x))
+end
 
 adapt_storage(to::FluxCPUAdaptor, x::T) where T <: CUDA.CUSPARSE.CUDA.CUSPARSE.AbstractCuSparseMatrix = adapt(Array, x)
 adapt_storage(to::FluxCPUAdaptor, x::CUDA.RNG) = Random.default_rng()


### PR DESCRIPTION
Working through the remaining errors on CI, e.g. https://buildkite.com/julialang/flux-dot-jl/builds/4348#018cb8e9-4564-4edf-8f3c-84044696b2a6. I think reverse CI on https://github.com/FluxML/Zygote.jl/pull/1328 didn't catch this because it only runs CPU tests. We should consider using JLArrays or something to reduce that risk.

A proper fix would be to define some `*` or `mul!` methods for `ChainRules.OneElement`, but until those are in place this patch should restore the old functionality.

### PR Checklist

- [x] Tests are added
- [ ] ~~Entry in NEWS.md~~
- [ ] ~~Documentation, if applicable~~
