### PR TITLE
Distinct init for kernel and recurrent

### DIFF
--- a/src/layers/recurrent.jl
+++ b/src/layers/recurrent.jl
@@ -2,8 +2,8 @@
 # Vanilla RNN
 
 @doc raw"""
-    RNNCell(in => out, σ = tanh; kernel_init = glorot_uniform, 
-      recurrent_kernel_init = glorot_uniform, bias = true)
+    RNNCell(in => out, σ = tanh; init_kernel = glorot_uniform, 
+      init_recurrent_kernel = glorot_uniform, bias = true)
 
 The most basic recurrent layer. Essentially acts as a `Dense` layer, but with the
 output fed back into the input each time step.
@@ -20,8 +20,8 @@ See [`RNN`](@ref) for a layer that processes entire sequences.
 
 - `in => out`: The input and output dimensions of the layer.
 - `σ`: The non-linearity to apply to the output. Default is `tanh`.
-- `kernel_init`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
-- `recurrent_kernel_init`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
+- `init_kernel`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
+- `init_recurrent_kernel`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
 - `bias`: Whether to include a bias term initialized to zero. Default is `true`.
 
 # Forward
@@ -61,45 +61,45 @@ ŷ   # The hidden states at each time step
 ```
 """
 struct RNNCell{F, I, H, V}
-    σ::F
-    Wi::I
-    Wh::H
-    bias::V
+  σ::F
+  Wi::I
+  Wh::H
+  bias::V
 end
 
 @layer RNNCell
 
 function RNNCell(
-    (in, out)::Pair,
-    σ = tanh;
-    kernel_init = glorot_uniform,
-    recurrent_kernel_init = glorot_uniform,
-    bias = true,
+  (in, out)::Pair,
+  σ = tanh;
+  init_kernel = glorot_uniform,
+  init_recurrent_kernel = glorot_uniform,
+  bias = true,
 )
-    Wi = kernel_init(out, in)
-    Wh = recurrent_kernel_init(out, out)
-    b = create_bias(Wi, bias, size(Wi, 1))
-    return RNNCell(σ, Wi, Wh, b)
+  Wi = init_kernel(out, in)
+  Wh = init_recurrent_kernel(out, out)
+  b = create_bias(Wi, bias, size(Wi, 1))
+  return RNNCell(σ, Wi, Wh, b)
 end
 
 (m::RNNCell)(x::AbstractVecOrMat) = m(x, zeros_like(x, size(m.Wh, 1)))
 
 function (m::RNNCell)(x::AbstractVecOrMat, h::AbstractVecOrMat)
-    _size_check(m, x, 1 => size(m.Wi, 2))
-    σ = NNlib.fast_act(m.σ, x)
-    h = σ.(m.Wi * x .+ m.Wh * h .+ m.bias)
-    return h
+  _size_check(m, x, 1 => size(m.Wi, 2))
+  σ = NNlib.fast_act(m.σ, x)
+  h = σ.(m.Wi * x .+ m.Wh * h .+ m.bias)
+  return h
 end
 
 function Base.show(io::IO, m::RNNCell)
-    print(io, "RNNCell(", size(m.Wi, 2), " => ", size(m.Wi, 1))
-    print(io, ", ", m.σ)
-    print(io, ")")
+  print(io, "RNNCell(", size(m.Wi, 2), " => ", size(m.Wi, 1))
+  print(io, ", ", m.σ)
+  print(io, ")")
 end
 
 @doc raw"""
-    RNN(in => out, σ = tanh; kernel_init = glorot_uniform, 
-      recurrent_kernel_init = glorot_uniform, bias = true)
+    RNN(in => out, σ = tanh; init_kernel = glorot_uniform, 
+      init_recurrent_kernel = glorot_uniform, bias = true)
 
 The most basic recurrent layer. Essentially acts as a `Dense` layer, but with the
 output fed back into the input each time step.  
@@ -117,8 +117,8 @@ See [`RNNCell`](@ref) for a layer that processes a single time step.
 
 - `in => out`: The input and output dimensions of the layer.
 - `σ`: The non-linearity to apply to the output. Default is `tanh`.
-- `kernel_init`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
-- `recurrent_kernel_init`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
+- `init_kernel`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
+- `init_recurrent_kernel`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
 - `bias`: Whether to include a bias term initialized to zero. Default is `true`.
 
 # Forward
@@ -166,36 +166,36 @@ model = Model(RNN(32 => 64), zeros(Float32, 64))
 ```
 """
 struct RNN{M}
-    cell::M
+  cell::M
 end
 
 @layer :expand RNN
 
 function RNN((in, out)::Pair, σ = tanh; cell_kwargs...)
-    cell = RNNCell(in => out, σ; cell_kwargs...)
-    return RNN(cell)
+  cell = RNNCell(in => out, σ; cell_kwargs...)
+  return RNN(cell)
 end
 
 (m::RNN)(x) = m(x, zeros_like(x, size(m.cell.Wh, 1)))
 
 function (m::RNN)(x, h)
-    @assert ndims(x) == 2 || ndims(x) == 3
-    # [x] = [in, L] or [in, L, B]
-    # [h] = [out] or [out, B]
-    y = []
-    for x_t in eachslice(x, dims = 2)
-        h = m.cell(x_t, h)
-        # y = [y..., h]
-        y = vcat(y, [h])
-    end
-    return stack(y, dims = 2)
+  @assert ndims(x) == 2 || ndims(x) == 3
+  # [x] = [in, L] or [in, L, B]
+  # [h] = [out] or [out, B]
+  y = []
+  for x_t in eachslice(x, dims = 2)
+    h = m.cell(x_t, h)
+    # y = [y..., h]
+    y = vcat(y, [h])
+  end
+  return stack(y, dims = 2)
 end
 
 
 # LSTM
 @doc raw"""
-    LSTMCell(in => out; kernel_init = glorot_uniform,
-      recurrent_kernel_init = glorot_uniform, bias = true)
+    LSTMCell(in => out; init_kernel = glorot_uniform,
+      init_recurrent_kernel = glorot_uniform, bias = true)
 
 The [Long Short Term Memory](https://www.researchgate.net/publication/13853244_Long_Short-term_Memory) cell.
 Behaves like an RNN but generally exhibits a longer memory span over sequences.
@@ -216,8 +216,8 @@ See also [`LSTM`](@ref) for a layer that processes entire sequences.
 # Arguments
 
 - `in => out`: The input and output dimensions of the layer.
-- `kernel_init`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
-- `recurrent_kernel_init`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
+- `init_kernel`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
+- `init_recurrent_kernel`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
 - `bias`: Whether to include a bias term initialized to zero. Default is `true`.
 
 # Forward
@@ -252,49 +252,49 @@ julia> size(h′)  # out x batch_size
 ```
 """
 struct LSTMCell{I, H, V}
-    Wi::I
-    Wh::H
-    bias::V
+  Wi::I
+  Wh::H
+  bias::V
 end
 
 @layer LSTMCell
 
 function LSTMCell(
-    (in, out)::Pair;
-    kernel_init = glorot_uniform,
-    recurrent_kernel_init = glorot_uniform,
-    bias = true,
+  (in, out)::Pair;
+  init_kernel = glorot_uniform,
+  init_recurrent_kernel = glorot_uniform,
+  bias = true,
 )
-    Wi = kernel_init(out * 4, in)
-    Wh = recurrent_kernel_init(out * 4, out)
-    b = create_bias(Wi, bias, out * 4)
-    cell = LSTMCell(Wi, Wh, b)
-    return cell
+  Wi = init_kernel(out * 4, in)
+  Wh = init_recurrent_kernel(out * 4, out)
+  b = create_bias(Wi, bias, out * 4)
+  cell = LSTMCell(Wi, Wh, b)
+  return cell
 end
 
 function (m::LSTMCell)(x::AbstractVecOrMat)
-    h = zeros_like(x, size(m.Wh, 2))
-    c = zeros_like(h)
-    return m(x, (h, c))
+  h = zeros_like(x, size(m.Wh, 2))
+  c = zeros_like(h)
+  return m(x, (h, c))
 end
 
 function (m::LSTMCell)(x::AbstractVecOrMat, (h, c))
-    _size_check(m, x, 1 => size(m.Wi, 2))
-    b = m.bias
-    g = m.Wi * x .+ m.Wh * h .+ b
-    input, forget, cell, output = chunk(g, 4; dims = 1)
-    c′ = @. sigmoid_fast(forget) * c + sigmoid_fast(input) * tanh_fast(cell)
-    h′ = @. sigmoid_fast(output) * tanh_fast(c′)
-    return h′, c′
+  _size_check(m, x, 1 => size(m.Wi, 2))
+  b = m.bias
+  g = m.Wi * x .+ m.Wh * h .+ b
+  input, forget, cell, output = chunk(g, 4; dims = 1)
+  c′ = @. sigmoid_fast(forget) * c + sigmoid_fast(input) * tanh_fast(cell)
+  h′ = @. sigmoid_fast(output) * tanh_fast(c′)
+  return h′, c′
 end
 
 Base.show(io::IO, m::LSTMCell) =
-    print(io, "LSTMCell(", size(m.Wi, 2), " => ", size(m.Wi, 1) ÷ 4, ")")
+  print(io, "LSTMCell(", size(m.Wi, 2), " => ", size(m.Wi, 1) ÷ 4, ")")
 
 
 @doc raw""""
-    LSTM(in => out; kernel_init = glorot_uniform,
-      recurrent_kernel_init = glorot_uniform, bias = true)
+    LSTM(in => out; init_kernel = glorot_uniform,
+      init_recurrent_kernel = glorot_uniform, bias = true)
 
 [Long Short Term Memory](https://www.researchgate.net/publication/13853244_Long_Short-term_Memory)
 recurrent layer. Behaves like an RNN but generally exhibits a longer memory span over sequences.
@@ -317,8 +317,8 @@ See [`LSTMCell`](@ref) for a layer that processes a single time step.
 # Arguments
 
 - `in => out`: The input and output dimensions of the layer.
-- `kernel_init`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
-- `recurrent_kernel_init`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
+- `init_kernel`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
+- `init_recurrent_kernel`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
 - `bias`: Whether to include a bias term initialized to zero. Default is `true`.
 
 # Forward
@@ -356,39 +356,39 @@ size(h)  # out x len x batch_size
 ```
 """
 struct LSTM{M}
-    cell::M
+  cell::M
 end
 
 @layer :expand LSTM
 
 function LSTM((in, out)::Pair; cell_kwargs...)
-    cell = LSTMCell(in => out; cell_kwargs...)
-    return LSTM(cell)
+  cell = LSTMCell(in => out; cell_kwargs...)
+  return LSTM(cell)
 end
 
 function (m::LSTM)(x)
-    h = zeros_like(x, size(m.cell.Wh, 1))
-    c = zeros_like(h)
-    return m(x, (h, c))
+  h = zeros_like(x, size(m.cell.Wh, 1))
+  c = zeros_like(h)
+  return m(x, (h, c))
 end
 
 function (m::LSTM)(x, (h, c))
-    @assert ndims(x) == 2 || ndims(x) == 3
-    h′ = []
-    c′ = []
-    for x_t in eachslice(x, dims = 2)
-        h, c = m.cell(x_t, (h, c))
-        h′ = vcat(h′, [h])
-        c′ = vcat(c′, [c])
-    end
-    return stack(h′, dims = 2), stack(c′, dims = 2)
+  @assert ndims(x) == 2 || ndims(x) == 3
+  h′ = []
+  c′ = []
+  for x_t in eachslice(x, dims = 2)
+    h, c = m.cell(x_t, (h, c))
+    h′ = vcat(h′, [h])
+    c′ = vcat(c′, [c])
+  end
+  return stack(h′, dims = 2), stack(c′, dims = 2)
 end
 
 # GRU
 
 @doc raw"""
-    GRUCell(in => out; kernel_init = glorot_uniform,
-      recurrent_kernel_init = glorot_uniform, bias = true)
+    GRUCell(in => out; init_kernel = glorot_uniform,
+      init_recurrent_kernel = glorot_uniform, bias = true)
 
 [Gated Recurrent Unit](https://arxiv.org/abs/1406.1078v1) layer. 
 Behaves like an RNN but generally exhibits a longer memory span over sequences. 
@@ -408,8 +408,8 @@ See also [`GRU`](@ref) for a layer that processes entire sequences.
 # Arguments
 
 - `in => out`: The input and output dimensions of the layer.
-- `kernel_init`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
-- `recurrent_kernel_init`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
+- `init_kernel`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
+- `init_recurrent_kernel`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
 - `bias`: Whether to include a bias term initialized to zero. Default is `true`.
 
 # Forward
@@ -438,49 +438,49 @@ julia> h′ = g(x, h);
 ```
 """
 struct GRUCell{I, H, V}
-    Wi::I
-    Wh::H
-    b::V
+  Wi::I
+  Wh::H
+  b::V
 end
 
 @layer GRUCell
 
 function GRUCell(
-    (in, out)::Pair;
-    kernel_init = glorot_uniform,
-    recurrent_kernel_init = glorot_uniform,
-    bias = true,
+  (in, out)::Pair;
+  init_kernel = glorot_uniform,
+  init_recurrent_kernel = glorot_uniform,
+  bias = true,
 )
-    Wi = kernel_init(out * 3, in)
-    Wh = recurrent_kernel_init(out * 3, out)
-    b = create_bias(Wi, bias, size(Wi, 1))
-    return GRUCell(Wi, Wh, b)
+  Wi = init_kernel(out * 3, in)
+  Wh = init_recurrent_kernel(out * 3, out)
+  b = create_bias(Wi, bias, size(Wi, 1))
+  return GRUCell(Wi, Wh, b)
 end
 
 (m::GRUCell)(x::AbstractVecOrMat) = m(x, zeros_like(x, size(m.Wh, 2)))
 
 function (m::GRUCell)(x::AbstractVecOrMat, h)
-    _size_check(m, x, 1 => size(m.Wi, 2))
-    gxs = chunk(m.Wi * x, 3, dims = 1)
-    ghs = chunk(m.Wh * h, 3, dims = 1)
-    if m.b isa AbstractArray
-        bs = chunk(m.b, 3, dims = 1)
-    else # b == false
-        bs = [false, false, false]
-    end
-    r = @. sigmoid_fast(gxs[1] + ghs[1] + bs[1])
-    z = @. sigmoid_fast(gxs[2] + ghs[2] + bs[2])
-    h̃ = @. tanh_fast(gxs[3] + r * ghs[3] + bs[3])
-    h′ = @. (1 - z) * h̃ + z * h
-    return h′
+  _size_check(m, x, 1 => size(m.Wi, 2))
+  gxs = chunk(m.Wi * x, 3, dims = 1)
+  ghs = chunk(m.Wh * h, 3, dims = 1)
+  if m.b isa AbstractArray
+    bs = chunk(m.b, 3, dims = 1)
+  else # b == false
+    bs = [false, false, false]
+  end
+  r = @. sigmoid_fast(gxs[1] + ghs[1] + bs[1])
+  z = @. sigmoid_fast(gxs[2] + ghs[2] + bs[2])
+  h̃ = @. tanh_fast(gxs[3] + r * ghs[3] + bs[3])
+  h′ = @. (1 - z) * h̃ + z * h
+  return h′
 end
 
 Base.show(io::IO, m::GRUCell) =
-    print(io, "GRUCell(", size(m.Wi, 2), " => ", size(m.Wi, 1) ÷ 3, ")")
+  print(io, "GRUCell(", size(m.Wi, 2), " => ", size(m.Wi, 1) ÷ 3, ")")
 
 @doc raw"""
-    GRU(in => out; kernel_init = glorot_uniform,
-      recurrent_kernel_init = glorot_uniform, bias = true)
+    GRU(in => out; init_kernel = glorot_uniform,
+      init_recurrent_kernel = glorot_uniform, bias = true)
 
 [Gated Recurrent Unit](https://arxiv.org/abs/1406.1078v1) layer. Behaves like an
 RNN but generally exhibits a longer memory span over sequences. This implements
@@ -500,8 +500,8 @@ See [`GRUCell`](@ref) for a layer that processes a single time step.
 # Arguments
 
 - `in => out`: The input and output dimensions of the layer.
-- `kernel_init`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
-- `recurrent_kernel_init`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
+- `init_kernel`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
+- `init_recurrent_kernel`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
 - `bias`: Whether to include a bias term initialized to zero. Default is `true`.
 
 # Forward
@@ -528,36 +528,36 @@ h = gru(x, h0)  # out x len x batch_size
 ```
 """
 struct GRU{M}
-    cell::M
+  cell::M
 end
 
 @layer :expand GRU
 
 function GRU((in, out)::Pair; cell_kwargs...)
-    cell = GRUCell(in => out; cell_kwargs...)
-    return GRU(cell)
+  cell = GRUCell(in => out; cell_kwargs...)
+  return GRU(cell)
 end
 
 function (m::GRU)(x)
-    h = zeros_like(x, size(m.cell.Wh, 2))
-    return m(x, h)
+  h = zeros_like(x, size(m.cell.Wh, 2))
+  return m(x, h)
 end
 
 function (m::GRU)(x, h)
-    @assert ndims(x) == 2 || ndims(x) == 3
-    h′ = []
-    # [x] = [in, L] or [in, L, B]
-    for x_t in eachslice(x, dims = 2)
-        h = m.cell(x_t, h)
-        h′ = vcat(h′, [h])
-    end
-    return stack(h′, dims = 2)
+  @assert ndims(x) == 2 || ndims(x) == 3
+  h′ = []
+  # [x] = [in, L] or [in, L, B]
+  for x_t in eachslice(x, dims = 2)
+    h = m.cell(x_t, h)
+    h′ = vcat(h′, [h])
+  end
+  return stack(h′, dims = 2)
 end
 
 # GRU v3
 @doc raw"""
-    GRUv3Cell(in => out; kernel_init = glorot_uniform,
-      recurrent_kernel_init = glorot_uniform, bias = true)
+    GRUv3Cell(in => out; init_kernel = glorot_uniform,
+      init_recurrent_kernel = glorot_uniform, bias = true)
     
 [Gated Recurrent Unit](https://arxiv.org/abs/1406.1078v3) layer. 
 Behaves like an RNN but generally exhibits a longer memory span over sequences. 
@@ -578,8 +578,8 @@ See [`GRU`](@ref) and [`GRUCell`](@ref) for variants of this layer.
 # Arguments
 
 - `in => out`: The input and output dimensions of the layer.
-- `kernel_init`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
-- `recurrent_kernel_init`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
+- `init_kernel`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
+- `init_recurrent_kernel`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
 - `bias`: Whether to include a bias term initialized to zero. Default is `true`.
 
 # Forward
@@ -595,52 +595,52 @@ The arguments of the forward pass are:
 Returns the new hidden state `h'` as an array of size `out` or `out x batch_size`.
 """
 struct GRUv3Cell{I, H, V, HH}
-    Wi::I
-    Wh::H
-    b::V
-    Wh_h̃::HH
+  Wi::I
+  Wh::H
+  b::V
+  Wh_h̃::HH
 end
 
 @layer GRUv3Cell
 
 function GRUv3Cell(
-    (in, out)::Pair;
-    kernel_init = glorot_uniform,
-    recurrent_kernel_init = glorot_uniform,
-    bias = true,
+  (in, out)::Pair;
+  init_kernel = glorot_uniform,
+  init_recurrent_kernel = glorot_uniform,
+  bias = true,
 )
-    Wi = kernel_init(out * 3, in)
-    Wh = recurrent_kernel_init(out * 3, out)
-    Wh_h̃ = recurrent_kernel_init(out, out)
-    b = create_bias(Wi, bias, out * 3)
-    return GRUv3Cell(Wi, Wh, b, Wh_h̃)
+  Wi = init_kernel(out * 3, in)
+  Wh = init_recurrent_kernel(out * 3, out)
+  Wh_h̃ = init_recurrent_kernel(out, out)
+  b = create_bias(Wi, bias, out * 3)
+  return GRUv3Cell(Wi, Wh, b, Wh_h̃)
 end
 
 (m::GRUv3Cell)(x::AbstractVecOrMat) = m(x, zeros_like(x, size(m.Wh, 2)))
 
 function (m::GRUv3Cell)(x::AbstractVecOrMat, h)
-    _size_check(m, x, 1 => size(m.Wi, 2))
-    gxs = chunk(m.Wi * x, 3, dims = 1)
-    ghs = chunk(m.Wh * h, 3, dims = 1)
-    if m.b isa AbstractArray
-        bs = chunk(m.b, 3, dims = 1)
-    else # m.b == false
-        bs = [false, false, false]
-    end
-    r = @. sigmoid_fast(gxs[1] + ghs[1] + bs[1])
-    z = @. sigmoid_fast(gxs[2] + ghs[2] + bs[2])
-    h̃ = tanh_fast.(gxs[3] .+ (m.Wh_h̃ * (r .* h)) .+ bs[3])
-    h′ = @. (1 - z) * h̃ + z * h
-    return h′
+  _size_check(m, x, 1 => size(m.Wi, 2))
+  gxs = chunk(m.Wi * x, 3, dims = 1)
+  ghs = chunk(m.Wh * h, 3, dims = 1)
+  if m.b isa AbstractArray
+    bs = chunk(m.b, 3, dims = 1)
+  else # m.b == false
+    bs = [false, false, false]
+  end
+  r = @. sigmoid_fast(gxs[1] + ghs[1] + bs[1])
+  z = @. sigmoid_fast(gxs[2] + ghs[2] + bs[2])
+  h̃ = tanh_fast.(gxs[3] .+ (m.Wh_h̃ * (r .* h)) .+ bs[3])
+  h′ = @. (1 - z) * h̃ + z * h
+  return h′
 end
 
 Base.show(io::IO, m::GRUv3Cell) =
-    print(io, "GRUv3Cell(", size(m.Wi, 2), " => ", size(m.Wi, 1) ÷ 3, ")")
+  print(io, "GRUv3Cell(", size(m.Wi, 2), " => ", size(m.Wi, 1) ÷ 3, ")")
 
 
 @doc raw"""
-    GRUv3(in => out; kernel_init = glorot_uniform,
-      recurrent_kernel_init = glorot_uniform, bias = true)
+    GRUv3(in => out; init_kernel = glorot_uniform,
+      init_recurrent_kernel = glorot_uniform, bias = true)
 
 [Gated Recurrent Unit](https://arxiv.org/abs/1406.1078v3) layer. Behaves like an
 RNN but generally exhibits a longer memory span over sequences. This implements
@@ -661,32 +661,32 @@ See [`GRU`](@ref) and [`GRUCell`](@ref) for variants of this layer.
 # Arguments
 
 - `in => out`: The input and output dimensions of the layer.
-- `kernel_init`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
-- `recurrent_kernel_init`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
+- `init_kernel`: The initialization function to use for the input to hidden connection weights. Default is `glorot_uniform`.
+- `init_recurrent_kernel`: The initialization function to use for the hidden to hidden connection weights. Default is `glorot_uniform`.
 - `bias`: Whether to include a bias term initialized to zero. Default is `true`.
 """
 struct GRUv3{M}
-    cell::M
+  cell::M
 end
 
 @layer :expand GRUv3
 
 function GRUv3((in, out)::Pair; cell_kwargs...)
-    cell = GRUv3Cell(in => out; cell_kwargs...)
-    return GRUv3(cell)
+  cell = GRUv3Cell(in => out; cell_kwargs...)
+  return GRUv3(cell)
 end
 
 function (m::GRUv3)(x)
-    h = zeros_like(x, size(m.cell.Wh, 2))
-    return m(x, h)
+  h = zeros_like(x, size(m.cell.Wh, 2))
+  return m(x, h)
 end
 
 function (m::GRUv3)(x, h)
-    @assert ndims(x) == 2 || ndims(x) == 3
-    h′ = []
-    for x_t in eachslice(x, dims = 2)
-        h = m.cell(x_t, h)
-        h′ = vcat(h′, [h])
-    end
-    return stack(h′, dims = 2)
+  @assert ndims(x) == 2 || ndims(x) == 3
+  h′ = []
+  for x_t in eachslice(x, dims = 2)
+    h = m.cell(x_t, h)
+    h′ = vcat(h′, [h])
+  end
+  return stack(h′, dims = 2)
 end


### PR DESCRIPTION
Adding different initializers options for input matrix and recurrent matrix in recurrent cells as described in #2514. Similar approaches are available in:
 -  [Keras/TF](https://www.tensorflow.org/api_docs/python/tf/keras/layers/LSTMCell) 
 - [Flax](https://flax.readthedocs.io/en/latest/api_reference/flax.nnx/nn/recurrent.html#flax.nnx.nn.recurrent.LSTMCell)

An example of the implementation is as follows:

```julia
function RNNCell((in, out)::Pair, σ=relu;
    kernel_init = glorot_uniform,
    recurrent_kernel_init = glorot_uniform,
    bias = true)
    Wi = kernel_init(out, in)
    U = recurrent_kernel_init(out, out)
    b = create_bias(Wi, bias, size(Wi, 1))
    return RNNCell(σ, Wi, U, b)
end
```

### PR Checklist

- [ ] ~Tests are added~ (should not be necessary)
- [ ] Entry in NEWS.md
- [x] Documentation, if applicable (updated docstrings)
