### PR TITLE
fix `Flux.@functor`

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -99,14 +99,16 @@ end
 
 macro functor(args...)
   @warn """The use of `Flux.@functor` is deprecated.
-      Most likely, you should write `Flux.@layer MyLayer` which will add various convenience methods for your type,
+      Most likely, you should write `Flux.@layer MyLayer`\
+      which will add various convenience methods for your type,\
       such as pretty-printing and use with Adapt.jl.
-      However, this is not required. Flux.jl v0.15 uses Functors.jl v0.5, which makes exploration of most nested `struct`s
-      opt-out instead of opt-in... so Flux will automatically see inside any custom struct definitions.
+      However, this is not required. Flux.jl v0.15 uses Functors.jl v0.5,\
+      which makes exploration of most nested `struct`s opt-out instead of opt-in...\
+      so Flux will automatically see inside any custom struct definitions.
       If you really want to apply the `@functor` macro to a custom struct, use `Functors.@functor` instead.
       """ maxlog=1
-
-  return Functors.functorm(args...)
+  # From https://discourse.julialang.org/t/calling-a-macro-from-within-a-macro-revisited/19680
+  return esc(:($Functors.@functor($(args...))))
 end
 
 # Allows caching of the parameters when params is called within gradient() to fix #2040.

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -2,3 +2,16 @@
     ps = Flux.params([2,3])
     @test length(ps) == 1
 end
+
+@testset "Flux.@functor" begin
+    # https://github.com/FluxML/Flux.jl/issues/2545
+    struct A2545; x; y; end
+    Flux.@functor A2545
+    a = A2545(1, 2)
+    @test fmap(x -> 2x, a) == A2545(2, 4)
+
+    struct B2545; x; y; end
+    Flux.@functor B2545 (x,)
+    b = B2545(1, 2)
+    @test fmap(x -> 2x, b) == B2545(2, 2)
+end


### PR DESCRIPTION
fix #2545 following the `retestset2` approach in the OP of
https://discourse.julialang.org/t/calling-a-macro-from-within-a-macro-revisited/19680
