### PR TITLE
Add `:named` show option to `@layer` macro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ See also [github's page](https://github.com/FluxML/Flux.jl/releases) for a compl
 
 ## Unreleased
 
+- `@layer :named MyModel` is a new show option that displays fieldnames in the expanded pretty-print (e.g. `cell = RNNCell(...)` instead of just `RNNCell(...)`) ([#2543](https://github.com/FluxML/Flux.jl/issues/2543)).
 - `BatchNorm` in training mode now throws a clear error when a channel sees only a single value (e.g. batch size 1 with no spatial dimensions), instead of silently corrupting the running variance with `NaN`. The batch variance of a single value is undefined; this matches PyTorch's behavior (`testmode!` inference with batch size 1 is unaffected) ([#1992](https://github.com/FluxML/Flux.jl/issues/1992)).
 
 ## v0.16.11 (6 August 2026)

--- a/src/layers/macro.jl
+++ b/src/layers/macro.jl
@@ -68,10 +68,13 @@ function _layer_macro(exs...)
   elseif exs[1] == QuoteNode(:noexpand)
     push!(out.args, _macro_layer_show(esc(exs[2])))
     exs[2:end]
+  elseif exs[1] == QuoteNode(:named)
+    push!(out.args, _macro_named_show(esc(exs[2])))
+    exs[2:end]
   elseif exs[1] == QuoteNode(:ignore)
     exs[2:end]
   elseif exs[1] isa QuoteNode
-    error("`@layer` accepts only the options `:ignore`, `:noexpand`, and `:expand` before the layer type (to control `show`).")
+    error("`@layer` accepts only the options `:ignore`, `:noexpand`, `:named`, and `:expand` before the layer type (to control `show`).")
   else
     push!(out.args, _macro_big_show(esc(exs[1])))
     exs

--- a/src/layers/macro.jl
+++ b/src/layers/macro.jl
@@ -15,6 +15,8 @@ The optional argument `showtype` can take any of the following values:
 
 - `:expand` (default): This will expand the representation of container types like `Chain`, 
    while maintaining a compat representation of types like `Dense` containing only arrays.
+- `:named`: Like `:expand`, but displays fieldnames as `field = value` in the expanded representation.
+   This is useful for container types whose children have meaningful names (e.g. `cell`, `layer`).
 - `:noexpand`: This is to be used in case your type contains other layers but you want to keep the representation simple.
 - `:ignore`: To opt out of the pretty printing.
 

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -19,6 +19,23 @@ function _macro_big_show(ex)
   end
 end
 
+# This is called by @layer :named and returns an expression:
+function _macro_named_show(ex)
+    quote
+        function Base.show(io::IO, m::MIME"text/plain", x::$ex)
+            if get(io, :typeinfo, nothing) === nothing  # e.g. top level in REPL
+                _big_show(io, x)
+            elseif !get(io, :compact, false)  # e.g. printed inside a Vector, but not a Matrix
+                _layer_show(io, x)
+            else
+                show(io, x)
+            end
+        end
+
+        Flux._show_children(x::$ex) = Functors.children(x)
+    end
+end
+
 function _big_show(io::IO, obj, indent::Int=0, name=nothing)
   children = _show_children(obj)
   if all(_show_leaflike, children)

--- a/src/layers/show.jl
+++ b/src/layers/show.jl
@@ -55,6 +55,10 @@ function _big_show(io::IO, obj, indent::Int=0, name=nothing)
       for k in Base.keys(obj)
         _big_show(io, obj[k], indent+2, k)
       end
+    elseif children isa NamedTuple
+      for k in Base.keys(children)
+        _big_show(io, children[k], indent+2, k)
+      end
     else
       for c in children
         _big_show(io, c, indent+2)

--- a/test/layers/show.jl
+++ b/test/layers/show.jl
@@ -88,3 +88,17 @@ Flux.@layer NoFields
   str = repr("text/plain", Chain(Dense(1=>1), Dense(1=>1), NoFields()))
   @test occursin("4 arrays, 4 parameters", str)
 end
+
+# @layer :named shows fieldnames in expanded output
+struct NamedContainer; inner; extra; end
+Flux.@layer :named NamedContainer
+
+@testset "named layer printing" begin
+  # Custom type with :named
+  nc = NamedContainer(Dense(2, 3), Dense(3, 4))
+  str = repr("text/plain", nc)
+  @test occursin("inner = Dense(2 => 3)", str)
+  @test occursin("extra = Dense(3 => 4)", str)
+
+
+end


### PR DESCRIPTION
Layers like `RNN` or `Chain` do not print their field names. This patch allows certain containers to display field names making the structure much easier to read and debug.

Add a new `:named` option to the `Flux.@layer` macro, which allows _big_show to preserve and display the layer's NamedTuple structure.

- Created a new `_macro_named_show` function that evaluates the children returning a NamedTuple.
- Added tests in layers/show.jl



### PR Checklist

- [x] Tests are added
- [x] Entry in NEWS.md
- [ ] Documentation, if applicable

closes #2543 