### PR TITLE
Fix Typos in Old Tutorials Documentation

### DIFF
--- a/docs/old_tutorials/2024-04-10-blitz.md
+++ b/docs/old_tutorials/2024-04-10-blitz.md
@@ -219,7 +219,7 @@ Flux comes with a bunch of pre-defined optimisers and makes writing our own real
 opt_state = Flux.setup(Descent(η), model)
 ```
 
-Training a network reduces down to iterating on a dataset mulitple times, performing these steps in order. Just for a quick implementation, let’s train a network that learns to predict `0.5` for every input of 10 floats. `Flux` defines the `train!` function to do it for us.
+Training a network reduces down to iterating on a dataset multiple times, performing these steps in order. Just for a quick implementation, let’s train a network that learns to predict `0.5` for every input of 10 floats. `Flux` defines the `train!` function to do it for us.
 
 ```julia
 data, labels = rand(10, 100), fill(0.5, 2, 100)

--- a/docs/old_tutorials/2024-04-10-mlp.md
+++ b/docs/old_tutorials/2024-04-10-mlp.md
@@ -156,7 +156,7 @@ train()
 
 `train` performs the following steps:
 
-* **Initializes the model parameters:** Creates the `args` object that contains the defult values for training our model.
+* **Initializes the model parameters:** Creates the `args` object that contains the default values for training our model.
 * **Loads the train and test data:** Calls the function `getdata` we defined above.
 * **Constructs the model:** Builds the model and loads the train and test data sets, and our model  onto the GPU (if available).
 * **Trains the model:** Sets [Adam](@ref Optimisers.Adam) as the optimiser for training out model, runs the training process for `10` epochs (as defined in the `args` object) and shows the `accuracy` value for the train and test data.


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the old tutorials documentation files. Specifically, it fixes the spelling of "multiple" and "default" in the following files:
- docs/old_tutorials/2024-04-10-blitz.md
- docs/old_tutorials/2024-04-10-mlp.md

These changes improve the clarity and professionalism of the documentation. No code functionality is affected.