### PR TITLE
Correct dead link for "quickstart page" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ plot(x -> 2x-x^3, -2, 2, legend=false)
 scatter!(x -> model([x]), -2:0.1f0:2)
 ```
 
-The [quickstart page](https://fluxml.ai/Flux.jl/stable/models/quickstart/) has a longer example. See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples. Ask questions on the [Julia discourse](https://discourse.julialang.org/) or [slack](https://discourse.julialang.org/t/announcing-a-julia-slack/4866).
+The [quickstart page](http://fluxml.ai/Flux.jl/stable/guide/models/quickstart/) has a longer example. See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples. Ask questions on the [Julia discourse](https://discourse.julialang.org/) or [slack](https://discourse.julialang.org/t/announcing-a-julia-slack/4866).
 
 If you use Flux in your research, please [cite](CITATION.bib) our work.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ plot(x -> 2x-x^3, -2, 2, legend=false)
 scatter!(x -> model([x]), -2:0.1f0:2)
 ```
 
-The [quickstart page](http://fluxml.ai/Flux.jl/stable/guide/models/quickstart/) has a longer example. See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples. Ask questions on the [Julia discourse](https://discourse.julialang.org/) or [slack](https://discourse.julialang.org/t/announcing-a-julia-slack/4866).
+The [quickstart page](https://fluxml.ai/Flux.jl/stable/guide/models/quickstart/) has a longer example. See the [documentation](https://fluxml.github.io/Flux.jl/) for details, or the [model zoo](https://github.com/FluxML/model-zoo/) for examples. Ask questions on the [Julia discourse](https://discourse.julialang.org/) or [slack](https://discourse.julialang.org/t/announcing-a-julia-slack/4866).
 
 If you use Flux in your research, please [cite](CITATION.bib) our work.


### PR DESCRIPTION
The correct link is
https://fluxml.ai/Flux.jl/stable/guide/models/quickstart/
which replaces the invalid link
https://fluxml.ai/Flux.jl/stable/models/quickstart/