### PR TITLE
Add train_step! and TrainState

### DIFF
--- a/src/Flux.jl
+++ b/src/Flux.jl
@@ -63,7 +63,7 @@ export Chain, Dense, Embedding, EmbeddingBag,
   # from OneHotArrays.jl
   onehot, onehotbatch, onecold,
   # from Train
-  setup, train!,
+  setup, train!, train_step!, TrainState,
   # from Optimsers.jl
   freeze!, thaw!, adjust!, update!, trainable,
   # from Zygote.jl

--- a/src/train.jl
+++ b/src/train.jl
@@ -10,7 +10,7 @@ using ProgressLogging: @progress, @withprogress, @logprogress
 using EnzymeCore: Duplicated
 using ADTypes: AbstractADType, AutoEnzyme, AutoZygote
 
-export setup, train!
+export setup, train!, train_step!, TrainState
 
 """
     opt_state = setup(rule, model)
@@ -163,5 +163,145 @@ train!(loss, model::Duplicated, data, opt; cb = nothing) = train!(loss, AutoEnzy
 function train!(loss, model::Duplicated, data, rule::Optimisers.AbstractRule; cb=nothing)
     return train!(loss, model, data, _rule_to_state(model, rule); cb)
 end
+
+"""
+    TrainState(rule, model)
+
+Container bundling everything needed to take training steps with [`train_step!`](@ref Flux.train_step!):
+the `model`, the optimisation `rule`, the optimiser state, the number of steps taken so far,
+an allocator cache (see [`GPUArrays.AllocCache`](https://juliagpu.github.io/GPUArrays.jl/))
+reused across steps to reduce GPU memory pressure, and an optional cache for AD frameworks
+that support reusing gradient-preparation state across steps (e.g. Mooncake).
+
+It is the recommended state object when training step-by-step,
+in particular when the step is to be compiled (e.g. with Reactant) since the same state is
+threaded through every iteration.
+
+The `model` is stored inside the state and is mutated in place by `train_step!`.
+For use with Enzyme.jl, pass a `Duplicated` model, exactly as for [`gradient`](@ref Flux.gradient).
+
+# Fields
+- `model`: the model being trained.
+- `rule`: the `Optimisers.AbstractRule` (e.g. `Adam()`) encoding the optimisation algorithm.
+- `opt_state`: the optimiser state, as returned by [`Flux.setup`](@ref).
+- `step::Int`: number of calls to `train_step!` made so far.
+- `alloc_cache`: a `GPUArrays.AllocCache` used to cache memory allocations across steps.
+- `ad_cache`: cache for AD frameworks that support reusing preparation state across steps
+  (e.g. Mooncake). `nothing` when unused.
+
+# Example
+```julia
+model = Chain(Dense(2 => 3, relu), Dense(3 => 1))
+state = Flux.TrainState(Adam(1e-3), model)
+
+loss(m, x, y) = Flux.mse(m(x), y)
+
+for data in dataloader
+    l = Flux.train_step!(loss, data, state)
+    @info "loss" l
+end
+```
+
+See also [`train_step!`](@ref Flux.train_step!) and [`train!`](@ref Flux.train!).
+"""
+mutable struct TrainState{TM, TR<:Optimisers.AbstractRule, TS}
+    model::TM
+    rule::TR
+    opt_state::TS
+    step::Int
+    alloc_cache::GPUArrays.AllocCache
+    ad_cache::Any  # untyped so AD backends can stash a freshly-prepared cache across steps
+end
+
+function TrainState(rule::Optimisers.AbstractRule, model)
+    opt_state = setup(rule, model)
+    return TrainState(model, rule, opt_state, 0, GPUArrays.AllocCache(), nothing)
+end
+
+function Base.show(io::IO, ts::TrainState)
+    print(io, "TrainState(", ts.rule, ", model; step = ", ts.step, ")")
+end
+
+"""
+    train_step!(loss, [adtype,] data, state::TrainState)
+
+Take a single optimisation step, updating `state.model` in place: compute the gradient of
+`loss` with respect to the model and apply the optimisation rule stored in `state`.
+The loss value is returned.
+
+Unlike [`train!`](@ref Flux.train!) which iterates over a
+whole data iterator, `train_step!` performs exactly one update, leaving the loop to the
+caller. This gives full control, and lets the step be compiled (e.g. with Reactant) and
+called repeatedly with the same `state`.
+
+The loss is evaluated as `loss(model, data...)` if `data isa Tuple`, otherwise as
+`loss(model, data)`, matching [`train!`](@ref Flux.train!).
+
+The optional `adtype` selects the automatic differentiation backend, among those supported
+by [`gradient`](@ref Flux.gradient). If omitted, Zygote is used, unless `state.model` is a
+`Duplicated` from Enzyme.jl, in which case Enzyme is used.
+
+A `DomainError` is thrown if the loss is infinite or `NaN`.
+
+# Auxiliary information
+
+As with [`withgradient`](@ref Flux.withgradient), the `loss` function may return auxiliary
+information alongside the scalar loss, by returning a `Tuple` or `NamedTuple` whose **first**
+element is the scalar loss used for the gradient. In that case `train_step!` returns the
+whole object, so any extra outputs are available to the caller:
+
+```julia
+loss(m, x, y) = (loss = Flux.mse(m(x), y), pred = m(x))  # loss first, then aux
+
+res = Flux.train_step!(loss, (x, y), state)
+res.loss   # scalar used for the optimisation step
+res.pred   # auxiliary output
+```
+
+When `loss` returns just a scalar, that scalar is returned (no wrapping).
+
+!!! note
+    Returning auxiliary information is currently only supported with the Zygote backend,
+    matching [`withgradient`](@ref Flux.withgradient).
+
+# Example
+```julia
+model = Chain(Dense(2 => 3, relu), Dense(3 => 1))
+state = Flux.TrainState(Adam(1e-3), model)
+
+loss(m, x, y) = Flux.mse(m(x), y)
+
+for epoch in 1:epochs
+    for data in dataloader
+        Flux.train_step!(loss, data, state)
+    end
+end
+```
+
+See also [`TrainState`](@ref Flux.TrainState) and [`train!`](@ref Flux.train!).
+"""
+function train_step!(loss, adtype::AbstractADType, data, state::TrainState)
+    d_splat = data isa Tuple ? data : (data,)
+    val = GPUArrays.@cached state.alloc_cache begin
+        val, gs = Flux.withgradient(m -> loss(m, d_splat...), adtype, state.model)
+        l = _loss_value(val)
+        if !isfinite(l)
+            throw(DomainError(lazy"Loss is $l on step $(state.step + 1), stopping training"))
+        end
+        state.opt_state, state.model = _update!(state.opt_state, state.model, gs[1])
+        val
+    end
+    state.step += 1
+    return val
+end
+
+# Extract the scalar loss from the value returned by the loss function, which may carry
+# auxiliary information as the trailing elements of a Tuple or NamedTuple (loss first).
+_loss_value(l) = l
+_loss_value(l::Union{Tuple, NamedTuple}) = first(l)
+
+train_step!(loss, data, state::TrainState) = train_step!(loss, AutoZygote(), data, state)
+
+train_step!(loss, data, state::TrainState{<:Duplicated}) = train_step!(loss, AutoEnzyme(), data, state)
 
 end # module Train


### PR DESCRIPTION
## Summary

Adds a step-by-step training API to complement `train!`.

The goal is to have a method, `train_step!`, that combines the gradient computation and the update step, while also implementing under the hood some extra goodies like: 1) caching allocator for gpu; 2) ad framework cache; 3) reactant compilation. 

## Added types and methods

- **`TrainState(rule, model)`** — a mutable container bundling everything needed to take training steps:
  - `model` — stored inside the state and mutated in place by `train_step!`
  - `rule` — the `Optimisers.AbstractRule` (e.g. `Adam()`)
  - `opt_state` — the optimiser state from `Flux.setup`
  - `step::Int` — number of steps taken so far
  - `alloc_cache` — a `GPUArrays.AllocCache` reused across steps to reduce GPU memory pressure
  - `ad_cache` — an (untyped) slot for AD frameworks (e.g. Mooncake) that can reuse gradient-preparation state across steps; defaults to `nothing`

- **`train_step!(loss, [adtype,] data, state::TrainState)`** — performs a single optimisation step, updating `state.model` in place and returning the loss. Inspired by `Lux.Training.single_train_step!`, adapted to Flux's convention where the model carries its own parameters. Storing the model inside the state means the same object can be threaded through every iteration and compiled (e.g. with Reactant).
  - Evaluates `loss(model, data...)` for tuple data, else `loss(model, data)`, matching `train!`.
  - Defaults to Zygote, or Enzyme when the model is `Duplicated`.
  - Throws `DomainError` on non-finite loss.
  - **Auxiliary outputs**: like `withgradient`, the loss may return a `Tuple`/`NamedTuple` with the scalar loss first; the full value is then returned (currently Zygote-only, matching `withgradient`).

```julia
state = Flux.TrainState(Adam(1e-3), model)
for data in dataloader
    Flux.train_step!(loss, data, state)
end
```

## Status / open questions

- The `ad_cache` field is an integration point — nothing reads/writes it yet. A follow-up (e.g. a Mooncake extension) would populate and reuse it.
- Aux output is not yet supported with Enzyme (inherited from `withgradient`).
- No tests or docs-page entries added yet — happy to add `test/train.jl` cases and a manual reference if the API shape looks right.

Feedback welcome on the API: argument order is `(loss, [adtype,] data, state)` and the model living inside `TrainState` rather than being passed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)