### PR TITLE
remove `public dropout`

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -36,7 +36,7 @@ export Chain, Dense, Embedding, Maxout, SkipConnection, Parallel, PairwiseFusion
   # modules
   Losses, Train,
   # layers
-  Bilinear, Scale, dropout,
+  Bilinear, Scale,
   # utils
   outputsize, state, create_bias, @layer,
 ))


### PR DESCRIPTION
Line `@reexport using NNlib` means this is already exported, leading to this error:
```
julia> using Flux
Precompiling Flux...
Info Given Flux was explicitly requested, output will be shown live 
ERROR: LoadError: cannot declare Flux.dropout public; it is already declared exported

julia> VERSION
v"1.12.0-DEV.320"
```