### PR TITLE
ConvTranspose with symmetric, non-const padding

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -3,7 +3,7 @@ using NNlib: conv, ∇conv_data, depthwiseconv, output_size
 # pad dims of x with dims of y until ndims(x) == ndims(y)
 _paddims(x::Tuple, y::Tuple) = (x..., y[(end - (length(y) - length(x) - 1)):end]...)
 
-#expand(N, i::Tuple) = i
+expand(N, i::Tuple) = i
 expand(N, i::Integer) = ntuple(_ -> i, N)
 
 conv_reshape_bias(c) = conv_reshape_bias(c.bias, c.stride)

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -208,6 +208,16 @@ end
   m1 = ConvTranspose((3,5,3), 3=>6, stride=3)
   m2 = ConvTranspose((3,5,3), 3=>6, stride=3, outpad=(1,0,1))
   @test size(m2(x))[1:3] == (size(m1(x))[1:3] .+ (1,0,1))
+
+  # test ConvTranspose constructor with tuple padding
+  kernel_dims = (3, 3)
+  pad = (1, 0)
+  x = randn(Float32, 5, 6, 1, 16)
+  m = ConvTranspose(kernel_dims, 1=>1, pad=pad)
+  result = m(x)
+  # Formula obtained from https://makeyourownneuralnetwork.blogspot.com/2020/02/calculating-output-size-of-convolutions.html
+  output_dims(pad_dims, kernel_dim, input_dim, stride) = (input_dim.-1).*stride.-(pad_dims.*2).+(kernel_dim.-1).+1
+  @test output_dims(m.pad, kernel_dims, size(x)[1:2], m.stride) == size(result)[1:2]
 end
 
 @testset "CrossCor" begin


### PR DESCRIPTION
This is my stab at attempting to fix #2424 . Seems that the issue is with the way how the `pad` argument is handled when calling the `ConvTranspose` function.

### PR Checklist

- [x] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
