### PR TITLE
invert h and x arguments in RNNs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ See also [github's page](https://github.com/FluxML/Flux.jl/releases) for a compl
 
 ## v0.15.0 
 * Recurrent layers have undergone a complete redesign in [PR 2500](https://github.com/FluxML/Flux.jl/pull/2500).
-  * `RNNCell`, `LSTMCell`, and `GRUCell` are now exported and provide functionality for single time-step processing: `rnncell(x_t, h_t) -> h_{t+1}`.
+  * `RNNCell`, `LSTMCell`, and `GRUCell` are now exported and provide functionality for single time-step processing: `rnncell(h_t, x_t) -> h_{t+1}`.
   * `RNN`, `LSTM`, and `GRU` no longer store the hidden state internally, it has to be explicitely passed to the layer. Moreover, they now process entire sequences at once, rather than one element at a time: `rnn(x, h) -> h′`.
   * The `Recur` wrapper has been deprecated and removed.
   * The `reset!` function has also been removed; state management is now entirely up to the user.

--- a/docs/src/guide/models/recurrence.md
+++ b/docs/src/guide/models/recurrence.md
@@ -151,7 +151,7 @@ function RecurrentModel(input_size::Int, hidden_size::Int)
 end
 
 function (m::RecurrentModel)(x)
-    z = m.rnn(x, m.h0)  # [hidden_size, seq_len, batch_size] or [hidden_size, seq_len]
+    z = m.rnn(m.h0, x)  # [hidden_size, seq_len, batch_size] or [hidden_size, seq_len]
     ŷ = m.dense(z)      # [1, seq_len, batch_size] or [1, seq_len]
     return ŷ
 end

--- a/docs/src/guide/models/recurrence.md
+++ b/docs/src/guide/models/recurrence.md
@@ -19,7 +19,7 @@ Wxh = randn(Float32, output_size, input_size)
 Whh = randn(Float32, output_size, output_size)
 b = zeros(Float32, output_size)
 
-function rnn_cell(x, h)
+function rnn_cell(h, x)
     h = tanh.(Wxh * x .+ Whh * h .+ b)
     return h
 end

--- a/docs/src/guide/models/recurrence.md
+++ b/docs/src/guide/models/recurrence.md
@@ -33,12 +33,12 @@ h0 = zeros(Float32, output_size)
 y = []
 ht = h0
 for xt in x
-    ht = rnn_cell(xt, ht)
+    ht = rnn_cell(ht, xt)
     y = [y; [ht]]  # concatenate in non-mutating (AD friendly) way
 end
 ```
 
-Notice how the above is essentially a `Dense` layer that acts on two inputs, `xt` and `ht`.
+Notice how the above is essentially a `Dense` layer that acts on two inputs, `ht` and `xt`.
 
 The output at each time step, called the hidden state, is used as the input to the next time step and is also the output of the model. 
 
@@ -58,7 +58,7 @@ rnn_cell = Flux.RNNCell(input_size => output_size)
 y = []
 ht = h0
 for xt in x
-    ht = rnn_cell(xt, ht)
+    ht = rnn_cell(ht, xt)
     y = [y; [ht]]
 end
 ```
@@ -78,7 +78,7 @@ struct RecurrentCellModel{H,C,D}
 end
 
 # we choose to not train the initial hidden state
-Flux.@layer RecurrentCellModel trainable=(cell,dense) 
+Flux.@layer RecurrentCellModel trainable = (cell, dense) 
 
 function RecurrentCellModel(input_size::Int, hidden_size::Int)
     return RecurrentCellModel(
@@ -91,7 +91,7 @@ function (m::RecurrentCellModel)(x)
     z = []
     ht = m.h0
     for xt in x
-        ht = m.cell(xt, ht)
+        ht = m.cell(ht, xt)
         z = [z; [ht]]
     end
     z = stack(z, dims=2) # [hidden_size, seq_len, batch_size] or [hidden_size, seq_len]

--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -74,7 +74,7 @@ function RNNCell((in, out)::Pair, σ=tanh; init = glorot_uniform, bias = true)
   return RNNCell(σ, Wi, Wh, b)
 end
 
-(m::RNNCell)(x::AbstractVecOrMat) = m(x, zeros_like(x, size(m.Wh, 1)))
+(m::RNNCell)(x::AbstractVecOrMat) = m(zeros_like(x, size(m.Wh, 1)), x)
 
 function (m::RNNCell)(h::AbstractVecOrMat, x::AbstractVecOrMat)
   _size_check(m, x, 1 => size(m.Wi,2))

--- a/test/layers/recurrent.jl
+++ b/test/layers/recurrent.jl
@@ -44,7 +44,7 @@
     test_gradients(r, h, x, loss=loss4) # vcat and stack
 
     # no initial state same as zero initial state
-    @test r(x[1]) ≈ r(x[1], zeros(Float32, 5))
+    @test r(x[1]) ≈ r(zeros(Float32, 5), x[1])
 
     # Now initial state has a batch dimension.
     h = randn(Float32, 5, 4)
@@ -82,7 +82,7 @@ end
 
     # no initial state same as zero initial state
     rnn = model.rnn 
-    @test rnn(x) ≈ rnn(x, zeros(Float32, 4))
+    @test rnn(x) ≈ rnn(zeros(Float32, 4), x)
 
     x = rand(Float32, 2, 3)
     y = model(x)
@@ -112,17 +112,17 @@ end
     x = [rand(Float32, 3, 4) for _ in 1:6]
     h = zeros(Float32, 5, 4)
     c = zeros(Float32, 5, 4)
-    hnew, cnew = cell(x[1], (h, c))
+    hnew, cnew = cell((h, c), x[1])
     @test hnew isa Matrix{Float32}
     @test cnew isa Matrix{Float32}
     @test size(hnew) == (5, 4)
     @test size(cnew) == (5, 4)
-    test_gradients(cell, x[1], (h, c), loss = (m, hc, x) -> mean(m(hc, x)[1]))
+    test_gradients(cell, (h, c), x[1], loss = (m, hc, x) -> mean(m(hc, x)[1]))
     test_gradients(cell, (h, c), x, loss = loss)
 
     # no initial state same as zero initial state
     hnew1, cnew1 = cell(x[1])
-    hnew2, cnew2 = cell(x[1], (zeros(Float32, 5), zeros(Float32, 5)))
+    hnew2, cnew2 = cell((zeros(Float32, 5), zeros(Float32, 5)), x[1])
     @test hnew1 ≈ hnew2
     @test cnew1 ≈ cnew2
 
@@ -140,7 +140,7 @@ end
 
     Flux.@layer :expand ModelLSTM
 
-    (m::ModelLSTM)(x) = m.lstm(x, (m.h0, m.c0))
+    (m::ModelLSTM)(x) = m.lstm((m.h0, m.c0), x)
 
     model = ModelLSTM(LSTM(2 => 4), zeros(Float32, 4), zeros(Float32, 4))
     
@@ -182,7 +182,7 @@ end
     test_gradients(r, h, x; loss)
 
     # no initial state same as zero initial state
-    @test r(x[1]) ≈ r(x[1], zeros(Float32, 5))
+    @test r(x[1]) ≈ r(zeros(Float32, 5), x[1])
 
     # Now initial state has a batch dimension.
     h = randn(Float32, 5, 4)
@@ -218,7 +218,7 @@ end
 
     # no initial state same as zero initial state
     gru = model.gru
-    @test gru(x) ≈ gru(x, zeros(Float32, 4))
+    @test gru(x) ≈ gru(zeros(Float32, 4), x)
     
     # No Bias
     gru = GRU(2 => 4, bias=false)
@@ -236,7 +236,7 @@ end
     test_gradients(r, h, x)
 
     # no initial state same as zero initial state
-    @test r(x) ≈ r(x, zeros(Float32, 5))
+    @test r(x) ≈ r(zeros(Float32, 5), x)
 
     # Now initial state has a batch dimension.
     h = randn(Float32, 5, 4)
@@ -268,5 +268,5 @@ end
 
     # no initial state same as zero initial state
     gru = model.gru
-    @test gru(x) ≈ gru(x, zeros(Float32, 4))
+    @test gru(x) ≈ gru(zeros(Float32, 4), x)
 end


### PR DESCRIPTION
In order to cause less breakage and avoid confusion such as in 
https://discourse.julialang.org/t/dimension-mismatch-in-flux-jl-rnn-example/122410
this PR reinstates the previous ordering for the arguments to a cell, i.e. `cell(h, x)` instead of the `cell(x, h)` we have on master.

