### PR TITLE
Fix function `_size_check()`

### DIFF
--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -191,8 +191,8 @@ Dense(W::LinearAlgebra.Diagonal, bias = true, σ = identity) =
   Scale(W.diag, bias, σ)
 
 function _size_check(layer, x::AbstractArray, (d, n)::Pair)
-  d > 0 || throw(DimensionMismatch(string("layer ", layer,
-    " expects ndims(input) > ", ndims(x)-d, ", but got ", summary(x))))
+  d <= ndims(x) || throw(DimensionMismatch(string("layer ", layer,
+    " expects ndims(input) >= ", d, ", but got ", summary(x))))
   size(x, d) == n || throw(DimensionMismatch(string("layer ", layer,
     lazy" expects size(input, $d) == $n, but got ", summary(x))))
 end

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -191,7 +191,7 @@ Dense(W::LinearAlgebra.Diagonal, bias = true, σ = identity) =
   Scale(W.diag, bias, σ)
 
 function _size_check(layer, x::AbstractArray, (d, n)::Pair)
-  d <= ndims(x) || throw(DimensionMismatch(string("layer ", layer,
+  0 < d <= ndims(x) || throw(DimensionMismatch(string("layer ", layer,
     " expects ndims(input) >= ", d, ", but got ", summary(x))))
   size(x, d) == n || throw(DimensionMismatch(string("layer ", layer,
     lazy" expects size(input, $d) == $n, but got ", summary(x))))


### PR DESCRIPTION
The previous check `d > 0` and the corresponding error message didn't make sense if `d` was the dimension to be checked. It would make sense to check that the difference between the available number of dimensions and the desired dimension is greater than or equal to zero, i.e., `ndims(x) - d >= 0` or `d <= ndims()` respectively.

Moreover, checking for `d > 0` is rather pointless, since all implemented checks set `d > 0`.

A corrected implementation is provided in this PR, which should fix this issue.