### PR TITLE
Added shape validation for Conv weight tensor

### DIFF
--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -515,7 +515,6 @@ If the shape does not match, a `DimensionMismatch` error is thrown.
 
 This is internally used to validate weight initialization functions.
 """
-
 function _sizecheck(f, sz::Integer...)
   W = f(sz...)
   size(W) == sz || throw(DimensionMismatch(

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -518,10 +518,9 @@ This is internally used to validate weight initialization functions.
 
 function _sizecheck(f, sz::Integer...)
   W = f(sz...)
-  err = DimensionMismatch(
+  size(W) == sz || throw(DimensionMismatch(
       "Weight shape mismatch: expected $(sz), got $(size(W))",
-  )
-  size(W) == sz || throw(err)
+  ))
   W
 end
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -176,12 +176,6 @@ distribution.
 
 This is internally used by the [`Conv`](@ref) layer.
 """
-function _sizecheck(f, sz::Integer...)
-    W = f(sz...)
-    err = DimensionMismatch("Weight shape mismatch: expected $(sz), got $(size(W))")
-    size(W) == sz || throw(err)
-    W
-end
 
 function convfilter(filter::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer};
           init = glorot_uniform, groups = 1) where N
@@ -510,6 +504,27 @@ function _conv_size_check(layer, x::AbstractArray)
     lazy" expects size(input, $d) == $n, but got ", summary(x))))
 end
 ChainRulesCore.@non_differentiable _conv_size_check(::Any, ::Any)
+
+"""
+    _sizecheck(f, sz::Integer...)
+
+Ensures that the output of `f(sz...)` has the expected shape `sz`.
+
+Constructs a tensor using the function `f` with the given size `sz` and verifies that its shape matches `sz`.  
+If the shape does not match, a `DimensionMismatch` error is thrown.
+
+This is internally used to validate weight initialization functions.
+"""
+
+function _sizecheck(f, sz::Integer...)
+  W = f(sz...)
+  err = DimensionMismatch(
+      "Weight shape mismatch: expected $(sz), got $(size(W))",
+  )
+  size(W) == sz || throw(err)
+  W
+end
+
 """
     AdaptiveMaxPool(out::NTuple)
 

--- a/src/layers/conv.jl
+++ b/src/layers/conv.jl
@@ -162,6 +162,10 @@ function Conv(k::NTuple{N,Integer}, ch::Pair{<:Integer,<:Integer}, σ = identity
             bias = true) where N
     
   weight = convfilter(k, ch; init, groups)
+  shape = (k..., ch.first÷groups, ch.second)
+  if size(weight) != shape
+    error("Weight shape mismatch: expected $(shape), got $(size(weight))")
+  end
   Conv(weight, bias, σ; stride, pad, dilation, groups)
 end
 

--- a/test/layers/conv.jl
+++ b/test/layers/conv.jl
@@ -87,6 +87,14 @@ end
     # Test that we cannot ask for non-integer multiplication factors
     @test_throws AssertionError Conv((2, 2), 3=>10, groups=2)
     @test_throws AssertionError Conv((2, 2), 2=>9, groups=2)
+
+    # Test that Conv throws a DimensionMismatch error when the initializer 
+    # produces a tensor with an incorrect shape.
+    @test_throws DimensionMismatch Conv(
+      (3, 3),
+      1 => 1;
+      init = (_...) -> rand(3, 3, 1),
+    )
   end
 end
 


### PR DESCRIPTION
This pull request addresses an issue that was raised in [Flux.jl Issue #2506](https://github.com/FluxML/Flux.jl/issues/2506).
### Problem
Initially, when we overwrote the `init` function with a tensor of a shape different from the one specified by the `k` and `ch` parameters, the `Conv` function would create a filter using the shape of the `init` tensor instead of using the shape defined by the input parameters. This led to unexpected behavior.

### Solution
In this modification, if the shape of the created weight tensor does not match the expected shape (k..., ch.first ÷ groups, ch.second), an error is now raised. This ensures that the filter shape is consistent with the input parameters, preventing potential mismatches in convolution operations.
```
weights = Flux.kaiming_normal()(3, 3, 1)
Conv((3, 3), 1 => 1; pad = (1, 1), init = (_...) -> weights)
# Expected shape: (3, 3, 1, 1), got (3, 3, 1), error

weights = Flux.kaiming_normal()(3, 3, 1, 1)
Conv((3, 3), 1 => 1; pad = (1, 1), init = (_...) -> weights)
# Expected shape: (3, 3, 1, 1), got (3, 3, 1, 1), ok
```