### PR TITLE
Fix FluxMPIExt for AMDGPU

### DIFF
--- a/ext/FluxMPIExt/FluxMPIExt.jl
+++ b/ext/FluxMPIExt/FluxMPIExt.jl
@@ -24,7 +24,7 @@ function DistributedUtils.__initialize(
         error(lazy"CUDA devices are not functional and `force_cuda` is set to `true`. This is caused by backend: $(caller).")
     end
 
-    if amdgpu_devices !== missing && AMDGPU.functional()
+    if amdgpu_devices !== missing && functional(AMDGPUDevice)
         if amdgpu_devices === nothing
             set_device!(AMDGPUDevice, nothing, local_rank + 1)
         else

--- a/ext/FluxMPIExt/FluxMPIExt.jl
+++ b/ext/FluxMPIExt/FluxMPIExt.jl
@@ -3,7 +3,7 @@ module FluxMPIExt
 using Flux: MPIBackend, NCCLBackend, DistributedUtils,
             MPI_CUDA_AWARE, MPI_ROCM_AWARE
 using MPI: MPI
-using MLDataDevices: AbstractDevice, CUDADevice, AMDGPUDevice, functional, set_device!
+using MLDataDevices: AbstractDevice, CUDADevice, AMDGPUDevice, functional, set_device!, cpu_device
 
 
 function DistributedUtils.__initialize(


### PR DESCRIPTION
With ROCM-aware MPI, the initialization,

```julia
import AMDGPU
using Flux
import MPI
AMDGPU.allowscalar(false)
DistributedUtils.initialize(MPIBackend)
```
fails with (output from 2 MPI tasks):

```
ERROR: LoadError: UndefVarError: `AMDGPU` not defined in `FluxMPIExt`
Stacktrace:
ERROR: LoadError: UndefVarError: `AMDGPU` not defined in `FluxMPIExt`
Stacktrace:
 [1] __initialize(::Type{MPIBackend}; cuda_devices::Nothing, amdgpu_devices::Nothing, force_cuda::Bool, caller::String, force_amdgpu::Bool)
 [1] __initialize(::Type{MPIBackend}; cuda_devices::Nothing, amdgpu_devices::Nothing, force_cuda::Bool, caller::String, force_amdgpu::Bool)
   @ FluxMPIExt ~/julia-depot/packages/Flux/BkG8S/ext/FluxMPIExt/FluxMPIExt.jl:27
   @ FluxMPIExt ~/julia-depot/packages/Flux/BkG8S/ext/FluxMPIExt/FluxMPIExt.jl:27
 [2] __initialize
 [2] __initialize
   @ ~/julia-depot/packages/Flux/BkG8S/ext/FluxMPIExt/FluxMPIExt.jl:9 [inlined]
 [3] #initialize#1
   @ ~/julia-depot/packages/Flux/BkG8S/ext/FluxMPIExt/FluxMPIExt.jl:9 [inlined]
   @ ~/julia-depot/packages/Flux/BkG8S/src/distributed/public_api.jl:47 [inlined]
 [3] #initialize#1
   @ ~/julia-depot/packages/Flux/BkG8S/src/distributed/public_api.jl:47 [inlined]
 [4] initialize(backend::Type{MPIBackend})
 [4] initialize(backend::Type{MPIBackend})
   @ Flux.DistributedUtils ~/julia-depot/packages/Flux/BkG8S/src/distributed/public_api.jl:45
 [5] top-level scope
   @ Flux.DistributedUtils ~/julia-depot/packages/Flux/BkG8S/src/distributed/public_api.jl:45
```

I had also the error `UndefVarError: `cpu_device` not defined in `FluxMPIExt`.


### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
