### PR TITLE
Add back missing `rng_from_array(::CuArray)` method

### DIFF
--- a/ext/FluxCUDAExt/FluxCUDAExt.jl
+++ b/ext/FluxCUDAExt/FluxCUDAExt.jl
@@ -43,6 +43,7 @@ end
 ChainRulesCore.@non_differentiable check_use_cuda()
 
 include("functor.jl")
+include("utils.jl")
 
 function __init__()
     Flux.CUDA_LOADED[] = true

--- a/ext/FluxCUDAExt/utils.jl
+++ b/ext/FluxCUDAExt/utils.jl
@@ -1,1 +1,1 @@
-rng_from_array(::CuArray) = CUDA.default_rng()
+Flux.rng_from_array(::CuArray) = CUDA.default_rng()

--- a/test/ext_cuda/runtests.jl
+++ b/test/ext_cuda/runtests.jl
@@ -32,3 +32,7 @@ end
 @testset "ctc" begin
   include("ctc.jl")
 end
+@testset "utils" begin
+  include("utils.jl")
+end
+  

--- a/test/ext_cuda/utils.jl
+++ b/test/ext_cuda/utils.jl
@@ -9,3 +9,9 @@
     @test y isa Wrapped{<:CuArray}
   end
 end
+
+@testset "rng_from_array" begin
+    x = cu(randn(2,2))
+    rng = Flux.rng_from_array(x)
+    @test rng == CUDA.default_rng()
+end


### PR DESCRIPTION
Hi, for some reason, `rng_from_array(::CuArray)` was missing from the loading path in `FluxCUDAExt`. 
Seems like it has been left behind when migrating to extensions.
I enabled it back, and added a corresponding tests.
For some reason, the `tests/ext_cuda/utils.jl` was also not being executed despite already containing a test case.
I also added this into the corresponding `runtests.jl`.  

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
