### PR TITLE
Fix loading of pooling layers

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -168,3 +168,11 @@ end
 #   """
 # ))
 
+# In Flux <= v0.14, pooling layers contained no state.
+# These workarounds allow such pooling layers to be loaded in Flux v0.16. 
+# (https://github.com/FluxML/Flux.jl/pull/2598)
+loadmodel!(dst::MaxPool{N, M}, src::Tuple{}; kw...) where {N, M} = dst
+loadmodel!(dst::AdaptiveMaxPool{S, O}, src::Tuple{}; kw...) where {S, O} = dst
+
+loadmodel!(dst::MeanPool{N, M}, src::Tuple{}; kw...) where {N, M} = dst
+loadmodel!(dst::AdaptiveMeanPool{S, O}, src::Tuple{}; kw...) where {S, O} = dst

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -169,10 +169,9 @@ end
 # ))
 
 # In Flux <= v0.14, pooling layers contained no state.
-# These workarounds allow such pooling layers to be loaded in Flux v0.16. 
+# These workarounds allow such pooling layers to be loaded in Flux >= v0.16. 
 # (https://github.com/FluxML/Flux.jl/pull/2598)
 loadmodel!(dst::MaxPool{N, M}, src::Tuple{}; kw...) where {N, M} = dst
-loadmodel!(dst::AdaptiveMaxPool{S, O}, src::Tuple{}; kw...) where {S, O} = dst
-
 loadmodel!(dst::MeanPool{N, M}, src::Tuple{}; kw...) where {N, M} = dst
+loadmodel!(dst::AdaptiveMaxPool{S, O}, src::Tuple{}; kw...) where {S, O} = dst
 loadmodel!(dst::AdaptiveMeanPool{S, O}, src::Tuple{}; kw...) where {S, O} = dst

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -109,8 +109,6 @@ function loadmodel!(dst, src; filter = _ -> true, cache = Base.IdSet())
   return dst
 end
 
-loadmodel!(dst::MaxPool{N, M}, src::Tuple{}; kw...) where {N, M} = dst
-
 """
     state(x)
 

--- a/src/loading.jl
+++ b/src/loading.jl
@@ -109,6 +109,8 @@ function loadmodel!(dst, src; filter = _ -> true, cache = Base.IdSet())
   return dst
 end
 
+loadmodel!(dst::MaxPool{N, M}, src::Tuple{}; kw...) where {N, M} = dst
+
 """
     state(x)
 


### PR DESCRIPTION
As [discussed on Slack](https://julialang.slack.com/archives/C690QRAA3/p1741632284486259), I tried my hand at fixing #2584 and https://github.com/FluxML/Metalhead.jl/issues/287.
This line of code appears to be enough to make Metalhead's `VGG` models load.

Without it, the following error is thrown:
```Julia-repl
julia> using Metalhead

julia> VGG(19; pretrain=true)
ERROR: ArgumentError: Tried to load Base.OneTo(0) into (:pad, :k, :stride) but the structures do not match.
Stacktrace:
  [1] loadmodel!(dst::MaxPool{2, 4}, src::Tuple{}; filter::Function, cache::IdSet{Any})
    @ Flux ~/Developer/Flux.jl/src/loading.jl:104
  [2] loadmodel!(dst::Tuple{…}, src::Tuple{…}; filter::Function, cache::IdSet{…})
    @ Flux ~/Developer/Flux.jl/src/loading.jl:118
  [3] loadmodel!(dst::Chain{Tuple{…}}, src::@NamedTuple{layers::Tuple{…}}; filter::Function, cache::IdSet{Any})
    @ Flux ~/Developer/Flux.jl/src/loading.jl:118
```

I could use some guidance on whether this fix is adequate and how to test it.