### PR TITLE
Fix Typos in Docs

### DIFF
--- a/docs/old_tutorials/2024-04-10-blitz.md
+++ b/docs/old_tutorials/2024-04-10-blitz.md
@@ -200,7 +200,7 @@ for (k, p) in trainables(model, path=true)
 end
 ```
 
-You don't have to use layers, but they can be convient for many simple kinds of models and fast iteration.
+You don't have to use layers, but they can be convenient for many simple kinds of models and fast iteration.
 
 The next step is to update our weights and perform optimisation. As you might be familiar, *Gradient Descent* is a simple algorithm that takes the weights and steps using a learning rate and the gradients. `weights = weights - learning_rate * gradient`.
 

--- a/docs/old_tutorials/2024-04-10-mlp.md
+++ b/docs/old_tutorials/2024-04-10-mlp.md
@@ -101,7 +101,7 @@ end
 ```
 
 
-In addition, we define the function (`accuracy`) to report the accuracy of our model during the training process. To compute the accuray, we need to decode the output of our model using the [onecold](https://fluxml.ai/Flux.jl/stable/data/onehot/#Flux.onecold) function. 
+In addition, we define the function (`accuracy`) to report the accuracy of our model during the training process. To compute the accuracy, we need to decode the output of our model using the [onecold](https://fluxml.ai/Flux.jl/stable/data/onehot/#Flux.onecold) function. 
 
 ```julia
 function accuracy(dataloader, model)


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `convient` → `convenient`
  - `accuray` → `accuracy`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.