### PR TITLE
Add hint for choosing a different GPU backend

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -357,7 +357,7 @@ function gpu(to::FluxCUDAAdaptor, x)
         @info """
         The CUDA functionality is being called but
         `CUDA.jl` must be loaded to access it.
-        Add `using CUDA` or `import CUDA` to your code.
+        Add `using CUDA` or `import CUDA` to your code.  Alternatively, configure a different GPU backend by calling `Flux.gpu_backend!`.
         """ maxlog=1
         return x
     end


### PR DESCRIPTION
Adds a tip pointing out how to choose a different GPU backend. This will help `AMDGPU` and `Metal` users get oriented with Flux.jl.
### PR Checklist
- [x] Documentation, if applicable
