### PR TITLE
Fix the "Gradients and Layers" documentation (#2628)

### DIFF
--- a/docs/src/guide/models/basics.md
+++ b/docs/src/guide/models/basics.md
@@ -310,7 +310,7 @@ Here's a composition of 3 functions, in which the last step is the function `onl
 which takes a 1-element vector and gives us the number inside:
 
 ```jldoctest poly; output = false, filter = r"[+-]?([0-9]*[.])?[0-9]+(f[+-]*[0-9])?"
-model1 = only ∘ Layer(20, 1) ∘ Layer(1, 20)
+model1 = only ∘ Layer(20, 1, identity) ∘ Layer(1, 20)
 
 y = model1(Float32[0.1])  # output is a Float32 number
 
@@ -331,7 +331,7 @@ This `model2` will work the same way (although its fields have different names):
 ```jldoctest poly; output = false, filter = r"[+-]?([0-9]*[.])?[0-9]+(f[+-]*[0-9])?"
 model2 = let
     lay1 = Layer(1, 20)  # local variables containing layers
-    lay2 = Layer(20, 1)
+    lay2 = Layer(20, 1, identity)
     function fwd(x)  # equivalent to x -> only(lay2(lay1(x)))
         mid = lay1(x)
         lay2(mid) |> only


### PR DESCRIPTION
Fix the  "Gradients and Layers"   documentation issue #2628 

[target document part](https://fluxml.ai/Flux.jl/stable/guide/models/basics/#Simple-Neural-Networks)

In model3, the second layer does not have a sigmoid activation, whereas in model1 and model2 the second layer does include a sigmoid activation. As a result, the structures of model1/model2 and model3 are actually quite different, but in the “Flux’s layers” section the text implies that model1 and model3 are structurally almost the same, which is contradictory. If we make the second layer of model1 and model2 linear, this inconsistency disappears.

### PR Checklist
- [ ] Tests are added (docs-only, not run)                                                                                                                    
- [ ] Entry in NEWS.md (not included; seems unnecessary for docs-only change)
- [x] Documentation, if applicable     
