### PR TITLE
Adding `summarise_array` to show.jl

### DIFF
--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -100,6 +100,8 @@ function _macro_layer_show(ex)
   end
 end
 
+summarise_array(a) = ""
+
 function _layer_show(io::IO, layer, indent::Int=0, name=nothing)
   _str = isnothing(name) ? "" : "$name = "
   str = _str * _layer_string(io, layer)
@@ -108,6 +110,7 @@ function _layer_show(io::IO, layer, indent::Int=0, name=nothing)
     print(io, " "^max(2, (indent==0 ? 20 : 39) - indent - length(str)))
     printstyled(io, "# ", underscorise(sum(length, trainables(layer); init=0)), " parameters"; 
 color=:light_black)
+    printstyled(io, join(summarise_array.(trainables(layer))); color=:light_black)
     nonparam = _childarray_sum(length, layer) - sum(length, trainables(layer), init=0)
     if nonparam > 0
       printstyled(io, ", plus ", underscorise(nonparam), indent==0 ? " non-trainable" : ""; color=:light_black)


### PR DESCRIPTION
I'm not sure if you'll want this, and maybe there is a better way to do what this does, but:

This PR adds two lines that, if I haven't missed anything, should make no difference to the current behavior of `Base.show`. But it allows the user some customization of the model/layer display.

The particular problem this solves for me is "being able to easily inspect summary stats of the model weights at the individual tensor level". With the change in this PR, I can define eg. this:

```julia
Flux.summarise_array(a) = "; L=$(length(a)):σ=$(round(std(a), digits = 3))"
```

and then when I display my model in the REPL, I can see the details I wanted for each tensor in each layer, in the context of the model structure:
<img width="631" alt="image" src="https://github.com/user-attachments/assets/b8d92032-2247-4e24-a984-eb70cafac33a" />

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable
