### PR TITLE
Fix check_equal_leaves so gradient comparisons actually run

### DIFF
--- a/test/test_module.jl
+++ b/test/test_module.jl
@@ -80,11 +80,17 @@ function _contains_no_numerical(kp, x)
 end
 
 function check_equal_leaves(a, b; rtol=1e-4, atol=1e-4)
-    # Since Zygote could use nothing for an entire subtree, we prune the
-    # the tree using _contains_no_numerical
-    fmapstructure_with_path(a, b, exclude=_contains_no_numerical) do kp, x, y
+    # Recurse until we hit a genuine leaf (where we compare the arrays) or a
+    # subtree containing no numerical arrays. The latter is pruned because a
+    # backend can return `nothing` for an entire subtree, and we must not recurse
+    # into it.
+    exclude(kp, x) = Functors.isleaf(x) || _contains_no_numerical(kp, x)
+    fmapstructure_with_path(a, b; exclude) do kp, x, y
         # @show kp
-        if x isa AbstractArray{<:AbstractFloat}
+        # Compare only where both backends produced a numerical gradient. A `nothing`
+        # on either side marks a leaf that backend did not differentiate (e.g. the
+        # non-trainable running stats of a normalisation layer), which we skip.
+        if x isa AbstractArray{<:AbstractFloat} && y isa AbstractArray{<:AbstractFloat}
             @test x ≈ y rtol=rtol atol=atol
         end
     end


### PR DESCRIPTION
## The bug

`check_equal_leaves` (in `test/test_module.jl`) is the function that compares gradients from two AD backends inside `test_gradients`. It was passing `exclude=_contains_no_numerical` to `fmapstructure_with_path`:

```julia
fmapstructure_with_path(a, b, exclude=_contains_no_numerical) do kp, x, y
    if x isa AbstractArray{<:AbstractFloat}
        @test x ≈ y rtol=rtol atol=atol
    end
end
```

In Functors, `exclude` is the **leaf predicate**: the mapped closure runs on nodes where `exclude` returns `true`, and the walk recurses where it returns `false`. Since `_contains_no_numerical` is `true` only for subtrees with **no** float arrays, the closure ran exclusively on numeric-free nodes — where `x isa AbstractArray{<:AbstractFloat}` is never true. **The `@test x ≈ y` never executed.**

So every gradient comparison routed through `check_equal_leaves` (reference vs Zygote on CPU, GPU, Reactant) was a silent no-op. Demonstration with the current code:

```julia
julia> @testset "demo" begin
           check_equal_leaves(
               (weight=[1.0 2.0], bias=[3.0], σ=nothing),
               (weight=[999.0 999.0], bias=[-999.0], σ=nothing),  # wildly different
           )
       end
Test Summary: | Total  Time
demo          |     0  0.4s      # 0 tests — the mismatch is not caught
```

This means the finite-differences-vs-Zygote gradient checks in `test/layers/*.jl` (recurrent.jl alone has 22 `test_gradients` calls) have not actually been verifying gradient values.

Introduced in #2656.

## The fix

1. Leaf predicate becomes `isleaf(x) || _contains_no_numerical(kp, x)`, so the walk recurses down to genuine array leaves (still pruning numeric-free subtrees a backend may return as `nothing`).
2. Compare a leaf only when **both** `x` and `y` are float arrays. The finite-differences reference reconstructs the full model via `destructure`, so non-trainable buffers (e.g. a normalisation layer's running stats `μ`/`σ²`) appear as their original *values* where the compared backend returns `nothing`; those leaves are skipped instead of raising `isapprox(::Array, ::Nothing)`.

## Verification

With the fix, the comparison fires and behaves correctly:

- Deliberately-wrong gradients are now **caught** (the demo above reports 2 failures).
- All models in `TEST_MODELS` pass the real finite-differences-vs-Zygote check (previously 0 comparisons ran; `BatchNorm` surfaced the running-stats mismatch, now handled).
- `test/layers/recurrent.jl` passes **316/316** (all previously no-ops).

CI will exercise the full suite; if any latent gradient/tolerance discrepancies were being masked, they'll now surface as real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)