### PR TITLE
Port Rotary Positional Embedding from NeuralAttentionlib.jl

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -71,7 +71,7 @@ include("functor.jl")
 
 @compat(public, (
   # from OneHotArrays.jl
-  onehot, onehotbatch, onecold,  
+  onehot, onehotbatch, onecold,
   # from Functors.jl
   functor, @functor, KeyPath, haskeypath, getkeypath,
   # from Optimise/Train/Optimisers.jl
@@ -90,6 +90,7 @@ include("layers/conv.jl")
 include("layers/recurrent.jl")
 include("layers/normalise.jl")
 include("layers/upsample.jl")
+include("layers/rotary.jl")
 include("layers/attention.jl")
 
 include("loading.jl")

--- a/src/layers/rotary.jl
+++ b/src/layers/rotary.jl
@@ -1,4 +1,23 @@
 """
+    Rotary Position Embeddings (RoPE)
+
+This is a port of the RoPE implementation from NeuralAttentionlib.jl, which is an implementation of
+the Rotary Position Embeddings (RoPE) described in the RoFormer paper.
+
+Original sources:
+- Paper: "RoFormer: Enhanced Transformer with Rotary Position Embedding"
+  Authors: Jianlin Su, Yu Lu, Shengfeng Pan, Ahmed Murtadha, Bo Wen
+  URL: https://arxiv.org/abs/2104.09864
+  
+- Code: NeuralAttentionlib.jl
+  Author: chengchingwen
+  Repository: https://github.com/chengchingwen/NeuralAttentionlib.jl
+
+RoPE encodes absolute positional information with a rotation matrix that naturally 
+incorporates explicit relative position dependency in self-attention formulation.
+"""
+
+"""
 Calculate position-dependent frequency.
 """
 function _default_freq_decay(i, hidden_size)

--- a/src/layers/rotary.jl
+++ b/src/layers/rotary.jl
@@ -1,0 +1,138 @@
+
+"""
+    sincos_position_embed(pos, idx, hidden_size)
+
+Calculate sinusoidal position embedding for a single position and feature index.
+Uses alternating sine and cosine based on feature index parity.
+"""
+function sincos_position_embed(pos, idx, hidden_size)
+    i = (idx + 1) ÷ 2  # which frequency we're calculating
+    pos_idx = pos - 1
+
+    # freq = 1/10000^(2i/d) following original transformer paper
+    freq = 10.0f0^(-(8i/hidden_size))
+    angle = pos_idx * freq
+
+    # Alternate between sin and cos based on feature index
+    return iseven(idx) ? cos(angle) : sin(angle)
+end
+
+ChainRulesCore.@non_differentiable sincos_position_embed(pos, idx, hidden_size)
+
+"""
+    _rotary_transform(x1, x2, cos_θ, sin_θ)
+
+Helper function to perform rotary transformation of a feature pair.
+"""
+function _rotary_transform(x1, x2, cos_θ, sin_θ)
+    y1 = x1 * cos_θ - x2 * sin_θ
+    y2 = x2 * cos_θ + x1 * sin_θ
+    return y1, y2
+end
+
+"""
+    _apply_rotary(x, seq_len)
+
+Apply rotary transformation to input tensor.
+"""
+function _apply_rotary(x, seq_len)
+    hidden_size = size(x, 1)
+
+    # Get positional encodings
+    pos_enc = similar(x, hidden_size, seq_len)
+    for i in 1:hidden_size, j in 1:seq_len
+        pos_enc[i,j] = sincos_position_embed(j, i, hidden_size)
+    end
+
+    y = similar(x)
+    half_size = hidden_size ÷ 2
+
+    # Apply rotary transformation
+    for j in 1:seq_len
+        for i in 1:half_size
+            idx = 2i - 1
+            x1, x2 = x[idx,j], x[idx+1,j]
+            cos_θ, sin_θ = pos_enc[idx,j], pos_enc[idx+1,j]
+
+            y[idx,j], y[idx+1,j] = _rotary_transform(x1, x2, cos_θ, sin_θ)
+        end
+    end
+
+    return y
+end
+
+"""
+    with_rotary_position_embedding(x)
+
+Apply rotary position embeddings to input tensor x.
+
+Input tensor should be of shape (features, sequence_length, ...).
+Features dimension must be even.
+
+# Arguments
+- `x`: Input tensor of shape (features, sequence_length, ...)
+
+# Returns
+- Tensor of same shape as input with rotary position embeddings applied
+"""
+function with_rotary_position_embedding(x::AbstractArray)
+    hidden_size = size(x, 1)
+    iseven(hidden_size) || throw(ArgumentError("Feature dimension ($(hidden_size)) must be even"))
+    return _apply_rotary(x, size(x, 2))
+end
+
+# Gradient rules
+function ChainRulesCore.rrule(::typeof(_rotary_transform), x1, x2, cos_θ, sin_θ)
+    y1, y2 = _rotary_transform(x1, x2, cos_θ, sin_θ)
+
+    function rotary_transform_pullback(Ȳ)
+        ∂y1, ∂y2 = Ȳ
+
+        # Inverse rotation matrix for gradients
+        ∂x1 = ∂y1 * cos_θ + ∂y2 * sin_θ
+        ∂x2 = -∂y1 * sin_θ + ∂y2 * cos_θ
+
+        return (NoTangent(), ∂x1, ∂x2, NoTangent(), NoTangent())
+    end
+
+    return (y1, y2), rotary_transform_pullback
+end
+
+function ChainRulesCore.rrule(::typeof(_apply_rotary), x, seq_len)
+    y = _apply_rotary(x, seq_len)
+
+    function apply_rotary_pullback(Ȳ)
+        hidden_size = size(x, 1)
+        pos_enc = similar(x, hidden_size, seq_len)
+        for i in 1:hidden_size, j in 1:seq_len
+            pos_enc[i,j] = sincos_position_embed(j, i, hidden_size)
+        end
+
+        ∂x = similar(Ȳ)
+        half_size = hidden_size ÷ 2
+
+        for j in 1:seq_len
+            for i in 1:half_size
+                idx = 2i - 1
+                cos_θ, sin_θ = pos_enc[idx,j], pos_enc[idx+1,j]
+                ∂y1, ∂y2 = Ȳ[idx,j], Ȳ[idx+1,j]
+
+                ∂x[idx,j] = ∂y1 * cos_θ + ∂y2 * sin_θ
+                ∂x[idx+1,j] = -∂y1 * sin_θ + ∂y2 * cos_θ
+            end
+        end
+
+        return (NoTangent(), ∂x, NoTangent())
+    end
+
+    return y, apply_rotary_pullback
+end
+
+function ChainRulesCore.rrule(::typeof(with_rotary_position_embedding), x::AbstractArray)
+    y = with_rotary_position_embedding(x)
+    function rotary_pullback(Ȳ)
+        _, ∂x, _ = rrule(_apply_rotary, x, size(x,2))[2](Ȳ)
+        return (NoTangent(), ∂x)
+    end
+    return y, rotary_pullback
+end

--- a/src/layers/rotary.jl
+++ b/src/layers/rotary.jl
@@ -1,19 +1,19 @@
 """
     Rotary Position Embeddings (RoPE)
 
-This is a port of the RoPE implementation from NeuralAttentionlib.jl, which is an implementation of
+This is a port and simplified code of the RoPE implementation from NeuralAttentionlib.jl, which is an implementation of
 the Rotary Position Embeddings (RoPE) described in the RoFormer paper.
 
 Original sources:
 - Paper: "RoFormer: Enhanced Transformer with Rotary Position Embedding"
   Authors: Jianlin Su, Yu Lu, Shengfeng Pan, Ahmed Murtadha, Bo Wen
   URL: https://arxiv.org/abs/2104.09864
-  
+
 - Code: NeuralAttentionlib.jl
   Author: chengchingwen
   Repository: https://github.com/chengchingwen/NeuralAttentionlib.jl
 
-RoPE encodes absolute positional information with a rotation matrix that naturally 
+RoPE encodes absolute positional information with a rotation matrix that naturally
 incorporates explicit relative position dependency in self-attention formulation.
 """
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -205,7 +205,7 @@ ChainRulesCore.@non_differentiable kaiming_normal(::Any...)
 """
     truncated_normal([rng], size...; mean = 0, std = 1, lo = -2, hi = 2) -> Array
     truncated_normal([rng]; kw...) -> Function
-  
+
 Return an `Array{Float32}` of the given `size` where each element is drawn from a truncated normal distribution.
 The numbers are distributed like `filter(x -> lo<=x<=hi, mean .+ std .* randn(100))`.
 
@@ -253,7 +253,7 @@ ChainRulesCore.@non_differentiable truncated_normal(::Any...)
     lecun_normal([rng]; kw...) -> Function
 
 Return an `Array{Float32}` of the given `size` containing random numbers drawn from a truncated normal
-distribution centered on 0 with stddev `sqrt(1 / fan_in)`, where `fan_in` is the number of input units 
+distribution centered on 0 with stddev `sqrt(1 / fan_in)`, where `fan_in` is the number of input units
 in the weight tensor.
 
 # Examples
@@ -414,7 +414,7 @@ Has the following behaviour
 *  2D: An identity matrix (useful for an identity matrix multiplication)
 *  More than 2D: A dense block array of center tap spatial filters (useful for an identity convolution)
 
-Some caveats: 
+Some caveats:
 * Not all layers will be identity mapping when used with this init. Exceptions
   include recurrent layers and normalization layers.
 

--- a/test/layers/rotary.jl
+++ b/test/layers/rotary.jl
@@ -1,0 +1,32 @@
+using Flux: with_rotary_position_embedding
+
+@testset "Rotary Position Embedding Tests" begin
+    Random.seed!(123)
+    test_sizes = [(2,2), (4,6), (8,10)]
+
+    for (n, d) in test_sizes
+        x = randn(n, d)
+        test_gradients(
+            with_rotary_position_embedding,
+            x;
+            rtol=1e-4,
+            atol=1e-4,
+            test_gpu=false,
+            compare_finite_diff=true,
+            loss=(f, x) -> sum(f(x))
+        )
+    end
+
+    # Edge cases
+    test_gradients(
+        with_rotary_position_embedding,
+        zeros(4, 6);
+        loss=(f, x) -> sum(f(x))
+    )
+
+    test_gradients(
+        with_rotary_position_embedding,
+        ones(4, 6);
+        loss=(f, x) -> sum(f(x))
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,7 @@ Random.seed!(0)
       include("layers/upsample.jl")
       include("layers/show.jl")
       include("layers/macro.jl")
+      include("layers/rotary.jl")
     end
 
     @testset "outputsize" begin


### PR DESCRIPTION
This is pretty much standard thing to do these days with MultiHeadAttention layer, I think we should have it as part of Flux.
If anyone can review it, I would be happy. Too often I miss this.