### PR TITLE
Change default learning rate in Descent Optimizer

### DIFF
--- a/src/optimise/optimisers.jl
+++ b/src/optimise/optimisers.jl
@@ -31,7 +31,7 @@ mutable struct Descent <: AbstractOptimiser
   eta::Float64
 end
 
-Descent() = Descent(0.1)
+Descent() = Descent(0.01)
 
 function apply!(o::Descent, x, Δ)
   Δ .*= o.eta


### PR DESCRIPTION
Sets default lerning rate of `Descent()` optimizer to a lower value, to make models more likely to converge.

Closes #2623

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [ ] Documentation, if applicable

# Reasoning

It is more important that a solver converges rather than that the convergence is done quickly. 

I will add the code in the Issue as a test case later, before merging.
