### PR TITLE
Add output padding for ConvTranspose

### DIFF
--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -197,6 +197,17 @@ end
 
   @test occursin("groups=2", sprint(show, ConvTranspose((3,3), 2=>4, groups=2)))
   @test occursin("2 => 4"  , sprint(show, ConvTranspose((3,3), 2=>4, groups=2)))
+
+  # test ConvTranspose outpad argument for stride > 1
+  x = randn(Float32, 10, 11, 3,2)
+  m1 = ConvTranspose((3,5), 3=>6, stride=3)
+  m2 = ConvTranspose((3,5), 3=>6, stride=3, outpad=(1,0))
+  @test size(m2(x))[1:2] == (size(m1(x))[1:2] .+ (1,0))
+
+  x = randn(Float32, 10, 11, 12, 3,2)
+  m1 = ConvTranspose((3,5,3), 3=>6, stride=3)
+  m2 = ConvTranspose((3,5,3), 3=>6, stride=3, outpad=(1,0,1))
+  @test size(m2(x))[1:3] == (size(m1(x))[1:3] .+ (1,0,1))
 end
 
 @testset "CrossCor" begin


### PR DESCRIPTION
This PR provides the ability to increase `ConvTranspose`'s output shape when stride > 1, implemented in the same way as in PyTorch `output_padding` (see [ConvTranspose3d](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose3d.html) and [NaiveConvolutionTranspose3d.cpp](https://github.com/pytorch/pytorch/blob/b0ae0db8156f186eaed69b0332d8698a8dfc799a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp#L708)). 

The purpose of this is to conserve `Conv`/`ConvTranspose` inversability. For stride = N, N>1, there are N possibilities per dimension that result in the same `Conv` output (see [what-output-padding-does-in-nn-convtranspose2d](https://stackoverflow.com/questions/67096544/what-output-padding-does-in-nn-convtranspose2d)). The added argument `outpad` controls how much the output shape is increased to match the strided `Conv` counterpart. Can be provided as an integer to equally increase all dimensions, or as a tuple for individual dimensional control).

`outpad` is invalid if any `outpad` .>= `stride`. Currently there is no verification of this when constructing `ConvTranspose`, it only breaks when called and throws **DimensionMismatch**. A similar thing happens in PyTorch, it allows constructing ConvTransposeNd with invalid `output_paddding`, but then throws **RuntimeError** before doing the deconvolution. As the verification can be done in the constructor, it makes sense to handle it there, but let me know what you think.

I tried to follow the variable naming style, but it can also be changed if you see a better fitting alternative. The same applies for other things such as argument order.

### PR Checklist

- [X] Tests are added
- [ ] Entry in NEWS.md
- [X] Documentation, if applicable
