### PR TITLE
fix cuda ext for real

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,8 @@ cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 
 [extensions]
 FluxAMDGPUExt = "AMDGPU"
-FluxCUDAcuDNNExt = ["CUDA"] # cuDNN is not strongly required
+FluxCUDAExt = "CUDA"
+FluxCUDAcuDNNExt = ["CUDA", "cuDNN"]
 FluxEnzymeExt = "Enzyme"
 FluxMPIExt = "MPI"
 FluxMPINCCLExt = ["CUDA", "MPI", "NCCL"]

--- a/ext/FluxCUDAExt.jl
+++ b/ext/FluxCUDAExt.jl
@@ -1,0 +1,14 @@
+module FluxCUDAExt
+try
+    # Let's try to load the cuDNN package if it is not already loaded
+    # Thanks to this, users can just write `using CUDA`
+    # to obtain full CUDA/cuDNN support in Flux. 
+    Base.require(Main, :cuDNN)
+catch
+    @warn """Package cuDNN not found in current path.
+    - Run `import Pkg; Pkg.add(\"cuDNN\")` to install the cuDNN package, then restart julia.
+    - If cuDNN is not installed, some Flux functionalities will not be available when running on the GPU.
+    """
+end
+
+end 

--- a/ext/FluxCUDAcuDNNExt/FluxCUDAcuDNNExt.jl
+++ b/ext/FluxCUDAcuDNNExt/FluxCUDAcuDNNExt.jl
@@ -3,15 +3,8 @@ module FluxCUDAcuDNNExt
 using Flux
 using NNlib
 using CUDA
+using cuDNN
 
-try
-    using cuDNN
-catch
-    @warn """Package cuDNN not found in current path.
-    - Run `import Pkg; Pkg.add(\"cuDNN\")` to install the cuDNN package, then restart julia.
-    - If cuDNN is not installed, some Flux functionalities will not be available when running on the GPU.
-    """
-end
 
 function (BN::Flux.BatchNorm)(x::Union{CuArray{T,2},CuArray{T,4},CuArray{T,5}},
                               cache=nothing) where T<:Union{Float32, Float64}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,7 +114,8 @@ end
 
   if get(ENV, "FLUX_TEST_CUDA", "false") == "true"
     Pkg.add(["CUDA", "cuDNN"])
-    using CUDA, cuDNN
+    # using CUDA, cuDNN
+    using CUDA # cuDNN is loaded by FluxCUDAExt
 
     if CUDA.functional()
       @testset "CUDA" begin


### PR DESCRIPTION
Somehow I managed to trick myself into thinking that #2632 was working fine, but it was not, currently we need the full import `using CUDA, cuDNN, Flux` instead of just `using CUDA, Flux`. 

This is another attempt at fixing the extension loading in a retrocompatible way, that is necessitating only `using CUDA, Flux`. And now we properly test this on buildkite by not explicitly loading cuDNN. 

fix #2625 