### PR TITLE
Reactant docs guide + `trainstep!` in the ResNet example & benchmark

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,6 +37,7 @@ makedocs(
             "Training" => "guide/training/training.md",
             "Recurrence" => "guide/models/recurrence.md",
             "GPU Support" => "guide/gpu.md",
+            "Compiling with Reactant" => "guide/reactant.md",
             "Saving & Loading" => "guide/saving.md",
             "Performance Tips" => "guide/performance.md",
         ],

--- a/docs/src/guide/models/quickstart.md
+++ b/docs/src/guide/models/quickstart.md
@@ -107,6 +107,24 @@ for epoch in 1:1_000
 end
 ```
 
+If you want to keep control of the loop — for logging, early stopping, or a custom schedule — but would rather not spell out `gradient` and `update!` yourself, [`trainstep!`](@ref Flux.Train.trainstep!) is the per-step primitive that `train!` is built on. It evaluates the loss, computes the gradient, and updates `model` and `opt_state` in place, returning the loss. The batch is passed as a tuple and spliced into the loss after the model (so it is called as `loss(m, x, y)`):
+
+```julia
+losses = []
+@showprogress for epoch in 1:1_000
+    for xy_cpu in loader
+        x, y = xy_cpu |> device
+        loss = Flux.trainstep!(model, (x, y), opt_state) do m, x, y
+            y_hat = m(x)
+            Flux.logitcrossentropy(y_hat, y)
+        end
+        push!(losses, loss)
+    end
+end
+```
+
+This is exactly the original training loop above, with the `withgradient`/`update!` pair collapsed into a single call. Use [`trainstep_withgradient!`](@ref Flux.Train.trainstep_withgradient!) if you also need the gradient. On a [Reactant](../reactant.md) device, `trainstep!` (and `train!`) additionally compile and cache the whole step into one executable.
+
 * Notice that the full dataset `noisy` lives on the CPU, and is moved to the GPU one batch at a time, by `xy_cpu |> device`. This is generally what you want for large datasets. Calling `loader |> device` similarly modifies the `DataLoader` to move one batch at a time.
 
 * In our simple example, we conveniently created the model has a [`Chain`](@ref Flux.Chain) of layers.

--- a/docs/src/guide/performance.md
+++ b/docs/src/guide/performance.md
@@ -78,3 +78,24 @@ This will avoid the splatting penalty, and will hit the optimised `reduce` metho
 ## Be aware of GPU memory inefficiencies
 
 Currently, GPU memory is not handled as well as system memory. If your training loop is allocating significantly on the GPU, you can quickly fill your GPU memory and the piecemeal reclamation and shuffling of data between GPU and system memory can become extremely slow. If profiling shows that a significant portion of time is spent in the `gpu` function and your data sizes are not large, this may be the cause. Running an incremental garbage collection manually (`GC.gc(false)`) at regular intervals can keep your GPU memory free and responsive. See other tips for CUDA memory management [here](https://cuda.juliagpu.org/stable/usage/memory/).
+
+## Compile your training with Reactant
+
+The tips above tune *eager* execution. For the largest speedups, compile your model with [Reactant.jl](https://github.com/EnzymeAD/Reactant.jl): it traces your code and lowers it — through MLIR and XLA — into a single fused, kernel-optimised executable that is cached and reused across calls. For training, the forward pass, the Enzyme reverse pass and the optimiser update are compiled *together*, which removes per-operation dispatch and kernel-launch overhead and lets the compiler fuse operations and plan buffers across the whole step.
+
+You do not have to invoke the compiler yourself: when the model lives on a Reactant device, [`trainstep!`](@ref Flux.Train.trainstep!) — and [`train!`](@ref Flux.train!), which is built on it — compile and cache the fused step automatically.
+
+```julia
+using Flux, Reactant
+
+dev = reactant_device()
+model = model |> dev
+opt_state = Flux.setup(Adam(1f-3), model)   # set up the optimiser after moving to the device
+
+trainmode!(model)
+for (x, y) in loader                          # batches already on the device
+    Flux.trainstep!(loss, model, (x, y), opt_state)   # compiled on the first call, reused after
+end
+```
+
+The cached executable is keyed on the batch shape, so keeping batch sizes fixed avoids recompilation (a smaller final batch simply compiles one extra executable). The first call pays a one-time compilation cost that can be large, so this pays off over many steps rather than a handful. See [Compiling Flux with Reactant](reactant.md) for the full guide, including inference and manual `@compile`.

--- a/docs/src/guide/performance.md
+++ b/docs/src/guide/performance.md
@@ -91,9 +91,10 @@ using Flux, Reactant
 dev = reactant_device()
 model = model |> dev
 opt_state = Flux.setup(Adam(1f-3), model)   # set up the optimiser after moving to the device
-
+loader = DataLoader((X, Y); batchsize=32) |> dev  # move batches to the device during iteration
+loss(m, x, y) = Flux.logitcrossentropy(m(x), y)
 trainmode!(model)
-for (x, y) in loader                          # batches already on the device
+for (x, y) in loader
     Flux.trainstep!(loss, model, (x, y), opt_state)   # compiled on the first call, reused after
 end
 ```

--- a/docs/src/guide/reactant.md
+++ b/docs/src/guide/reactant.md
@@ -1,0 +1,181 @@
+# Compiling Flux with Reactant
+
+[Reactant.jl](https://github.com/EnzymeAD/Reactant.jl) traces your Julia code and compiles it — through [MLIR](https://mlir.llvm.org/) and [XLA](https://openxla.org/xla) — into a single optimised executable that runs on CPU, NVIDIA/AMD GPUs, or TPUs. For Flux this means the whole forward pass (and, for training, the [Enzyme](https://enzyme.mit.edu/) reverse pass and the optimiser update) is fused, kernel-optimised, and reused across calls, which is often substantially faster and more memory-efficient than eager execution.
+
+This guide builds up in three steps:
+
+1. A **manually compiled** example, so you can see exactly what Reactant does.
+2. The [`trainstep!`](@ref Flux.Train.trainstep!) API, which compiles and caches a single training step for you.
+3. [`train!`](@ref Flux.train!), the full training loop, which is built on top of `trainstep!`.
+
+## Installation
+
+Reactant is a normal dependency — add it and load it alongside Flux:
+
+```julia
+using Pkg; Pkg.add("Reactant")  # do this once
+
+using Flux, Reactant
+```
+
+Reactant automatically selects a GPU backend if one is available, falling back to the CPU otherwise. See the [Reactant GPU configuration docs](https://enzymead.github.io/Reactant.jl/dev/api/config#GPU-Configuration) for how to control this.
+
+## Moving data and models to the device
+
+Just like `gpu`/`cpu`, Flux provides a device object that moves a model (or any nested structure of arrays) onto the Reactant device, converting its arrays into Reactant's `ConcreteRArray`s:
+
+```julia
+using Flux, Reactant
+
+dev = reactant_device()   # a Reactant device object; call once and reuse
+
+model = Chain(Dense(4 => 8, tanh), Dense(8 => 2))
+x = randn(Float32, 4, 16)
+
+model_re = model |> dev   # a copy of the model with Reactant arrays
+x_re     = x     |> dev
+```
+
+As with the GPU adaptors, `dev` recurses into structures, so `(x, y) |> dev` moves both, and it uses `Float32` by default. Everything you feed to a compiled function must already live on the device.
+
+## 1. A manually compiled example
+
+Reactant does not run your code eagerly. Instead you *compile* a function once for a given set of input shapes and types, and then call the returned executable. The two entry points are:
+
+- `Reactant.@compile f(args...)` — trace and compile `f`, returning a callable executable. Call it later with device-resident arguments of the same shapes.
+- `Reactant.@jit f(args...)` — compile *and* immediately run, a convenient shortcut for one-off calls.
+
+### Compiling the forward pass (inference)
+
+```julia
+using Flux, Reactant
+
+dev = reactant_device()
+model = Chain(Dense(4 => 8, tanh), Dense(8 => 2)) |> dev
+x = randn(Float32, 4, 16) |> dev
+
+# Compile once...
+forward = Reactant.@compile model(x)
+
+# ...then call the compiled executable (fast, no recompilation):
+y = forward(x)              # a Reactant array on the device
+y_host = y |> cpu           # move the result back to the host
+
+# `@jit` compiles and runs in one go — handy for a one-off evaluation:
+y2 = Reactant.@jit model(x)
+```
+
+Note the call is `forward(x)`, **not** `forward(model, x)`: in `@compile model(x)` the model is the *callee*, so Reactant captures it (and its parameter arrays) inside the compiled executable, and you pass only the remaining arguments. Because the model is captured by reference, mutating its parameters in place — as training does — is reflected the next time you call `forward`. (Contrast this with the training-step examples below, where the model sits in an *argument* position, e.g. `@compile my_step!(loss, model, x, y, opt_state)`, and so must be passed at call time.)
+
+A compiled executable is specialised to the **shapes** of its inputs. Calling `forward` with a differently-shaped `x` (e.g. a smaller final batch) requires compiling a separate executable for that shape.
+
+!!! note "trainmode / testmode"
+    Layers such as `Dropout` and `BatchNorm` behave differently during training and inference. Call `testmode!(model)` before compiling an inference function, and `trainmode!(model)` before a training step, exactly as you would without Reactant.
+
+### Compiling a training step manually
+
+To differentiate under Reactant, use Flux's [`withgradient`](@ref Flux.withgradient) with the [`AutoEnzyme`](@ref) backend — Reactant relies on Enzyme for AD. You can compile the value-and-gradient computation, or a whole step that also updates the model in place:
+
+```julia
+using Flux, Reactant, Optimisers
+
+dev = reactant_device()
+model = Chain(Dense(4 => 8, tanh), Dense(8 => 2)) |> dev
+x, y = randn(Float32, 4, 16) |> dev, randn(Float32, 2, 16) |> dev
+
+loss(m, x, y) = Flux.mse(m(x), y)
+opt_state = Flux.setup(Adam(1f-2), model)
+
+# A plain Julia function describing one optimisation step. It differentiates the loss
+# with Enzyme, updates the model and optimiser state in place, and returns the loss.
+function my_step!(loss, model, x, y, opt_state)
+    l, grads = Flux.withgradient(m -> loss(m, x, y), AutoEnzyme(), model)
+    Optimisers.update!(opt_state, model, grads[1])
+    return l
+end
+
+trainmode!(model)
+step! = Reactant.@compile my_step!(loss, model, x, y, opt_state)   # compile once
+
+for epoch in 1:100
+    l = step!(loss, model, x, y, opt_state)   # reuse the executable each epoch
+    @info "epoch $epoch" loss=Reactant.to_number(l)
+end
+```
+
+Reactant traces the mutation of `model` and `opt_state` and fuses the whole step. Writing this by hand gives you full control, but it is boilerplate that Flux can handle for you — which is what the next section is about.
+
+## 2. The `trainstep!` API
+
+[`trainstep!`](@ref Flux.Train.trainstep!) performs exactly the step above — differentiate the loss, update `model` and `opt_state` in place, return the loss — and when the model lives on a Reactant device it **compiles and caches the fused step automatically**. You do not write `@compile` yourself, and repeated calls with the same model, optimiser, loss and batch shape reuse the cached executable.
+
+```julia
+using Flux, Reactant
+
+dev = reactant_device()
+model = Chain(Dense(4 => 8, tanh), Dense(8 => 2)) |> dev
+x, y = randn(Float32, 4, 16) |> dev, randn(Float32, 2, 16) |> dev
+
+loss(m, x, y) = Flux.mse(m(x), y)
+
+# Move the model to the device *before* `setup`, so the optimiser is set up for Reactant arrays.
+opt_state = Flux.setup(Adam(1f-2), model)
+
+trainmode!(model)
+for epoch in 1:100
+    l = Flux.trainstep!(loss, model, (x, y), opt_state)   # returns the host-side loss scalar
+    @info "epoch $epoch" loss=l
+end
+```
+
+The batch is passed as a tuple `(x, y)` and spliced into the loss as `loss(model, x, y)`. The returned loss is read back to the host as an ordinary number.
+
+Use [`trainstep_withgradient!`](@ref Flux.Train.trainstep_withgradient!) if you also need the gradient — it returns `(loss, grad)`, with the gradient left on the device. (Returning the gradient makes it an output of the compiled step and raises peak memory, so prefer `trainstep!` when you don't need it.)
+
+### Auxiliary loss outputs
+
+Like `withgradient`, the loss may return auxiliary data alongside the scalar loss: return a `Tuple` or `NamedTuple` whose first element is the loss, and the gradient is taken of the loss alone while the whole value is returned. This is convenient for logging a metric computed in the forward pass — and, on Reactant, the metric is computed on-device as part of the same compiled forward:
+
+```julia
+function loss(m, x, y)
+    ŷ = m(x)
+    Flux.mse(ŷ, y), (; acc = mean(onecold(ŷ) .== onecold(y)))
+end
+
+l, stats = Flux.trainstep!(loss, model, (x, y), opt_state)   # l == (loss, stats); stats.acc read to host
+```
+
+## 3. The `train!` API
+
+[`train!`](@ref Flux.train!) is a loop over the data built on top of `trainstep!`, so on a Reactant device it inherits the same automatic compile-and-cache. Move the model to the device and call `setup` first, and provide **device-resident** data — `train!` rejects host arrays on the Reactant path.
+
+```julia
+using Flux, Reactant
+
+dev = reactant_device()
+model = Chain(Dense(4 => 8, tanh), Dense(8 => 2)) |> dev
+opt_state = Flux.setup(Adam(1f-2), model)
+
+loss(m, x, y) = Flux.mse(m(x), y)
+
+# Move every batch to the device. In a real loop use a DataLoader wrapped with the device,
+# so each batch is moved lazily and the previous one is freed:
+#   train_loader = DataLoader((X, Y); batchsize=32) |> dev
+X, Y = randn(Float32, 4, 128), randn(Float32, 2, 128)
+data = [(X[:, i:i+15], Y[:, i:i+15]) |> dev for i in 1:16:128]
+
+Flux.train!(loss, model, data, opt_state)
+```
+
+`train!` runs a single step per batch, shows a progress bar, and stops with a `DomainError` if the loss becomes non-finite. Because the compiled step is cached and keyed on the batch shape, multi-epoch training does not recompile, and a smaller final batch simply compiles one additional executable that is then reused.
+
+## Tips and gotchas
+
+- **`setup` after moving to the device.** Always `model |> reactant_device()` *before* `Flux.setup`, so the optimiser state is created from Reactant arrays (this keeps stateful rules like `Adam`'s bias-correction term on the device).
+- **Device-resident data.** Every input to a compiled step must already live on the device. Move batches with `|> reactant_device()`; a common pattern is to wrap a `DataLoader` with the device so batches are moved lazily.
+- **Compilation is keyed on shape.** The first call for each distinct batch shape compiles; subsequent calls reuse the executable. Keeping batch sizes fixed (or accepting one extra compile for a smaller final batch) avoids repeated compilation.
+- **Watch the compile cache.** Flux caches one executable per distinct `(model, optimiser, loss, batch-shape)`. If you rebuild the model or optimiser every iteration, each iteration compiles a fresh step — Flux warns once the cache grows past a handful of entries. Entries are freed automatically when their model is garbage-collected.
+- **Reading results back.** `trainstep!`/`train!` return host-side numbers already. For a manually compiled function, move device arrays back with `cpu` (or `Reactant.to_number` for a scalar).
+- **AD backend.** On a Reactant device training always differentiates with Enzyme; an `adtype` argument other than `AutoEnzyme` is ignored (with a warning). `Duplicated` models are not supported here — pass the plain model that already lives on the device.
+
+See also the [`resnet_tinyimagenet` example](https://github.com/FluxML/Flux.jl/tree/master/examples/resnet_tinyimagenet) for a complete Reactant training script, including compiling a separate evaluation executable per batch shape.

--- a/examples/resnet_tinyimagenet/Project.toml
+++ b/examples/resnet_tinyimagenet/Project.toml
@@ -5,6 +5,7 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 HuggingFaceDatasets = "d94b9a45-fdf5-4270-b024-5cbb9ef7117d"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 cuDNN = "02a925ec-e4fe-4b08-9a7e-0d78e3d38ccd"
 

--- a/examples/resnet_tinyimagenet/README.md
+++ b/examples/resnet_tinyimagenet/README.md
@@ -3,7 +3,7 @@
 Trains a small-image **ResNet-18** on **Tiny-ImageNet-200** — a 200-class, 64×64 subset of
 ImageNet — pulled from the HuggingFace Hub with
 [HuggingFaceDatasets.jl](https://github.com/CarloLucibello/HuggingFaceDatasets.jl) and trained on
-the GPU with `Flux.train!`.
+the GPU with `Flux.trainstep!`.
 
 | file | what |
 | --- | --- |
@@ -21,8 +21,8 @@ the GPU with `Flux.train!`.
   max-pool) is replaced by a single 3×3 stride-1 conv so a 64×64 image isn't over-downsampled. The
   rest is stock ResNet-18 — four stages of two BasicBlocks (64→128→256→512), global average pool,
   linear head (~11.3M params).
-- **Training** — `AdamW`, cross-entropy, `Flux.train!`, on the GPU (falls back to CPU if CUDA is
-  unavailable).
+- **Training** — `AdamW`, cross-entropy, a hand-written epoch loop over `Flux.trainstep!`, on the
+  GPU (falls back to CPU if CUDA is unavailable).
 
 ## Running
 

--- a/examples/resnet_tinyimagenet/pytorch/README.md
+++ b/examples/resnet_tinyimagenet/pytorch/README.md
@@ -25,70 +25,69 @@ The `[project]` `torch` dependency is pinned to the CUDA 12.8 wheel index (`cu12
 recent NVIDIA GPUs (Blackwell / RTX 50-series included). Drop the `[tool.uv.sources]` /
 `[[tool.uv.index]]` blocks from `pyproject.toml` to fall back to the default CPU/CUDA wheels.
 
-Each epoch prints its pure training wall-time and throughput (`[train]`), followed by train/val
-loss and top-1 accuracy (`[eval]`).
+A normal run prints each epoch's training wall-time and throughput (`[train]`) followed by train/val
+loss and top-1 accuracy (`[eval]`); `--benchmark-epochs N` times training only — no evaluation — to
+line up with [`flux_bench.jl`](flux_bench.jl).
 
 ## Performance comparison
 
-Measured on this workstation — **RTX 5090 (32 GB)**, Julia 1.12.6 / Flux 0.16 / CUDA.jl vs
-PyTorch 2.11.0+cu128 — same model (11.27M params), batch size 128, 4 data-loading workers,
-`AdamW(1e-3)`. Throughput is the pure training loop (forward + backward + step) over the 100k-image
-train set; `flux_bench.jl` in this directory reproduces the Flux side with the same
-per-epoch timing.
+Measured on this workstation — **RTX 5090 (32 GB)**, Julia 1.12.6 / Flux 0.16.10 / **Reactant
+0.2.278** (XLA) vs PyTorch 2.11.0+cu128 — same model (11.27M params), batch size 128, 4
+data-loading workers, `AdamW(1e-3)`. Throughput is the pure training loop (forward + backward +
+step) over the 100k-image train set, **timing only, no evaluation**: [`flux_bench.jl`](flux_bench.jl)
+and `resnet_tinyimagenet.py --benchmark-epochs 3` are the matched drivers.
 
-| metric | Flux | PyTorch |
+| metric | Flux (Reactant) | PyTorch |
 | --- | --- | --- |
 | params | 11.27M | 11.27M |
-| **steady-state train** | **~32.4 s/epoch · ~3090 img/s** | **~30.3 s/epoch · ~3280 img/s** |
-| first train epoch | 70.2 s (incl. compilation) | 30.5 s |
-| epoch-0 full eval (110k imgs) | 65 s cold → 10.4 s warm | ~few s |
-| GPU during train | 90–97 % · ~540 W | 100 % · ~545 W |
-| GPU memory | pool reserves ~9 GB, flat¹ | ~3.8 GB |
-| process warmup before epoch 1 | package load + precompile (~min) | ~seconds |
+| **steady-state train** | **~32.5 s/epoch · ~3060 img/s** | **~30.1 s/epoch · ~3320 img/s** |
+| first train epoch | **235.6 s** (incl. XLA compilation) | 40.0 s (incl. cuDNN autotune) |
+| GPU utilization (steady) | ~96 % | ~100 % |
+| GPU memory | **~16.8 GB** working set · 23.5 GB reserved by default¹ | ~3.8 GB |
 
-¹ CUDA.jl's memory pool *reserves* (and retains) freed device memory rather than returning it to
-the driver; live working-set usage is a small fraction of that. The example wraps its training
-loader in a device iterator (see below) so the reservation stays flat at ~9 GB instead of climbing
-toward the full card. PyTorch's caching allocator holds only what it needs here (~3.8 GB).
+¹ By default Reactant/XLA's BFC allocator *preallocates* a fixed fraction of the card
+(`XLA_REACTANT_GPU_MEM_FRACTION`, default 0.75 → ~23.5 GB of the 32 GB here) on first use, regardless
+of the model's needs — the strategy JAX uses too. Setting `XLA_REACTANT_GPU_PREALLOCATE=false`
+allocates on demand and reveals the true footprint: **~16.8 GB, still ~4× PyTorch's ~3.8 GB**
+(throughput is unchanged). So the gap is real, not just a reservation policy: the fused whole-step
+executable appears to keep all forward activations live for the Enzyme reverse pass (plus gradient
+shadows and cuDNN conv workspaces), whereas PyTorch's eager autograd frees activations more
+incrementally. See Reactant's [GPU config](https://enzymead.github.io/Reactant.jl/dev/api/config#GPU-Configuration).
 
 **Takeaways**
 
-- **Steady-state throughput is within ~8 %** — both frameworks are GPU-compute-bound (both pin the
-  card at ~540 W, i.e. tensor-core saturated), so this small ResNet-18 runs at essentially the same
-  speed once warm. PyTorch is marginally ahead (cuDNN autotuning via `benchmark=True`, plus its
-  vectorized-on-GPU augmentation vs. Flux's per-image CPU augmentation).
-- **The real difference is warmup, not steady speed.** Julia pays a one-time first-call
-  compilation cost: epoch 1 is ~2× the steady time and the first full-train eval is ~6× the warm
-  eval, on top of a minute-plus of package load/precompile at startup. PyTorch reaches steady speed
-  on epoch 1. For a 30-epoch run this amortizes to a few percent; for short runs it dominates.
+- **Steady-state throughput is within ~8 %** — both frameworks are GPU-compute-bound on this small
+  ResNet-18, so once warm they run at essentially the same speed. PyTorch is marginally ahead (cuDNN
+  autotuning via `benchmark=True`, plus its vectorized-on-GPU augmentation vs. Flux's per-image CPU
+  augmentation). Reactant's steady-state matches the eager CUDA.jl path it replaced (~32.4 s/epoch).
+- **The cost is warmup.** On the first `trainstep!`, Reactant compiles the whole training step
+  (forward + Enzyme reverse + optimiser update) into a single XLA executable, so **epoch 1 is ~7× the
+  steady time** (~236 s vs ~32 s) — on top of the minute-plus of package load/precompile at startup.
+  PyTorch reaches steady speed on epoch 1 (its ~40 s is just cuDNN autotuning). The executable is
+  cached and reused for every later step, so the compile is a one-time cost: a modest fraction of a
+  30-epoch run, but dominant for short ones.
 - **Accuracy trajectories are comparable** (run-to-run variance from init/augmentation RNG); both
-  climb steadily toward the ~50 % top-1 the README quotes for a full 30-epoch run.
+  climb steadily toward the ~50 % top-1 the parent README quotes for a full 30-epoch run.
 
-### Why the training loop uses a device iterator
+### Why the training loop moves batches to the device
 
-The example (and `flux_bench.jl`) wrap the training loader in an
-[MLDataDevices](https://github.com/LuxDL/MLDataDevices.jl) device iterator — `DEVICE(train_loader)`.
-The naive alternative moves each batch inside the step (`m(x |> DEVICE)`) and one-hots labels on the
-fly, allocating fresh device arrays every step that immediately become garbage; CUDA.jl's pool
-*retains* those freed blocks, so the **reservation keeps creeping up** epoch over epoch (toward the
-full card). The device iterator instead yields GPU-resident batches and `unsafe_free!`s each previous
-one, so the pool stops growing. Measured back-to-back on the same process (3 epochs each):
-
-| path | steady train | peak pool reservation |
-| --- | --- | --- |
-| baseline (`x \|> DEVICE` in step) | ~32.6 s/epoch | 2.8 → 10.5 → 10.6 GB, **still climbing** |
-| `DEVICE(loader)` device iterator | ~32.4 s/epoch | **9.2 GB, flat every epoch** |
-
-So the device iterator **doesn't change throughput** (both are GPU-compute-bound — there's no host
-transfer to overlap away) but it **caps the memory reservation** at a flat working set instead of
-letting it grow — which is why the example adopts it. Note the batch (labels included) arrives on the
-GPU, so the one-hot runs there:
+Both the example and `flux_bench.jl` wrap the training loader in an
+[MLDataDevices](https://github.com/LuxDL/MLDataDevices.jl) device iterator — `device(train_loader)` —
+so every batch arrives on the accelerator (and the previous one is freed). On Reactant this is
+**required**, not just an optimisation: `Flux.trainstep!` runs the compiled XLA step, which only
+accepts device-resident arrays — a host-resident batch raises an error. The loop is one fused,
+cached executable per step:
 
 ```julia
-Flux.train!(model, DEVICE(train_loader), opt) do m, x, y   # x, y arrive on the GPU
-    logitcrossentropy(m(x), onehotbatch(y, 0:NCLASSES-1))   # onehotbatch works on GPU labels
+for (x, y) in train_loader          # x, y already on the Reactant device
+    Flux.trainstep!(loss_fn, model, (x, y), opt_state)   # compiled once, reused every step/epoch
 end
 ```
+
+`trainstep!` differentiates `loss_fn` with Enzyme and folds the AdamW update into the compiled step,
+returning the loss (read back to the host). The full loop — with running-mean train metrics — lives
+in [`../resnet_tinyimagenet.jl`](../resnet_tinyimagenet.jl). Swap `using Reactant` for `using CUDA`
+there to run the eager CUDA.jl path instead (same steady-state speed, without the one-time compile).
 
 ## Notes on faithfulness
 

--- a/examples/resnet_tinyimagenet/pytorch/flux_bench.jl
+++ b/examples/resnet_tinyimagenet/pytorch/flux_bench.jl
@@ -1,52 +1,39 @@
 # Timed driver for the Flux ResNet-18 / Tiny-ImageNet example, mirroring the PyTorch
-# `--benchmark-epochs` run: eval at epoch 0, then N timed train epochs each followed by eval.
-# Reuses the model / data / loss definitions from the example file itself.
+# `--benchmark-epochs` run: N timed training epochs, no evaluation — just the per-epoch training
+# wall-time and throughput. Reuses the model / data / `loss_fn` / `trainstep!` loop from the example.
+#
+# The example `using`s Reactant, so training runs through the compiled XLA step (`Flux.trainstep!`);
+# epoch 1 therefore includes the one-time step compilation. Comment out `using Reactant` (and
+# uncomment `using CUDA`) in the example to bench the eager GPU path instead.
 
 include(joinpath(@__DIR__, "..", "resnet_tinyimagenet.jl"))
 
 using Printf
 
 function bench(; epochs=3, batchsize=128, lr=1e-3, num_workers=4)
-    @info "Setup" DEVICE epochs batchsize lr num_workers
+    device = isdefined(Main, :Reactant) ? reactant_device() : gpu_device()
+    @info "Setup" device epochs batchsize lr num_workers
 
     train_ds = load_dataset("zh-plus/tiny-imagenet", split="train")
-    val_ds   = load_dataset("zh-plus/tiny-imagenet", split="valid")
     train_ds = train_ds.cast_column("image", datasets.Image(mode="RGB"))
-    val_ds   = val_ds.cast_column("image", datasets.Image(mode="RGB"))
-
     train_data = mapobs(train_transform, train_ds)
-    val_data   = mapobs(decode, val_ds)
-
     train_loader = Flux.DataLoader(train_data; batchsize, shuffle=true, num_workers)
-    val_loader   = Flux.DataLoader(val_data; batchsize, num_workers)
+    train_loader = device(train_loader)  # move each batch to the device, free the previous one
 
-    model = resnet18() |> DEVICE
+    model = resnet18() |> device
     nparams = sum(length, Flux.trainables(model))
     @printf "[model] resnet18  params=%.2fM\n" nparams/1e6
-    opt = Flux.setup(AdamW(lr), model)
+    opt_state = Flux.setup(AdamW(lr), model)
 
-    function run_eval(epoch)
-        te = time()
-        tl, ta = loss_and_accuracy(train_loader, model)
-        vl, va = loss_and_accuracy(val_loader, model)
-        @printf "[eval] epoch=%d train_loss=%.4f train_acc=%.4f val_loss=%.4f val_acc=%.4f eval_time=%.1fs\n" epoch tl ta vl va (time()-te)
-        flush(stdout)
-    end
-
-    run_eval(0)
+    trainmode!(model)
     for epoch in 1:epochs
-        trainmode!(model)
-        nimg = Ref(0)
-        t0 = time()
-        Flux.train!(model, DEVICE(train_loader), opt) do m, x, y   # device iterator: GPU batches
-            nimg[] += length(y)
-            logitcrossentropy(m(x), onehotbatch(y, 0:NCLASSES-1))
+        nimg = 0
+        t = @elapsed for (x, y) in train_loader
+            Flux.trainstep!(loss_fn, model, (x, y), opt_state)
+            nimg += length(y)
         end
-        CUDA.synchronize()
-        dt = time() - t0
-        @printf "[train] epoch=%d time=%.2fs throughput=%.0f img/s\n" epoch dt nimg[]/dt
+        @printf "[train] epoch=%d time=%.2fs throughput=%.0f img/s\n" epoch t nimg/t
         flush(stdout)
-        run_eval(epoch)
     end
     return model
 end

--- a/examples/resnet_tinyimagenet/pytorch/resnet_tinyimagenet.py
+++ b/examples/resnet_tinyimagenet/pytorch/resnet_tinyimagenet.py
@@ -1,11 +1,3 @@
-"""PyTorch port of the Flux ResNet-18 / Tiny-ImageNet-200 example.
-
-A faithful mirror of `../resnet_tinyimagenet.jl`: same small-image ResNet-18, same data
-(`zh-plus/tiny-imagenet` from the HuggingFace Hub), same augmentation, same AdamW /
-cross-entropy training loop. Kept close to the Julia version so the two can be compared
-line-for-line and, more importantly, benchmarked head to head on the same GPU.
-"""
-
 import argparse
 import time
 
@@ -123,16 +115,9 @@ def loss_and_accuracy(loader, model):
     return lsum / total, correct / total
 
 
-def collate_identity(samples):
-    # HF with torch format already returns column tensors when we index a batch; but DataLoader
-    # calls collate per-sample. We instead let DataLoader batch and stack the dict columns.
-    keys = samples[0].keys()
-    return {k: torch.utils.data.default_collate([s[k] for s in samples]) for k in keys}
-
-
-def main(epochs=30, batchsize=128, lr=1e-3, num_workers=4, benchmark_epochs=None):
+def main(epochs=30, batchsize=128, lr=1e-3, num_workers=4, benchmark_epochs=None, use_compile=False):
     print(f"[setup] device={DEVICE} epochs={epochs} batchsize={batchsize} lr={lr} "
-          f"num_workers={num_workers}")
+          f"num_workers={num_workers} compile={use_compile}")
     torch.backends.cudnn.benchmark = True
 
     train_ds = load_dataset("zh-plus/tiny-imagenet", split="train")
@@ -145,12 +130,12 @@ def main(epochs=30, batchsize=128, lr=1e-3, num_workers=4, benchmark_epochs=None
 
     train_loader = DataLoader(
         train_ds, batch_size=batchsize, shuffle=True, num_workers=num_workers,
-        collate_fn=collate_identity, pin_memory=True, drop_last=False,
+        pin_memory=True, drop_last=False,
         persistent_workers=num_workers > 0,
     )
     val_loader = DataLoader(
         val_ds, batch_size=batchsize, shuffle=False, num_workers=num_workers,
-        collate_fn=collate_identity, pin_memory=True,
+        pin_memory=True,
         persistent_workers=num_workers > 0,
     )
 
@@ -160,6 +145,12 @@ def main(epochs=30, batchsize=128, lr=1e-3, num_workers=4, benchmark_epochs=None
     model = resnet18().to(DEVICE)
     nparams = sum(p.numel() for p in model.parameters())
     print(f"[model] resnet18  params={nparams/1e6:.2f}M")
+    # torch.compile (TorchInductor) is PyTorch's analogue of Reactant's XLA compilation: it captures
+    # the forward — and, via AOTAutograd, the backward — into fused Triton/cuDNN kernels. The optimiser
+    # step and the CPU-side augmentation stay eager, so this compiles less of the loop than Reactant,
+    # which fuses forward + reverse + update into a single executable.
+    if use_compile:
+        model = torch.compile(model)
     # Match Flux's AdamW default (lambda=0 -> no weight decay); torch defaults to 0.01.
     opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=0.0)
 
@@ -169,7 +160,12 @@ def main(epochs=30, batchsize=128, lr=1e-3, num_workers=4, benchmark_epochs=None
         print(f"[eval] epoch={epoch} train_loss={train_loss:.4f} train_acc={train_acc:.4f} "
               f"val_loss={val_loss:.4f} val_acc={val_acc:.4f}")
 
-    run_eval(0)
+    # In benchmark mode, time training only (no evaluation) so this run matches `flux_bench.jl`;
+    # a normal run still evaluates each epoch, mirroring `../resnet_tinyimagenet.jl`.
+    benchmarking = benchmark_epochs is not None
+
+    if not benchmarking:
+        run_eval(0)
     for epoch in range(1, epochs + 1):
         model.train()
         t0 = time.perf_counter()
@@ -183,11 +179,12 @@ def main(epochs=30, batchsize=128, lr=1e-3, num_workers=4, benchmark_epochs=None
             opt.step()
             nimg += y.numel()
         if DEVICE.type == "cuda":
-            torch.cuda.synchronize()
+            torch.cuda.synchronize()   # CUDA is async — wait for the queued work before timing
         dt = time.perf_counter() - t0
         print(f"[train] epoch={epoch} time={dt:.2f}s throughput={nimg/dt:.0f} img/s")
-        run_eval(epoch)
-        if benchmark_epochs is not None and epoch >= benchmark_epochs:
+        if not benchmarking:
+            run_eval(epoch)
+        if benchmarking and epoch >= benchmark_epochs:
             break
 
     return model
@@ -201,10 +198,13 @@ def parse_cli():
     p.add_argument("--num-workers", type=int, default=4, help="data-loading worker processes")
     p.add_argument("--benchmark-epochs", type=int, default=None,
                    help="stop after this many train epochs (for timing runs)")
+    p.add_argument("--compile", action="store_true",
+                   help="wrap the model in torch.compile (TorchInductor) — PyTorch's XLA analogue")
     return p.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_cli()
     main(epochs=args.epochs, batchsize=args.batchsize, lr=args.lr,
-         num_workers=args.num_workers, benchmark_epochs=args.benchmark_epochs)
+         num_workers=args.num_workers, benchmark_epochs=args.benchmark_epochs,
+         use_compile=args.compile)

--- a/examples/resnet_tinyimagenet/resnet_tinyimagenet.jl
+++ b/examples/resnet_tinyimagenet/resnet_tinyimagenet.jl
@@ -5,16 +5,19 @@ using Flux.Losses: logitcrossentropy
 using Flux: onehotbatch, onecold, trainmode!, testmode!
 using MLUtils: MLUtils, mapobs
 using HuggingFaceDatasets
-using CUDA # replace with `Metal` or `AMDGPU` for other backends
-
-const DEVICE = gpu_device() # will select the first available GPU device, or CPU if none are available
-const NCLASSES = 200
+# using CUDA     # Replace with `Metal` or `AMDGPU` for other backends.
+               # Comment out if using Reactant.
+using Reactant # Automatically selects the available gpu or cpu backend.
+               # Comment out if don't want XLA compilation.
+               # See https://enzymead.github.io/Reactant.jl/dev/api/config#GPU-Configuration
+               # for memory management.
 
 # ------------------------------------------------------------------------------------------------
 # Data
 #
 # ImageNet per-channel mean/std (Tiny-ImageNet is an ImageNet subset), shaped for (W, H, C, N)
 # broadcasting.
+const NCLASSES = 200
 const MEAN = reshape(Float32[0.485, 0.456, 0.406], 1, 1, 3, 1)
 const STD  = reshape(Float32[0.229, 0.224, 0.225], 1, 1, 3, 1)
 
@@ -118,24 +121,19 @@ end
 # ------------------------------------------------------------------------------------------------
 # Training
 
-function loss_and_accuracy(loader, model)
-    testmode!(model)
-    correct, total = 0, 0
-    lsum = 0f0
-    for (x, y) in loader
-        ŷ = model(x |> DEVICE) |> cpu
-        yoh = onehotbatch(y, 0:NCLASSES-1)
-        lsum += logitcrossentropy(ŷ, yoh; agg=sum)
-        correct += sum(onecold(ŷ, 0:NCLASSES-1) .== y)
-        total += length(y)
-    end
-    return lsum / total, correct / total
+function loss_fn(model, x, y)
+    ŷ = model(x)
+    loss = logitcrossentropy(ŷ, onehotbatch(y, 0:NCLASSES-1))
+    correct = sum(onecold(ŷ, 0:NCLASSES-1) .== y)
+    n = length(y)
+    return loss, (; correct, n)
 end
 
 function main(; epochs=30, batchsize=128, lr=1e-3, weight_decay=0.0,
               num_workers=4, seed=0, clip_norm=false)
-    Random.seed!(seed)
-    @info "Setup" DEVICE epochs batchsize lr weight_decay num_workers seed clip_norm
+    seed > 0 && Random.seed!(seed)
+    device = isdefined(Main, :Reactant) ? reactant_device() : gpu_device()
+    @info "Setup" device epochs batchsize lr weight_decay num_workers seed clip_norm
 
     train_ds = load_dataset("zh-plus/tiny-imagenet", split="train")
     val_ds   = load_dataset("zh-plus/tiny-imagenet", split="valid")
@@ -147,30 +145,62 @@ function main(; epochs=30, batchsize=128, lr=1e-3, weight_decay=0.0,
     train_data = mapobs(train_transform, train_ds)
     val_data   = mapobs(decode, val_ds)
 
-    train_loader = Flux.DataLoader(train_data; batchsize, shuffle=true, num_workers)
+    train_loader = Flux.DataLoader(train_data; batchsize, shuffle=true, num_workers, )
     val_loader   = Flux.DataLoader(val_data; batchsize, num_workers)
+    train_loader = device(train_loader)  # in loops, move each batch to the GPU and free the previous one
+    val_loader   = device(val_loader)
 
-    model = resnet18() |> DEVICE
+    model = resnet18() |> device
 
     rule = AdamW(; eta=lr, lambda=weight_decay)
     clip_norm && (rule = OptimiserChain(ClipNorm(), rule))   # clip gradient L2 norm, then AdamW step
-    opt = Flux.setup(rule, model)
+    opt_state = Flux.setup(rule, model)
 
     r(x) = round(x, digits=4)
     r(x::Integer) = x
 
-    # `DEVICE(train_loader)` is a device iterator: 
-    # it moves each batch to the GPU and frees the previous one.
-    for epoch in 0:epochs
-        η = lr * (1 + cos(π * max(epoch - 1, 0) / epochs)) / 2
-        t = 0.0
-        if epoch > 0
-            Flux.adjust!(opt, η)
-            t = @elapsed Flux.train!(model, DEVICE(train_loader), opt) do m, x, y
-                    logitcrossentropy(m(x), onehotbatch(y, 0:NCLASSES-1))
+    @static if isdefined(Main, :Reactant)
+        # Since the last batch of an epoch may be smaller than the others, 
+        # we need to compile and cache a separate executable for each distinct batch shape.
+        compiled_cache = Dict{Any, Any}()
+        function eval_loss_fn(m, x, y)
+            compiled_fn = get!(compiled_cache, (size(x), size(y))) do
+                Reactant.@compile(loss_fn(m, x, y))
             end
+            return compiled_fn(m, x, y)
         end
-        train_loss, train_acc = loss_and_accuracy(train_loader, model)
+    else
+        eval_loss_fn = loss_fn
+    end
+
+    function loss_and_accuracy(loader, model)
+        testmode!(model)
+        correct, total = 0, 0
+        lsum = 0.0
+        for (x, y) in loader
+            loss, stats = eval_loss_fn(model, x, y) |> cpu
+            lsum    += loss * stats.n
+            correct += stats.correct
+            total   += stats.n
+        end
+        return lsum / total, correct / total
+    end
+
+    val_loss, val_acc = loss_and_accuracy(val_loader, model)
+    @info map(r, (; epoch=0, lr=NaN, train_loss=NaN, train_acc=NaN, val_loss, val_acc, time=NaN))
+    for epoch in 1:epochs
+        η = lr * (1 + cos(π * max(epoch - 1, 0) / epochs)) / 2
+        Flux.adjust!(opt_state, η)
+        trainmode!(model)
+        lsum, correct, total = 0.0, 0, 0
+        t = @elapsed for (x, y) in train_loader
+            l, stats = Flux.trainstep!(loss_fn, model, (x, y), opt_state)
+            # We use running sums to compute the epoch-average train loss and accuracy.
+            lsum += l * stats.n
+            correct += stats.correct
+            total += stats.n
+        end
+        train_loss, train_acc = lsum / total, correct / total
         val_loss, val_acc = loss_and_accuracy(val_loader, model)
         @info map(r, (; epoch, lr=η, train_loss, train_acc, val_loss, val_acc, time=t))
     end


### PR DESCRIPTION
Documentation and an example showcasing Reactant compilation and the `trainstep!` API (both already in master, #2707–#2712).

## Docs
- New guide **Compiling Flux with Reactant** (`guide/reactant.md`): manual `@compile`, `trainstep!`, `train!`, plus tips/gotchas, wired into the nav.
- Quickstart: a `trainstep!` section as the per-step primitive underlying `train!`.
- Performance Tips: an entry recommending Reactant compilation for the largest speedups.

## Example (`examples/resnet_tinyimagenet`)
- Julia script uses a `trainstep!` epoch loop with running-mean train metrics and a per-batch-shape compiled evaluation; selects Reactant or `gpu_device()` automatically.
- PyTorch port: `--benchmark-epochs` now times training only (matching `flux_bench.jl`), a new `--compile` (`torch.compile`) flag, and the redundant `collate_fn` removed.
- Benchmark README refreshed for Reactant vs PyTorch on an RTX 5090 — throughput, XLA-compile warmup, and a fair on-demand GPU-memory comparison via `XLA_REACTANT_GPU_PREALLOCATE=false`.

No `NEWS.md` entry — docs/example only; the underlying features are already listed under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
