### PR TITLE
fix code in docs too wide

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,9 @@ name = "Flux"
 uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 version = "0.16.7"
 
+[workspace]
+projects = ["test", "docs"]
+
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/assets/flux.css
+++ b/docs/src/assets/flux.css
@@ -65,10 +65,10 @@ nav.toc ul.internal li.toplevel {
 
 /* Content */
 
-article { max-width: none; }
+article { max-width: 45em; }
 
 article > p, article > ul {
-  max-width: 45em;
+  max-width: none;
 }
 
 /* Links */


### PR DESCRIPTION
In the documentation, code blocks are wider than the text:



<img width="909" height="522" alt="Screenshot 2025-12-25 at 10 20 58" src="https://github.com/user-attachments/assets/4b0e85aa-4f1b-4adc-9243-64172851ad44" />


This PR fixes the issue
