### PR TITLE
Fix Dense with a zero-sized batch dimension (#2407)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ See also [github's page](https://github.com/FluxML/Flux.jl/releases) for a compl
 
 ## Unreleased
 
+- `Dense` now handles inputs with a zero-sized batch dimension (e.g. `Dense(4 => 5)(randn(Float32, 4, 0, 6))`), returning a correctly-shaped empty array instead of an error or a wrong shape ([#2407](https://github.com/FluxML/Flux.jl/issues/2407)).
 - Fix stack overflow when applying f16/f32/f64 or cpu/gpu to empty structs declared with Flux.@layer.
 - `BatchNorm` in training mode now throws a clear error when a channel sees only a single value (e.g. batch size 1 with no spatial dimensions), instead of silently corrupting the running variance with `NaN`. The batch variance of a single value is undefined; this matches PyTorch's behavior (`testmode!` inference with batch size 1 is unaffected) ([#1992](https://github.com/FluxML/Flux.jl/issues/1992)).
 

--- a/src/layers/basic.jl
+++ b/src/layers/basic.jl
@@ -201,7 +201,8 @@ end
 
 function (a::Dense)(x::AbstractArray)
   _size_check(a, x, 1 => size(a.weight, 2))
-  reshape(a(reshape(x, size(x,1), :)), :, size(x)[2:end]...)
+  y = a(reshape(x, size(x,1), :))
+  reshape(y, size(y,1), size(x)[2:end]...)  # size(y,1) avoids a 0/0 when the batch dims contain a zero
 end
 
 function Base.show(io::IO, l::Dense)

--- a/test/layers/basic.jl
+++ b/test/layers/basic.jl
@@ -80,6 +80,10 @@
       @test size(Dense(10 => 5)(randn(10,2,3))) == (5,2,3)
       @test size(Dense(10 => 5)(randn(10,2,3,4))) == (5,2,3,4)
       @test_throws DimensionMismatch Dense(10 => 5)(randn(11,2,3))
+      # a zero-sized batch dimension should propagate, not error (#2407)
+      @test size(Dense(4 => 5)(randn32(4,0))) == (5,0)
+      @test size(Dense(4 => 5)(randn32(4,0,6))) == (5,0,6)
+      @test size(Dense(4 => 5)(randn32(4,3,0,6))) == (5,3,0,6)
     end
     @testset "zeros" begin
       @test Dense(10 => 1, identity, init = ones)(ones(10,1)) == 10*ones(1, 1)


### PR DESCRIPTION
Fixes #2407 (for `Dense`).

`Dense` on an input with `ndims > 2` and a zero-sized batch dimension returned a wrong shape (and used to `DivideError`):

```julia
julia> Dense(4 => 5)(randn(Float32, 4, 0, 6)) |> size
(0, 0, 6)   # should be (5, 0, 6)
```

The N-D method reshaped the output with `reshape(y, :, size(x)[2:end]...)`; inferring that `:` from `prod(y) / prod(batchdims)` is `0/0` whenever a batch dim is zero. The fix uses the known output width `size(y, 1)`, so no colon inference is needed:

```julia
julia> Dense(4 => 5)(randn(Float32, 4, 0, 6)) |> size
(5, 0, 6)
```

Gradients flow through the empty batch, and the 2-D case (already `5×0`) and non-empty cases are unchanged. This matches PyTorch's empty-tensor semantics for `nn.Linear`.

Note: only `Dense` is addressed here. `Conv` and `GlobalMeanPool` still error on zero-sized dims — those paths live in NNlib and need a separate fix.

- [x] Tests added (`test/layers/basic.jl`, "dimensions")
- [x] `NEWS.md` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)