### PR TITLE
Allow `Parallel(+, f)(x, y, z)` to work like broadcasting, and enable `Chain(identity, Parallel(+, f))(x, y, z)`

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -572,7 +572,8 @@ end
 
 function _parallel_check(layers, xs)
   nl = length(layers)
-  nx = length(xs) 
+  @assert nl > 1  # dispatch handles nl==1 cases
+  nx = length(xs)
   if (nl != nx)
     throw(ArgumentError(lazy"Parallel with $nl > 1 sub-layers can take one input or $nl inputs, but got $nx inputs"))
   end
@@ -590,6 +591,8 @@ end
 
 (m::Parallel)(xs::Tuple) = m(xs...)  # tuple is always splatted
 (m::_ParallelONE)(xs::Tuple) = m(xs...)  # solves an ambiguity
+
+(m::Parallel)() = throw(ArgumentError("Parallel layer cannot take 0 inputs"))
 
 Base.getindex(m::Parallel, i) = m.layers[i]
 Base.getindex(m::Parallel, i::AbstractVector) = Parallel(m.connection, m.layers[i])

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -514,7 +514,7 @@ julia> p(3, 4)  # == 3^2 + √4, two functions two inputs
 julia> p((3, 4))  # tuple is always splatted
 11.0
 
-julia> p(4, 4)  # == 4^2 + √4, one input used twice
+julia> p(4)  # == 4^2 + √4, one input used twice
 18.0
 
 julia> Parallel(hcat, inv)(1, 2, 4)  # one function three inputs

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -506,6 +506,25 @@ and [`Maxout`](@ref) which reduces by broadcasting `max`.
 # Examples
 
 ```jldoctest
+julia> p = Parallel(+, abs2, sqrt);
+
+julia> p(3, 4)  # == 3^2 + √4, two functions two inputs
+11.0
+
+julia> p((3, 4))  # tuple is always splatted
+11.0
+
+julia> p(4, 4)  # == 4^2 + √4, one input used twice
+18.0
+
+julia> Parallel(hcat, inv)(1, 2, 4)  # one function three inputs
+1×3 Matrix{Float64}:
+ 1.0  0.5  0.25
+```
+
+With Flux layers:
+
+```jldoctest
 julia> model = Chain(Dense(3 => 5),
                      Parallel(vcat, Dense(5 => 4), Chain(Dense(5 => 7), Dense(7 => 4))),
                      Dense(8 => 17));

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -562,9 +562,10 @@ function Parallel(connection; kw...)
   if :layers in keys(layers) || :connection in keys(layers)
     throw(ArgumentError("a Parallel layer cannot have a named sub-layer called `connection` or `layers`"))
   end
-  isempty(layers) && return Parallel(connection, ())
   Parallel(connection, layers)
 end
+Parallel(connection, layers::Union{Tuple{}, @NamedTuple{}}) =
+    throw(ArgumentError("cannot construct a Parallel layer with no sub-layers"))
 
 @layer :expand Parallel
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -261,8 +261,15 @@ using Flux: activations
     end
 
     @testset "trivial cases" begin
+      # zero inputs, always an error
+      @test_throws ArgumentError Parallel(hcat)()
+      @test_throws ArgumentError Parallel(hcat, inv)()
+      @test_throws ArgumentError Parallel(hcat, inv, sqrt)()
+
+      # zero layers -- not useful... can we make this an error without a breaking change?
       @test Parallel(hcat) isa Parallel{typeof(hcat), Tuple{}}  # not a NamedTuple
       @test Parallel(hcat)(1) == hcat()
+
       @test Parallel(hcat, inv)(2) == hcat(1/2)  # still calls connection once.
     end
 

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -266,11 +266,8 @@ using Flux: activations
       @test_throws ArgumentError Parallel(hcat, inv)()
       @test_throws ArgumentError Parallel(hcat, inv, sqrt)()
 
-      # zero layers -- not useful... can we make this an error without a breaking change?
-      @test Parallel(hcat) isa Parallel{typeof(hcat), Tuple{}}  # not a NamedTuple
-      @test Parallel(hcat)(1) == hcat()
-
-      @test Parallel(hcat, inv)(2) == hcat(1/2)  # still calls connection once.
+      # zero layers -- not useful... now made an error
+      @test_throws ArgumentError Parallel(hcat)
     end
 
     @testset "connection is called once" begin

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -234,11 +234,14 @@ using Flux: activations
     end
 
     @testset "vararg input" begin
-      inputs = randn(10), randn(5), randn(4)
+      inputs = randn32(10), randn32(5), randn32(4)
       @test size(Parallel(+, Dense(10, 2), Dense(5, 2), Dense(4, 2))(inputs)) == (2,)
       @test size(Parallel(+; a = Dense(10, 2), b = Dense(5, 2), c = Dense(4, 2))(inputs)) == (2,)
       @test_throws ArgumentError Parallel(+, sin, cos)(1,2,3)  # wrong number of inputs
-      @test Parallel(+, sin, cos)(pi/2) ≈ 1
+      @test Parallel(+, sin, cos)(pi/2) ≈ 1  # one input, several layers
+      @test Parallel(/, abs)(3, -4) ≈ 3/4    # one layer, several inputs
+      @test Parallel(/, abs)((3, -4)) ≈ 3/4
+      @test Parallel(/; f=abs)(3, -4) ≈ 3/4
     end
 
     @testset "named access" begin
@@ -270,6 +273,8 @@ using Flux: activations
       @test CNT[] == 2
       Parallel(f_cnt, sin)(1)
       @test CNT[] == 3
+      Parallel(f_cnt, sin)(1,2,3)
+      @test CNT[] == 4
     end
 
     # Ref https://github.com/FluxML/Flux.jl/issues/1673

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -35,6 +35,8 @@ using Flux: activations
     c = Chain(Dense(10, 5, σ), Dense(5, 2), Dense(2, 1, relu))
     @test c[1] == c[begin]
     @test c[3] == c[end]
+
+    @test Chain(identity)(1,2,3) == (1,2,3)  # multiple args become a tuple
   end
 
   @testset "Activations" begin

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -230,7 +230,7 @@ using Flux: activations
     end
 
     @testset "concat size" begin
-      input = randn(10, 2)
+      input = randn32(10, 2)
       @test size(Parallel((a, b) -> cat(a, b; dims=2), Dense(10, 10), identity)(input)) == (10, 4)
       @test size(Parallel(hcat, one = Dense(10, 10), two = identity)(input)) == (10, 4)
     end


### PR DESCRIPTION
At present Parallel allows multiple layers and one input, but not the reverse. This PR extends it to allow both ways... much like broadcasting in `connection((inputs .|> layers)...)`.
```julia
julia> Parallel(+, inv)(1, 2, 3)  # was an error
1.8333333333333333

julia> (1,2,3) .|> (inv,)
(1.0, 0.5, 0.3333333333333333)
```
Does this have any unintended side-effects?

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable
