### PR TITLE
unbreak enzyme tests

### DIFF
--- a/test/ext_enzyme/enzyme.jl
+++ b/test/ext_enzyme/enzyme.jl
@@ -1,12 +1,10 @@
 # ENZYME CPU TESTS
 
-if !Sys.iswindows()
-    @testset "enzyme gradients" begin
-        BROKEN_TESTS = []
-        for (model, x, name) in TEST_MODELS
-            @testset "Enzyme grad check $name" begin
-                @test test_gradients(model, x; reference=AutoZygote(), compare=AutoEnzyme()) broken=(name ∈ BROKEN_TESTS)
-            end
+@testset "enzyme gradients" begin
+    BROKEN_TESTS = []
+    for (model, x, name) in TEST_MODELS
+        @testset "Enzyme grad check $name" begin
+            @test test_gradients(model, x; reference=AutoZygote(), compare=AutoEnzyme()) broken=(name ∈ BROKEN_TESTS)
         end
     end
 end

--- a/test/ext_enzyme/enzyme.jl
+++ b/test/ext_enzyme/enzyme.jl
@@ -2,11 +2,7 @@
 
 if !Sys.iswindows()
     @testset "enzyme gradients" begin
-        if VERSION >= v"1.12"
-            BROKEN_TESTS = ["Bilinear", "MultiHeadAttention"]
-        else 
-            BROKEN_TESTS = []
-        end
+        BROKEN_TESTS = []
         for (model, x, name) in TEST_MODELS
             @testset "Enzyme grad check $name" begin
                 @test test_gradients(model, x; reference=AutoZygote(), compare=AutoEnzyme()) broken=(name ∈ BROKEN_TESTS)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ const FLUX_TEST_CPU       = get(ENV, "FLUX_TEST_CPU",    "true")  == "true"
 const FLUX_TEST_CUDA      = get(ENV, "FLUX_TEST_CUDA",   "false") == "true"
 const FLUX_TEST_DIST_MPI  = get(ENV, "FLUX_TEST_DISTRIBUTED_MPI",  "false") == "true"
 const FLUX_TEST_DIST_NCCL = get(ENV, "FLUX_TEST_DISTRIBUTED_NCCL", "false") == "true"
-const FLUX_TEST_ENZYME    = get(ENV, "FLUX_TEST_ENZYME", !Sys.iswindows()) == "true"
+const FLUX_TEST_ENZYME    = get(ENV, "FLUX_TEST_ENZYME", !Sys.iswindows()) == "true" #TODO fix enzyme on windows
 const FLUX_TEST_METAL     = get(ENV, "FLUX_TEST_METAL",  "false") == "true"
 const FLUX_TEST_REACTANT  = get(ENV, "FLUX_TEST_REACTANT", "true") == "true"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ const FLUX_TEST_CPU       = get(ENV, "FLUX_TEST_CPU",    "true")  == "true"
 const FLUX_TEST_CUDA      = get(ENV, "FLUX_TEST_CUDA",   "false") == "true"
 const FLUX_TEST_DIST_MPI  = get(ENV, "FLUX_TEST_DISTRIBUTED_MPI",  "false") == "true"
 const FLUX_TEST_DIST_NCCL = get(ENV, "FLUX_TEST_DISTRIBUTED_NCCL", "false") == "true"
-const FLUX_TEST_ENZYME    = get(ENV, "FLUX_TEST_ENZYME", "true") == "true"
+const FLUX_TEST_ENZYME    = get(ENV, "FLUX_TEST_ENZYME", !Sys.iswindows()) == "true"
 const FLUX_TEST_METAL     = get(ENV, "FLUX_TEST_METAL",  "false") == "true"
 const FLUX_TEST_REACTANT  = get(ENV, "FLUX_TEST_REACTANT", "true") == "true"
 


### PR DESCRIPTION
Enzyme gradient tests for multihead attention and bilinear layer are now passing with julia 1.12 on mac and ubuntu. 

Enzyme windows tests are failing with no stacktrace instead (cc @wsmoses) so I'm deactivating them. See
https://github.com/FluxML/Flux.jl/actions/runs/28079554315/job/83131151353



