### PR TITLE
Patch `Flux._isleaf` for abstract arrays with bitstype elements

### DIFF
--- a/src/functor.jl
+++ b/src/functor.jl
@@ -185,7 +185,7 @@ _isleaf(x) = Functors.isleaf(x)
 
 _isleaf(::AbstractArray{<:Number}) = true
 _isleaf(::AbstractArray{T}) where T = isbitstype(T)
-_isleaf(::Union{Transpose, Adjoint}) = false
+_isleaf(::Union{Transpose, Adjoint, PermutedDimsArray}) = false
 
 _isleaf(::AbstractRNG) = true
 

--- a/src/functor.jl
+++ b/src/functor.jl
@@ -181,12 +181,13 @@ julia> m.bias
 """
 cpu(x) = fmap(x -> adapt(FluxCPUAdaptor(), x), x, exclude = _isleaf)
 
-_isbitsarray(::AbstractArray{<:Number}) = true
-_isbitsarray(::AbstractArray{T}) where T = isbitstype(T)
-_isbitsarray(x) = false
+_isleaf(x) = Functors.isleaf(x)
+
+_isleaf(::AbstractArray{<:Number}) = true
+_isleaf(::AbstractArray{T}) where T = isbitstype(T)
+_isleaf(::Union{Transpose, Adjoint}) = false
 
 _isleaf(::AbstractRNG) = true
-_isleaf(x) = _isbitsarray(x) || Functors.isleaf(x)
 
 # the order below is important
 const GPU_BACKENDS = ("CUDA", "AMDGPU", "Metal", "CPU")

--- a/test/ext_cuda/cuda.jl
+++ b/test/ext_cuda/cuda.jl
@@ -109,7 +109,7 @@ end
   # This test should really not go through indirections and pull out Fills for efficiency
   # but we forcefully materialise. TODO: remove materialising CuArray here
   @test gradient(x -> sum(cpu(x)), ca)[1] isa CuArray # This involves FillArray, which should be GPU compatible
-  @test gradient(x -> sum(cpu(x)), ca')[1] isa CuArray
+  @test gradient(x -> sum(cpu(x)), ca')[1] isa Adjoint{Float32, <:CuArray}
 
   # Even more trivial: no movement
   @test gradient(x -> sum(abs, cpu(x)), a)[1] isa Matrix

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -588,6 +588,7 @@ end
       @test Flux._isleaf([x])
       @test !Flux._isleaf([x]')
       @test !Flux._isleaf(transpose([x]))
+      @test !Flux._isleaf(PermutedDimsArray([x;;], (1, 2)))
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/FluxML/Flux.jl/issues/2432:

```julia
julia> x = [1.0];
julia> Flux._isleaf(x') # should be false
true # false with this PR

julia> m = (; a = x, b = x'); # tied weights
julia> mcopy = fmap(copy, m; exclude = Flux._isleaf); # copy should preserve tie
julia> mcopy.a === mcopy.b' # should be true
false # true with this PR
```

On master we have `Flux._isleaf(x) = _isbitsarray(x) || Functors.isleaf(x)`, but `_isbitsarray(x)` returns `true` for any `AbstractArray{T}` where `isbitstype(T) == true`, and so we get `_isbitsarray([1.0]') == true` and therefore `Flux._isleaf([1.0]') == true`. In the referenced issue, this breaks parameter sharing between a set of weights and their transpose when a model is moved to the gpu.

The fundamental issue is that AFAICT there is not a good way to extend `Functors.isleaf` outside of Functors.jl for abstract types which may contain children of the same abstract type. For example, here `Transpose <: AbstractArray` contains a `parent::AbstractArray` field, and so Functors.jl must overload `Functor.functor(::Transpose)` otherwise it would not be recursed into. But of course this can't be done similarly outside of Functors.jl without type piracy (hence `Flux._isleaf`).

So in order to:

1. Avoid copying all the overloaded [`Functors.functor(::AbstractArray)` methods defined here](https://github.com/FluxML/Functors.jl/blob/cfc6a608e309c64e4da0f44cd937cb9efa4fd6c7/src/base.jl#L29-L49) into Flux, and
2. Maintain the desired behaviour of treating `AbstractArray`s with bitstype elements as leaves,

I've removed `_isbitsarray` in favour of defining `_isleaf` methods directly, and special-cased `Flux._isleaf(::Union{Transpose, Adjoint, PermutedDimsArray}) = false` to match Functors.jl. The other option is to do this in Functors.jl directly, but I'm not sure if treating all bitstype arrays as leaves is desirable in general (also it's probably breaking?).