### PR TITLE
Support auxiliary outputs in withgradient for Mooncake

### DIFF
--- a/ext/FluxMooncakeExt.jl
+++ b/ext/FluxMooncakeExt.jl
@@ -9,9 +9,33 @@ function Flux.gradient(f::F, adtype::AutoMooncake, args::Vararg{Any,N}) where {F
 end
 
 function Flux.withgradient(f::F, adtype::AutoMooncake, args::Vararg{Any,N}) where {F,N}
-    cache = Mooncake.prepare_gradient_cache(f, args...; config=Mooncake.Config(friendly_tangents=true))
-    val, grads = Mooncake.value_and_gradient!!(cache, f, args...)
+    config = Mooncake.Config(friendly_tangents=true)
+    cache = Mooncake.prepare_pullback_cache(f, args...; config)
+    # `prepare_pullback_cache` already runs the forward pass once to build the rule, and stores
+    # a primal-typed buffer of the output `y = f(args...)`. We reuse it to learn the structure
+    # of the output (without an extra forward pass) and to build the cotangent seed.
+    yout = cache.y_cache
+    seed = yout isa Union{Tuple, NamedTuple} ? _loss_seed(yout) : one(yout)
+    # `value_and_pullback!!` does a single forward + reverse and returns the full output `y`,
+    # so auxiliary outputs come for free in `val`.
+    val, grads = Mooncake.value_and_pullback!!(cache, seed, f, args...)
     return (val=val, grad=grads[2:end])
-end 
+end
+
+# Auxiliary outputs: `f` returns a Tuple or NamedTuple whose first element is the scalar loss.
+# We differentiate only the loss by seeding it with `one` and the auxiliary slots with zero
+# cotangents, so the gradient flows through the loss alone while the whole output is returned.
+_loss_seed(y::Tuple) = (one(first(y)), map(_zero_seed, Base.tail(y))...)
+_loss_seed(y::NamedTuple{names}) where {names} =
+    merge(NamedTuple{(names[1],)}((one(first(y)),)), map(_zero_seed, Base.tail(y)))
+
+# A primal-typed zero cotangent. Numeric leaves are zeroed; non-differentiable leaves (e.g.
+# strings) are passed through, since Mooncake maps them to `NoTangent` regardless of value.
+_zero_seed(x::Number) = zero(x)
+_zero_seed(x::AbstractArray{<:Number}) = zero(x)
+_zero_seed(x::AbstractArray) = map(_zero_seed, x)
+_zero_seed(x::Tuple) = map(_zero_seed, x)
+_zero_seed(x::NamedTuple) = map(_zero_seed, x)
+_zero_seed(x) = x
 
 end # module

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -192,6 +192,16 @@ f (generic function with 1 method)
 julia> Flux.withgradient(f, AutoMooncake(), [1.0, 2.0, 3.0])
 (val = 12.0, grad = ([2.0, 2.0, 2.0],))
 ```
+
+Auxillary outputs are also supported with Mooncake, by returning a Tuple or NamedTuple
+whose first element is the scalar loss:
+```julia-repl
+julia> Flux.withgradient(AutoMooncake(), [1.0, 2.0, 4.0]) do x
+          z = 1 ./ x
+          sum(z), z  # here z is an auxillary output
+       end
+(val = (1.75, [1.0, 0.5, 0.25]), grad = ([-1.0, -0.25, -0.0625],))
+```
 """
 function withgradient(f, adtype::ADTypes.AbstractADType, args...)
     error("AD backend has to be loaded to use `withgradient(f, AutoXXX(), args...)`.

--- a/test/ext_mooncake.jl
+++ b/test/ext_mooncake.jl
@@ -3,5 +3,30 @@
         @testset "grad check $name" begin
             @test test_gradients(model, x; reference=AutoZygote(), compare=AutoMooncake())
         end
-    end 
+    end
+end
+
+@testset "mooncake withgradient auxiliary output" begin
+    # scalar output (no aux)
+    g0 = Flux.withgradient(x -> sum(2 .* x), AutoMooncake(), [1.0, 2.0, 3.0])
+    @test g0.val ≈ 12.0
+    @test g0.grad[1] ≈ [2.0, 2.0, 2.0]
+
+    # Tuple aux output: the first element is the loss, the rest are auxiliary.
+    g1 = Flux.withgradient(AutoMooncake(), [1.0, 2.0, 4.0]) do x
+        z = 1 ./ x
+        sum(z), z  # here z is an auxillary output
+    end
+    @test g1.grad[1] ≈ [-1.0, -0.25, -0.0625]
+    @test g1.val[1] ≈ 1.75
+    @test g1.val[2] ≈ [1.0, 0.5, 0.25]
+
+    # NamedTuple aux output, including a non-differentiable auxiliary.
+    g2 = Flux.withgradient(AutoMooncake(), [1.0, 2.0, 4.0]) do x
+        z = 1 ./ x
+        (loss=sum(z), aux=string(z))
+    end
+    @test g2.grad[1] ≈ [-1.0, -0.25, -0.0625]
+    @test g2.val.loss ≈ 1.75
+    @test g2.val.aux == "[1.0, 0.5, 0.25]"
 end


### PR DESCRIPTION
## Summary

`Flux.withgradient(f, AutoMooncake(), args...)` now supports auxiliary outputs: when `f` returns a `Tuple` or `NamedTuple` whose first element is the scalar loss, the gradient flows through the loss alone and the whole output is returned as `val`. This matches the behaviour already provided by the Zygote backend.

```julia
julia> Flux.withgradient(AutoMooncake(), [1.0, 2.0, 4.0]) do x
          z = 1 ./ x
          sum(z), z  # here z is an auxillary output
       end
(val = (1.75, [1.0, 0.5, 0.25]), grad = ([-1.0, -0.25, -0.0625],))
```

## Implementation

It is implemented with `value_and_pullback!!`, seeded with `one` in the loss slot and zero cotangents in the auxiliary slots (non-differentiable auxiliaries such as strings map to `NoTangent`). The output structure is recovered from the buffer that `prepare_pullback_cache` already populates, so **no extra forward pass is needed** — it stays a single forward + reverse, identical in cost to the scalar path. Since `value_and_gradient!!` is documented as `value_and_pullback!!(rule, 1.0, ...)`, the scalar case is exactly equivalent to before.

## Tests

Added a testset in `test/ext_mooncake.jl` covering scalar output, `Tuple` aux, and `NamedTuple` aux (including a non-differentiable string aux). Verified that the scalar path still matches Zygote on Dense, Chain, Conv, BatchNorm and LSTM models.

## Note

The 2-pass optimization reads `cache.y_cache` to recover the output structure without re-evaluating `f`. This is an internal Mooncake field (exposed via `propertynames`) rather than documented public API, so a future `Cache` refactor in Mooncake may require an update here; the tests would catch any such break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)