### PR TITLE
docs: fix typos and trim trailing whitespace

### DIFF
--- a/docs/src/guide/models/basics.md
+++ b/docs/src/guide/models/basics.md
@@ -321,7 +321,7 @@ Flux.gradient((x,d) -> d(x)[1], x, layer3s)[2]  # NamedTuple{(:W, :b, :act)}
 This `∂f/∂layer3s` is a named tuple with the same fields as `Layer`.
 Within it, the gradient with respect to `W` is a matrix of seemingly random numbers.
 Notice that there is also an entry for `act`, which is `nothing`,
-as this field of the struct is not a smoothly adjustible parameter.
+as this field of the struct is not a smoothly adjustable parameter.
 
 We can compose these layers just as we did the polynomials above, in `poly4`.
 Here's a composition of 3 functions, in which the last step is the function `only`

--- a/docs/src/reference/training/gradients.md
+++ b/docs/src/reference/training/gradients.md
@@ -35,7 +35,7 @@ Zygote.pullback
 
 Zygote uses [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl) to define how to differentiate functions.
 
-Sometimes it is necessary to exclude some code, or a whole function, from automatic differentiation. 
+Sometimes it is necessary to exclude some code, or a whole function, from automatic differentiation.
 This can be done using the following methods:
 
 ```@docs
@@ -113,7 +113,7 @@ julia> ans == Flux.setup(Adam(), dup_model)
 
 julia> Flux.update!(opt_state, model, grads_f[1])  # exactly as for Zygote gradients
 
-julia> Flux.update!(opt_state, dup_model)  # equivlent new path, Enzyme only
+julia> Flux.update!(opt_state, dup_model)  # equivalent new path, Enzyme only
 ```
 
 Instead of using these FLux functions, you can also use Enzyme's own functions directly.

--- a/docs/src/tutorials/custom_layers.md
+++ b/docs/src/tutorials/custom_layers.md
@@ -63,7 +63,7 @@ julia> Flux.trainable(a)
 (W = Float32[1.0 2.0; 3.0 4.0; 5.0 6.0],)
 ```
 
-Only the fields returned by `trainable` will be seen by `Flux.setup` and `Flux.update!` for training. But all fields wil be seen by `gpu` and similar functions, for example:
+Only the fields returned by `trainable` will be seen by `Flux.setup` and `Flux.update!` for training. But all fields will be seen by `gpu` and similar functions, for example:
 
 ```julia-repl
 julia> a |> f16
@@ -109,7 +109,7 @@ Join(combine, paths...) = Join(combine, paths)
 ```
 Notice again that we parameterized the type of the `combine` and `paths` fields. In addition to the performance considerations of concrete types, this allows either field to be `Vector`s, `Tuple`s, or one of each - we don't need to pay attention to which.
 
-The next step is to use [`Flux.@layer`](@ref) to make our struct behave like a Flux layer. 
+The next step is to use [`Flux.@layer`](@ref) to make our struct behave like a Flux layer.
 In Flux < v0.15 this used to be important so that calling `Flux.setup` on a `Join` maps over the underlying trainable arrays on each path. Since Flux v0.15, this is no longer necessary, since now Functors.jl automatically traverses custom types. However, [`Flux.@layer`](@ref) is still recommended for pretty printing and other niceties.
 
 ```julia
@@ -214,4 +214,3 @@ end
 
 !!! note
     This `Split` layer is available from the [Fluxperimental.jl](https://github.com/FluxML/Fluxperimental.jl) package.
-

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -9,14 +9,14 @@ If no gradient is defined, `∂f/∂x` will be `nothing`.
 
 `f(args...)` must be a real number, see [`Zygote.jacobian`](@ref) for array output.
 
-The optional argument `adtype` allows specifying the automatic differentiation backend. 
+The optional argument `adtype` allows specifying the automatic differentiation backend.
 
-We provide specific support and testing for the following backends: 
+We provide specific support and testing for the following backends:
 `AutoZygote`, `AutoEnzyme`, `AutoMooncake`, and `AutoFiniteDifferences`.
 
 The package corresponding to any chosen backend (except Zygote) must be loaded in advance.
 
-If no `adtype` is given, then Zygote.jl is used by default, unless at least one argument 
+If no `adtype` is given, then Zygote.jl is used by default, unless at least one argument
 is of type `Duplicated` from Enzyme.jl, in which case Enzyme.jl is used.
 
 See also [`withgradient`](@ref) to keep the value `f(args...)`.
@@ -96,7 +96,7 @@ Note that Enzyme's `Active` is not supported.
 
 Besides returning the gradient, this is also stored within the `Duplicated` object.
 Calling `Enzyme.Duplicated(model)` allocates space for the gradient,
-which is zero'd befor use when calling `gradient`.
+which is zero'd before use when calling `gradient`.
 With the keyword `zero=false`, the new gradient will instead be added to what is already stored.
 
 # Examples
@@ -131,7 +131,7 @@ Duplicated(
 julia> Flux.destructure((weight = [6.0;;], bias = [6.0]))[1] |> norm
 8.48528137423857
 
-julia> Flux.gradient(dup_model, [1]; zero=false) do m, x  # implict Const([1]), and grad accumulation
+julia> Flux.gradient(dup_model, [1]; zero=false) do m, x  # implicit Const([1]), and grad accumulation
          sum(abs2, m(x))
        end
 ((layers = ((weight = [12.0;;], bias = [12.0], σ = nothing),),), nothing)
@@ -149,7 +149,7 @@ The optional argument `adtype` allows specifying the automatic differentiation b
 among the supported ones: `AutoZygote`, `AutoEnzyme`, `AutoMooncake`, and `AutoFiniteDifferences`.
 The package corresponding to the chosen backend must be loaded in advance.
 
-If no `adtype` is given, then Zygote.jl is used by default, unless at least one argument 
+If no `adtype` is given, then Zygote.jl is used by default, unless at least one argument
 is of type `Duplicated` from Enzyme.jl, in which case Enzyme.jl is used.
 
 Se also [`gradient`](@ref) to get just the gradient.
@@ -164,7 +164,7 @@ julia> ∇ == gradient(/, 1, 2)
 true
 ```
 
-`withgradient` allows you to capture auxillary outputs, in addition to the scalar
+`withgradient` allows you to capture auxiliary outputs, in addition to the scalar
 used by `gradient`. To do this, `f` must return a Tuple or NamedTuple.
 Then it calculates `grad = gradient(first∘f, args...)
 but returns the whole `val = f(args...)`:
@@ -172,7 +172,7 @@ but returns the whole `val = f(args...)`:
 ```jldoctest
 julia> withgradient([1,2,4]) do x
           z = 1 ./ x
-          sum(z), z  # here z is an auxillary output
+          sum(z), z  # here z is an auxiliary output
        end
 (val = (1.75, [1.0, 0.5, 0.25]), grad = ([-1.0, -0.25, -0.0625],))
 
@@ -193,12 +193,12 @@ julia> Flux.withgradient(f, AutoMooncake(), [1.0, 2.0, 3.0])
 (val = 12.0, grad = ([2.0, 2.0, 2.0],))
 ```
 
-Auxillary outputs are also supported with Mooncake, by returning a Tuple or NamedTuple
+Auxiliary outputs are also supported with Mooncake, by returning a Tuple or NamedTuple
 whose first element is the scalar loss:
 ```julia-repl
 julia> Flux.withgradient(AutoMooncake(), [1.0, 2.0, 4.0]) do x
           z = 1 ./ x
-          sum(z), z  # here z is an auxillary output
+          sum(z), z  # here z is an auxiliary output
        end
 (val = (1.75, [1.0, 0.5, 0.25]), grad = ([-1.0, -0.25, -0.0625],))
 ```

--- a/src/losses/functions.jl
+++ b/src/losses/functions.jl
@@ -280,7 +280,7 @@ Return the binary cross-entropy loss, computed as
     agg(@.(-y * log(ŷ + ϵ) - (1 - y) * log(1 - ŷ + ϵ)))
 
 Where typically, the prediction `ŷ` is given by the output of a [sigmoid](@ref man-activations) activation.
-The `ϵ == eps` term is included to avoid infinity. Using [`logitbinarycrossentropy`](@ref) is recomended
+The `ϵ == eps` term is included to avoid infinity. Using [`logitbinarycrossentropy`](@ref) is recommended
 over `binarycrossentropy` for numerical stability.
 
 Use [`label_smoothing`](@ref) to smooth the `y` value as preprocessing before
@@ -616,12 +616,12 @@ end
 
 """
     siamese_contrastive_loss(ŷ, y; margin = 1, agg = mean)
-                                    
+
 Return the [contrastive loss](http://yann.lecun.com/exdb/publis/pdf/hadsell-chopra-lecun-06.pdf)
 which can be useful for training Siamese Networks. It is given by
-                                    
-    agg(@. (1 - y) * ŷ^2 + y * max(0, margin - ŷ)^2)                           
-                                 
+
+    agg(@. (1 - y) * ŷ^2 + y * max(0, margin - ŷ)^2)
+
 Specify `margin` to set the baseline for distance at which pairs are dissimilar.
 
 # Example

--- a/src/optimise/Optimise.jl
+++ b/src/optimise/Optimise.jl
@@ -30,7 +30,7 @@ include("train.jl")
   # Valid method in Optimise, old implicit style, is:
   train!(loss, ps::Params, data, opt::AbstractOptimiser; cb = () -> ())
 
-  # Valid methods in Train, new explict style, are:
+  # Valid methods in Train, new explicit style, are:
   train!(loss, model, data, opt)  # preferred
   train!(loss, model, data, opt::Optimisers.AbstractRule)  # if you forget setup
 
@@ -38,13 +38,13 @@ include("train.jl")
 =#
 
 train!(loss, ps::Params, data, opt; cb=nothing) = error(
-  """can't mix implict Params with explict state!
+  """can't mix implicit Params with explicit state!
   To use `Flux.params(m)` in `train!`, the 4th argument must be from the old `Flux.Optimise` sub-module.
   But better to use the new explicit style, in which `m` itself is the 2nd argument.
   """)
 
 train!(loss, ps::Params, data, opt::Optimisers.AbstractRule; cb=nothing) = error(
-  """can't mix implict Params with explict rule from Optimisers.jl
+  """can't mix implicit Params with explicit rule from Optimisers.jl
   To use `Flux.params(m)` in `train!`, the 4th argument must be from the old `Flux.Optimise` sub-module.
   But better to use the new explicit style, in which `m` itself is the 2nd argument.
   """)
@@ -59,14 +59,14 @@ Optimisers.setup(rule::AbstractOptimiser, model) = setup(__old_to_new(rule), mod
 
 
 function __old_to_new(rule)
-  Base.depwarn("""Optimisers from  Flux.Optimise module are deprecated. 
+  Base.depwarn("""Optimisers from  Flux.Optimise module are deprecated.
                    Use optimisers from Optimisers.jl instead.""", :__old_to_new)
   return _old_to_new(rule)
 end
 
 for T in [:Descent, :Adam, :Momentum, :Nesterov,
    	      :AdaGrad, :AdaMax, :AdaDelta, :AMSGrad, :NAdam, :RAdam, :OAdam, :AdaBelief,
-   	      # :InvDecay, :ExpDecay, 
+   	      # :InvDecay, :ExpDecay,
           :SignDecay,
           ]
   @eval function _old_to_new(rule::$T)
@@ -77,7 +77,7 @@ end
 _old_to_new(rule::Optimiser) = Optimisers.OptimiserChain(map(_old_to_new, rule.os)...)
 const OptimiserChain = Optimiser  # lets you use new name with implicit params too.
 _old_to_new(rule::WeightDecay) = Optimisers.WeightDecay(rule.wd)  # called lambda now
-_old_to_new(rule::ClipNorm) = Optimisers.ClipNorm(rule.thresh)  # called omega, and there are more fields 
+_old_to_new(rule::ClipNorm) = Optimisers.ClipNorm(rule.thresh)  # called omega, and there are more fields
 _old_to_new(rule::ClipValue) = Optimisers.ClipGrad(rule.thresh)  # called delta now, and struct name differs
 const ClipGrad = ClipValue
 _old_to_new(rule::RMSProp) = Optimisers.RMSProp(rule.eta, rule.rho, rule.epsilon)  # RMSProp has no field centred


### PR DESCRIPTION

docs: fix typos and trim trailing whitespace

### PR Checklist

- [ ] Tests are added
- [ ] Entry in NEWS.md
- [X] Documentation, if applicable

Does this help?