### PR TITLE
Remove 2 items from public, to fix 1.12

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -60,7 +60,7 @@ export Chain, Dense, Embedding, EmbeddingBag,
   # from Train
   setup, train!,
   # from Optimsers.jl
-  destructure, freeze!, thaw!, adjust!, trainables, update!, trainable,
+  freeze!, thaw!, adjust!, update!, trainable,
   # from Zygote.jl
   hessian, diaghessian, jacobian, withjacobian, pullback,
   # AD functions


### PR DESCRIPTION
On master, but not on 1.11, Flux cannot be loaded because some symbols are both public and exported:
```
julia> using Flux
Info Given Flux was explicitly requested, output will be shown live 
ERROR: LoadError: cannot declare Flux.trainables public; it is already declared exported

julia> VERSION
v"1.12.0-DEV.1731"
```
Tracking things down, this was changed in https://github.com/JuliaLang/julia/pull/53664 . It means that `@reexport using Optimisers` is fragile -- if Optimisers.jl exports a symbol marked public here, it will immediately break Flux. 

(Was not noticed here for ages, Zygote wasn't compiling on master until https://github.com/FluxML/Zygote.jl/pull/1542)

Does not fix CI on master, which really should just not try to load Enzyme at all:
> Failed to precompile Enzyme [7da242da-08ed-463a-9acd-ee780be4f1d9] to  "/home/runner/.julia/compiled/v1.12/Enzyme/jl_FMXEUb".
> ERROR: LoadError: UndefVarError: `verbose_stmt_info` not defined in `Compiler`
