### PR TITLE
hotfix: `gpu_device` not defined in `Flux.DistributedUtils`

### DIFF
--- a/src/distributed/public_api.jl
+++ b/src/distributed/public_api.jl
@@ -132,7 +132,7 @@ Backend Agnostic API to perform an allreduce operation on the given buffer `send
 workers.
 """
 function allreduce!(backend::AbstractFluxDistributedBackend, sendrecvbuf, op::F) where {F}
-    return __allreduce!(backend, sendrecvbuf, op, gpu_device())
+    return __allreduce!(backend, sendrecvbuf, op, get_device(sendrecvbuf))
 end
 
 function allreduce!(


### PR DESCRIPTION
`gpu_device` was not explicitly imported in the `DistributedUtils` module, leading to an `UndefVarError`. Instead of importing it, this PR simply calls `get_device` on the buffer to get the device, as is done in the `bcast!` method from the same file, and the original [Lux.jl](https://github.com/LuxDL/Lux.jl/blob/main/src/distributed/public_api.jl?#L132) implementation.