### PR TITLE
Allow loading of `ConvTranspose` state without `.outpad` field

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-version = "0.14.18"
+version = "0.14.19"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -212,6 +212,12 @@ ChainRulesCore.@non_differentiable _greek_ascii_depwarn(::Any...)
 
 Base.@deprecate_binding FluxAMDAdaptor FluxAMDGPUAdaptor
 
+# Issue 2476, after ConvTranspose got a new field in 2462. Minimal fix to allow loading?
+function loadmodel!(dst::ConvTranspose, src::NamedTuple{(:σ, :weight, :bias, :stride, :pad, :dilation, :groups)}; kw...)
+  new_src = (; src.σ, src.weight, src.bias, src.stride, src.pad, dst.outpad, src.dilation, src.groups)
+  loadmodel!(dst, new_src; kw...)
+end
+
 # v0.15 deprecations
 
 # Enable these when 0.15 is released, and delete const ClipGrad = Optimise.ClipValue etc: 


### PR DESCRIPTION
Fixes https://github.com/FluxML/Flux.jl/issues/2476

Smallest change to do so, without otherwise altering the behaviour of `loadmodel!`.